### PR TITLE
refactor: stop using localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Library used by [Hathor Wallet](https://github.com/HathorNetwork/hathor-wallet).
 
 `npm install @hathor/wallet-lib`
 
-# Setting storage
+## Setting storage
 
-The lib requires a storage to be passed to it. Take a look at `src/storage.js` for the methods this storage object should implement.
+This lib requires a storage to be set so it can persist data. Take a look at `src/storage.js` for the methods this storage object should implement.
 ```
 const hathorLib = require('@hathor/wallet-lib');
 hathorLib.storage.setStorage(storageFactory);

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Library used by [Hathor Wallet](https://github.com/HathorNetwork/hathor-wallet).
 ## Install
 
 `npm install @hathor/wallet-lib`
+
+# Setting storage
+
+The lib requires a storage to be passed to it. Take a look at `src/storage.js` for the methods this storage object should implement.
+```
+const hathorLib = require('@hathor/wallet-lib');
+hathorLib.storage.setStorage(storageFactory);
+```

--- a/__tests__/encryption.test.js
+++ b/__tests__/encryption.test.js
@@ -7,6 +7,8 @@
 
 import wallet from '../src/wallet';
 
+const storage = require('../src/storage').default;
+
 test('Private key encryption/decryption', () => {
   const pin = '123456';
   const password = 'password';
@@ -20,7 +22,7 @@ test('Private key encryption/decryption', () => {
   expect(wallet.isPasswordCorrect(password)).toBeTruthy();
   expect(wallet.isPasswordCorrect(pin)).toBeFalsy();
 
-  let accessData = JSON.parse(localStorage.getItem('wallet:accessData'));
+  let accessData = storage.getItem('wallet:accessData');
   let decrypted = wallet.decryptData(accessData.mainKey, pin);
   let decryptedWords = wallet.decryptData(accessData.words, password);
 

--- a/__tests__/new_wallet.test.js
+++ b/__tests__/new_wallet.test.js
@@ -11,6 +11,8 @@ import { HDPrivateKey } from 'bitcore-lib';
 import CryptoJS from 'crypto-js';
 import WebSocketHandler from '../src/WebSocketHandler';
 
+const storage = require('../src/storage').default;
+
 var addressUsed = '';
 var addressShared = '';
 var txId = '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e';
@@ -53,22 +55,22 @@ mock.onGet('thin_wallet/address_history').reply((config) => {
 });
 
 const checkData = () => {
-  check(localStorage.getItem('wallet:address'), addressShared, doneCb);
-  check(localStorage.getItem('wallet:lastUsedAddress'), addressUsed, doneCb);
-  check(parseInt(localStorage.getItem('wallet:lastSharedIndex'), 10), 1, doneCb);
-  check(parseInt(localStorage.getItem('wallet:lastUsedIndex'), 10), 0, doneCb);
-  check(parseInt(localStorage.getItem('wallet:lastGeneratedIndex'), 10), 20, doneCb);
-  let accessData = localStorage.getItem('wallet:accessData');
+  check(storage.getItem('wallet:address'), addressShared, doneCb);
+  check(storage.getItem('wallet:lastUsedAddress'), addressUsed, doneCb);
+  check(parseInt(storage.getItem('wallet:lastSharedIndex'), 10), 1, doneCb);
+  check(parseInt(storage.getItem('wallet:lastUsedIndex'), 10), 0, doneCb);
+  check(parseInt(storage.getItem('wallet:lastGeneratedIndex'), 10), 20, doneCb);
+  let accessData = storage.getItem('wallet:accessData');
   checkNot(accessData, null, doneCb);
-  let accessDataJson = JSON.parse(accessData);
+  let accessDataJson = accessData;
   check('mainKey' in accessDataJson, true, doneCb);
   check(typeof accessDataJson['mainKey'], 'string', doneCb);
   check('hash' in accessDataJson, true, doneCb);
   check(accessDataJson['hash'], CryptoJS.SHA256(CryptoJS.SHA256(pin)).toString(), doneCb);
 
-  let walletData = localStorage.getItem('wallet:data');
+  let walletData = storage.getItem('wallet:data');
   checkNot(walletData, null, doneCb);
-  let walletDataJson = JSON.parse(walletData);
+  let walletDataJson = walletData;
   check('historyTransactions' in walletDataJson, true, doneCb);
   check(typeof walletDataJson['historyTransactions'], 'object', doneCb);
   check('00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e' in walletDataJson['historyTransactions'], true, doneCb);
@@ -86,7 +88,7 @@ beforeEach(() => {
 test('Generate new HD wallet', (done) => {
   doneCb = done;
 
-  // Generate new wallet and save data in localStorage
+  // Generate new wallet and save data in storage
   const words = wallet.generateWalletWords(256);
   check(wallet.wordsValid(words).valid, true, done);
   const promise = wallet.executeGenerateWallet(words, '', pin, 'password', true);
@@ -105,7 +107,7 @@ test('Generate HD wallet from predefined words', (done) => {
   addressShared = 'WgSpcCwYAbtt31S2cqU7hHJkUHdac2EPWG';
 
 
-  // Generate new wallet and save data in localStorage
+  // Generate new wallet and save data in storage
   const promise = wallet.executeGenerateWallet(words, '', pin, 'password', true);
 
   promise.then(() => {

--- a/__tests__/tokens_utils.js
+++ b/__tests__/tokens_utils.js
@@ -12,6 +12,8 @@ import wallet from '../src/wallet';
 import { util } from 'bitcore-lib';
 import WebSocketHandler from '../src/WebSocketHandler';
 
+const storage = require('../src/storage').default;
+
 const createdTxHash = '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e';
 const createdToken = util.buffer.bufferToHex(tokens.getTokenUID(createdTxHash, 0));
 
@@ -46,7 +48,7 @@ test('Token UID', () => {
 });
 
 const readyLoadHistory = (pin) => {
-  const encrypted = JSON.parse(localStorage.getItem('wallet:accessData')).mainKey;
+  const encrypted = storage.getItem('wallet:accessData').mainKey;
   const privKeyStr = wallet.decryptData(encrypted, pin);
   const privKey = HDPrivateKey(privKeyStr)
   return wallet.loadAddressHistory(0, GAP_LIMIT, privKey, pin);
@@ -55,13 +57,13 @@ const readyLoadHistory = (pin) => {
 test('New token', (done) => {
   const words = 'connect sunny silent cabin leopard start turtle tortoise dial timber woman genre pave tuna rice indicate gown draft palm collect retreat meadow assume spray';
   const pin = '123456';
-  // Generate new wallet and save data in localStorage
+  // Generate new wallet and save data in storage
   wallet.executeGenerateWallet(words, '', pin, 'password', false);
   const promise = readyLoadHistory(pin);
-  const address = localStorage.getItem('wallet:address');
+  const address = storage.getItem('wallet:address');
   promise.then(() => {
-    // Adding data to localStorage to be used in the signing process
-    const savedData = JSON.parse(localStorage.getItem('wallet:data'));
+    // Adding data to storage to be used in the signing process
+    const savedData = storage.getItem('wallet:data');
     const createdKey = `${createdTxHash},0`;
     savedData['historyTransactions'] = {
       '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e': {
@@ -76,7 +78,7 @@ test('New token', (done) => {
         ]
       }
     };
-    localStorage.setItem('wallet:data', JSON.stringify(savedData));
+    storage.setItem('wallet:data', savedData);
     const input = {'tx_id': '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e', 'index': '0', 'token': '00', 'address': address};
     const output = {'address': address, 'value': 100, 'tokenData': 0};
     const tokenName = 'TestCoin';

--- a/__tests__/transaction_utils.test.js
+++ b/__tests__/transaction_utils.test.js
@@ -12,16 +12,18 @@ import buffer from 'buffer';
 import { OP_PUSHDATA1 } from '../src/opcodes';
 import { DEFAULT_TX_VERSION } from '../src/constants';
 
+const storage = require('../src/storage').default;
+
 test('Tx weight constants', () => {
   transaction.updateTransactionWeightConstants(10, 1.5, 8);
-  expect(parseFloat(localStorage.getItem('wallet:txMinWeight'))).toBe(10);
-  expect(parseFloat(localStorage.getItem('wallet:txWeightCoefficient'))).toBe(1.5);
-  expect(parseFloat(localStorage.getItem('wallet:txMinWeightK'))).toBe(8);
+  expect(parseFloat(storage.getItem('wallet:txMinWeight'))).toBe(10);
+  expect(parseFloat(storage.getItem('wallet:txWeightCoefficient'))).toBe(1.5);
+  expect(parseFloat(storage.getItem('wallet:txMinWeightK'))).toBe(8);
 
   transaction.updateTransactionWeightConstants(15, 1.2, 10);
-  expect(parseFloat(localStorage.getItem('wallet:txMinWeight'))).toBe(15);
-  expect(parseFloat(localStorage.getItem('wallet:txWeightCoefficient'))).toBe(1.2);
-  expect(parseFloat(localStorage.getItem('wallet:txMinWeightK'))).toBe(10);
+  expect(parseFloat(storage.getItem('wallet:txMinWeight'))).toBe(15);
+  expect(parseFloat(storage.getItem('wallet:txWeightCoefficient'))).toBe(1.2);
+  expect(parseFloat(storage.getItem('wallet:txMinWeightK'))).toBe(10);
 });
 
 test('Unsigned int to bytes', () => {
@@ -164,14 +166,14 @@ test('Create input data', () => {
   expect(transaction.createInputData(signature, pubkeyBytes2).length).toBe(123);
 });
 
-test('Prepare data to send tokens', (done) => {
+test('Prepare data to send tokens', async (done) => {
   // Now we will update the data in the inputs
   let words = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
-  // Generate new wallet and save data in localStorage
-  wallet.executeGenerateWallet(words, '', '123456', 'password', true);
-  // Adding data to localStorage to be used in the signing process
-  let savedData = JSON.parse(localStorage.getItem('wallet:data'));
-  let addr = localStorage.getItem('wallet:address');
+  // Generate new wallet and save data in storage
+  await wallet.executeGenerateWallet(words, '', '123456', 'password', true);
+  // Adding data to storage to be used in the signing process
+  let savedData = storage.getItem('wallet:data');
+  let addr = storage.getItem('wallet:address');
   savedData['historyTransactions'] = {
     '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e': {
       'tx_id': '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e',
@@ -185,7 +187,7 @@ test('Prepare data to send tokens', (done) => {
       ]
     }
   };
-  localStorage.setItem('wallet:data', JSON.stringify(savedData));
+  storage.setItem('wallet:data', savedData);
 
   // First get data to sign
   let tx_id = '00034a15973117852c45520af9e4296c68adb9d39dc99a0342e23cd6686b295e';

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -9,6 +9,8 @@ import wallet from '../src/wallet';
 import dateFormatter from '../src/date';
 import { HATHOR_TOKEN_CONFIG } from '../src/constants';
 
+const storage = require('../src/storage').default;
+
 test('Wallet operations for transaction', () => {
   const words = wallet.generateWalletWords(256);
   wallet.executeGenerateWallet(words, '', '123456', 'password', false);
@@ -129,9 +131,9 @@ test('Wallet operations for transaction', () => {
     '171hK8MaRpG2SqQMMQ34EdTharUmP1Qk4r': {},
   }
 
-  const xpubkey = JSON.parse(localStorage.getItem('wallet:data')).xpubkey;
+  const xpubkey = storage.getItem('wallet:data').xpubkey;
 
-  localStorage.setItem('wallet:data', JSON.stringify({keys, historyTransactions, xpubkey}));
+  storage.setItem('wallet:data', {keys, historyTransactions, xpubkey});
 
   const expectedBalance = {
     '00': {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ var walletApi = require('./lib/api/wallet');
 var txApi = require('./lib/api/txApi');
 var versionApi = require('./lib/api/version');
 var axios = require('./lib/api/axiosInstance');
+var storage = require('./lib/storage');
 
 module.exports = {
   helpers: helpers.default,
@@ -26,4 +27,5 @@ module.exports = {
   errors: errors,
   constants: constants,
   axios: axios,
+  storage: storage.default,
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Library used by Hathor Wallet",
   "jest": {
     "setupFilesAfterEnv": [

--- a/setupTests.js
+++ b/setupTests.js
@@ -5,42 +5,37 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-let hathorMemoryStorage = {};
 // Creating memory storage to be used in the place of localStorage
-const storageFactory = {
+class MemoryOnlyStore {
+  constructor() {
+    this.hathorMemoryStorage = {};
+  }
+
   getItem(key) {
-    const ret = hathorMemoryStorage[key];
+    const ret = this.hathorMemoryStorage[key];
     if (ret === undefined) {
       return null
     }
     return ret;
-  },
+  }
 
   setItem(key, value) {
-    hathorMemoryStorage[key] = value;
-  },
+    this.hathorMemoryStorage[key] = value;
+  }
 
   removeItem(key) {
-    delete hathorMemoryStorage[key];
-  },
+    delete this.hathorMemoryStorage[key];
+  }
 
   clear() {
-    hathorMemoryStorage = {};
-  },
-
-  key(n) {
-    return Object.keys(hathorMemoryStorage)[n] || null;
-  },
-
-  getAll() {
-    return hathorMemoryStorage;
-  },
+    this.hathorMemoryStorage = {};
+  }
 }
 
 // Mocking localStorage for tests
 import 'jest-localstorage-mock';
 const storage = require('./src/storage').default;
-storage.setStore(storageFactory);
+storage.setStore(new MemoryOnlyStore());
 
 // Mocking WebSocket for tests
 import { Server, WebSocket } from 'mock-socket';

--- a/setupTests.js
+++ b/setupTests.js
@@ -5,8 +5,42 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+let hathorMemoryStorage = {};
+// Creating memory storage to be used in the place of localStorage
+const storageFactory = {
+  getItem(key) {
+    const ret = hathorMemoryStorage[key];
+    if (ret === undefined) {
+      return null
+    }
+    return ret;
+  },
+
+  setItem(key, value) {
+    hathorMemoryStorage[key] = value;
+  },
+
+  removeItem(key) {
+    delete hathorMemoryStorage[key];
+  },
+
+  clear() {
+    hathorMemoryStorage = {};
+  },
+
+  key(n) {
+    return Object.keys(hathorMemoryStorage)[n] || null;
+  },
+
+  getAll() {
+    return hathorMemoryStorage;
+  },
+}
+
 // Mocking localStorage for tests
 import 'jest-localstorage-mock';
+const storage = require('./src/storage').default;
+storage.setStorage(storageFactory);
 
 // Mocking WebSocket for tests
 import { Server, WebSocket } from 'mock-socket';
@@ -14,7 +48,7 @@ global.WebSocket = WebSocket;
 
 import helpers from './src/helpers';
 
-localStorage.setItem('wallet:server', 'http://localhost:8080/');
+storage.setItem('wallet:server', 'http://localhost:8080/');
 let wsURL = helpers.getWSServerURL();
 
 // Creating a ws mock server
@@ -69,5 +103,8 @@ mock.onGet('version').reply((config) => {
   }
   return [200, data];
 });
+
+import WS from './src/WebSocketHandler';
+WS.setup();
 
 global.window = {};

--- a/setupTests.js
+++ b/setupTests.js
@@ -40,7 +40,7 @@ const storageFactory = {
 // Mocking localStorage for tests
 import 'jest-localstorage-mock';
 const storage = require('./src/storage').default;
-storage.setStorage(storageFactory);
+storage.setStore(storageFactory);
 
 // Mocking WebSocket for tests
 import { Server, WebSocket } from 'mock-socket';

--- a/src/WebSocketHandler.js
+++ b/src/WebSocketHandler.js
@@ -29,7 +29,6 @@ class WS extends EventEmitter {
       this.connected = undefined;
       // Store variable that is passed to Redux if ws is online
       this.isOnline = undefined;
-      this.setup();
     }
 
     return WS.instance;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,6 +8,8 @@
 import { GENESIS_BLOCK, DECIMAL_PLACES, DEFAULT_SERVER } from './constants';
 import path from 'path';
 
+const storage = require('./storage').default;
+
 /**
  * Helper methods
  *
@@ -170,7 +172,7 @@ const helpers = {
    * @inner
    */
   getServerURL() {
-    let server = localStorage.getItem('wallet:server');
+    let server = storage.getItem('wallet:server');
     if (server === null) {
       server = DEFAULT_SERVER;
     }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -8,7 +8,7 @@
 import { GENESIS_BLOCK, DECIMAL_PLACES, DEFAULT_SERVER } from './constants';
 import path from 'path';
 
-const storage = require('./storage').default;
+import storage from './storage';
 
 /**
  * Helper methods

--- a/src/storage.js
+++ b/src/storage.js
@@ -16,10 +16,7 @@
  */
 class Storage {
   constructor() {
-    if (!Storage.instance) {
-      this.store = null;
-    }
-    return Storage.instance;
+    this.store = null;
   }
 
   /**

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Interface to use the storage object set by the client
+ *
+ * This storage should have the same methods as localStorage (from the browser) and has
+ * to support storaing js objects. It should handle any serialization needed.
+ *
+ * @class
+ * @name Storage
+ */
 class Storage {
   constructor() {
     if (!Storage.instance) {
@@ -7,30 +23,67 @@ class Storage {
     return Storage.instance;
   }
 
+  /**
+   * Set the underlying storage object
+   *
+   * @param {Object} myStorage The storage to be used
+   */
   setStorage(myStorage) {
     this.store = myStorage;
   }
 
+  /**
+   * Return the current value associated with the given key
+   *
+   * @param {string} key Key associated with the object
+   *
+   * @return {Object} the object stored
+   */
   getItem(key) {
     return this.store.getItem(key);
   }
 
+  /**
+   * Add the given object to the storage
+   *
+   * @param {string} key Key associated with the object
+   * @param {Object} value Object to be stored
+   */
   setItem(key, value) {
     return this.store.setItem(key, value);
   }
 
+  /**
+   * Remove the key and associated object from storage
+   *
+   * @param {string} key Key associated with the object
+   */
   removeItem(key) {
     return this.store.removeItem(key);
   }
 
+  /**
+   * Remove all key and associated objects from storage
+   */
   clear() {
     return this.store.clear();
   }
 
+  /**
+   * Return the name of the nth key in storage
+   *
+   * @param {string} n
+   *
+   * @return {Object} Object associated with nth key
+   */
   key(n) {
     return this.store.key(n);
   }
 
+  /**
+   * This method is optional and may be used to initialize the storage before the
+   * lib starts using it
+   */
   preStart() {
     return this.store.preStart();
   }

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,41 @@
+class Storage {
+  constructor() {
+    if (!Storage.instance) {
+      this.store = null;
+      this.memory = false;
+    }
+    return Storage.instance;
+  }
+
+  setStorage(myStorage) {
+    this.store = myStorage;
+  }
+
+  getItem(key) {
+    return this.store.getItem(key);
+  }
+
+  setItem(key, value) {
+    return this.store.setItem(key, value);
+  }
+
+  removeItem(key) {
+    return this.store.removeItem(key);
+  }
+
+  clear() {
+    return this.store.clear();
+  }
+
+  key(n) {
+    return this.store.key(n);
+  }
+
+  preStart() {
+    return this.store.preStart();
+  }
+}
+
+const instance = new Storage();
+
+export default instance;

--- a/src/storage.js
+++ b/src/storage.js
@@ -18,7 +18,6 @@ class Storage {
   constructor() {
     if (!Storage.instance) {
       this.store = null;
-      this.memory = false;
     }
     return Storage.instance;
   }

--- a/src/storage.js
+++ b/src/storage.js
@@ -23,11 +23,11 @@ class Storage {
   }
 
   /**
-   * Set the underlying storage object
+   * Set the underlying store object
    *
-   * @param {Object} myStorage The storage to be used
+   * @param {Object} myStorage The store to be used
    */
-  setStorage(myStorage) {
+  setStore(myStorage) {
     this.store = myStorage;
   }
 
@@ -66,17 +66,6 @@ class Storage {
    */
   clear() {
     return this.store.clear();
-  }
-
-  /**
-   * Return the name of the nth key in storage
-   *
-   * @param {string} n
-   *
-   * @return {Object} Object associated with nth key
-   */
-  key(n) {
-    return this.store.key(n);
   }
 
   /**

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -12,6 +12,8 @@ import { AddressError, OutputValueError } from './errors';
 import buffer from 'buffer';
 import { HATHOR_TOKEN_CONFIG, TOKEN_CREATION_MASK, TOKEN_MINT_MASK, TOKEN_MELT_MASK } from './constants';
 
+const storage = require('./storage').default;
+
 
 /**
  * Methods to create and handle tokens
@@ -39,7 +41,7 @@ const tokens = {
   },
 
   /**
-   * Add a new token to the localStorage and redux
+   * Add a new token to the storage and redux
    *
    * @param {string} uid Token uid
    * @param {string} name Token name
@@ -59,7 +61,7 @@ const tokens = {
   },
 
   /**
-   * Edit token name and symbol. Save in localStorage and redux
+   * Edit token name and symbol. Save in storage and redux
    *
    * @param {string} uid Token uid to be edited
    * @param {string} name New token name
@@ -80,7 +82,7 @@ const tokens = {
   },
 
   /**
-   * Unregister token from localStorage and redux
+   * Unregister token from storage and redux
    *
    * @param {string} uid Token uid to be unregistered
    *
@@ -145,7 +147,7 @@ const tokens = {
   },
 
   /**
-   * Returns the saved tokens in localStorage
+   * Returns the saved tokens in storage
    *
    * @return {Object} Array of objects ({'name', 'symbol', 'uid'}) of saved tokens
    *
@@ -153,17 +155,15 @@ const tokens = {
    * @inner
    */
   getTokens() {
-    let dataToken = localStorage.getItem('wallet:tokens');
-    if (dataToken) {
-      dataToken = localStorage.memory ? dataToken : JSON.parse(dataToken);
-    } else {
+    let dataToken = storage.getItem('wallet:tokens');
+    if (!dataToken) {
       dataToken = [HATHOR_TOKEN_CONFIG];
     }
     return dataToken;
   },
 
   /**
-   * Updates the saved tokens in localStorage
+   * Updates the saved tokens in storage
    *
    * @param {Object} Array of objects ({'name', 'symbol', 'uid'}) with new tokens
    *
@@ -172,8 +172,7 @@ const tokens = {
    *
    */
   saveToStorage(newTokens) {
-    const dataTokens = localStorage.memory ? newTokens : JSON.stringify(newTokens);
-    localStorage.setItem('wallet:tokens', dataTokens);
+    storage.setItem('wallet:tokens', newTokens);
   },
 
   /**
@@ -291,7 +290,7 @@ const tokens = {
     const promise = new Promise((resolve, reject) => {
       walletApi.sendTokens(txHex, (response) => {
         if (response.success) {
-          // Save in localStorage and redux new token configuration
+          // Save in storage and redux new token configuration
           this.addToken(response.tx.tokens[0], name, symbol);
           const mintPromise = this.mintTokens(response.tx.hash, response.tx.tokens[0], address, mintAmount, pin)
           mintPromise.then(() => {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -6,13 +6,12 @@
  */
 
 import transaction from './transaction';
+import storage from './storage';
 import { crypto, util } from 'bitcore-lib';
 import walletApi from './api/wallet';
 import { AddressError, OutputValueError } from './errors';
 import buffer from 'buffer';
 import { HATHOR_TOKEN_CONFIG, TOKEN_CREATION_MASK, TOKEN_MINT_MASK, TOKEN_MELT_MASK } from './constants';
-
-const storage = require('./storage').default;
 
 
 /**

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -16,6 +16,8 @@ import buffer from 'buffer';
 import Long from 'long';
 import walletApi from './api/wallet';
 
+const storage = require('./storage').default;
+
 /**
  * Transaction utils with methods to serialize, create and handle transactions
  *
@@ -320,8 +322,8 @@ const transaction = {
    * @inner
    */
   getSignature(index, hash, pin) {
-    const accessData = localStorage.getItem('wallet:accessData');
-    const encryptedPrivateKey = localStorage.memory ? accessData.mainKey : JSON.parse(accessData).mainKey;
+    const accessData = storage.getItem('wallet:accessData');
+    const encryptedPrivateKey = accessData.mainKey;
     const privateKeyStr = wallet.decryptData(encryptedPrivateKey, pin);
     const key = HDPrivateKey(privateKeyStr)
     const derivedKey = key.derive(index);
@@ -541,7 +543,7 @@ const transaction = {
   },
 
   /**
-   * Save txMinWeight and txWeightCoefficient to localStorage
+   * Save txMinWeight and txWeightCoefficient to storage
    *
    * @param {number} txMinWeight Minimum allowed weight for a tx (float)
    * @param {number} txWeightCoefficient Coefficient to be used when calculating tx weight (float)
@@ -550,9 +552,9 @@ const transaction = {
    * @inner
    */
   updateTransactionWeightConstants(txMinWeight, txWeightCoefficient, txMinWeightK) {
-    localStorage.setItem('wallet:txMinWeight', txMinWeight);
-    localStorage.setItem('wallet:txWeightCoefficient', txWeightCoefficient);
-    localStorage.setItem('wallet:txMinWeightK', txMinWeightK);
+    storage.setItem('wallet:txMinWeight', txMinWeight);
+    storage.setItem('wallet:txWeightCoefficient', txWeightCoefficient);
+    storage.setItem('wallet:txMinWeightK', txMinWeightK);
   },
 
   /**
@@ -564,9 +566,9 @@ const transaction = {
    * @inner
    */
   getTransactionWeightConstants() {
-    return {'txMinWeight': parseFloat(localStorage.getItem('wallet:txMinWeight')),
-            'txWeightCoefficient': parseFloat(localStorage.getItem('wallet:txWeightCoefficient')),
-            'txMinWeightK': parseFloat(localStorage.getItem('wallet:txMinWeightK'))}
+    return {'txMinWeight': parseFloat(storage.getItem('wallet:txMinWeight')),
+            'txWeightCoefficient': parseFloat(storage.getItem('wallet:txWeightCoefficient')),
+            'txMinWeightK': parseFloat(storage.getItem('wallet:txMinWeightK'))}
   }
 }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -11,12 +11,12 @@ import { HDPrivateKey, crypto, encoding, util } from 'bitcore-lib';
 import { AddressError, OutputValueError } from './errors';
 import dateFormatter from './date';
 import helpers from './helpers';
+import storage from './storage';
 import wallet from './wallet';
 import buffer from 'buffer';
 import Long from 'long';
 import walletApi from './api/wallet';
 
-const storage = require('./storage').default;
 
 /**
  * Transaction utils with methods to serialize, create and handle transactions

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -14,11 +14,10 @@ import tokens from './tokens';
 import helpers from './helpers';
 import { OutputValueError } from './errors';
 import version from './version';
+import storage from './storage';
 import WebSocketHandler from './WebSocketHandler';
 import dateFormatter from './date';
 import _ from 'lodash';
-
-const storage = require('./storage').default;
 
 /**
  * We use storage and Redux to save data.


### PR DESCRIPTION
The lib now doesn't require localStorage and clients should pass a storage to the lib using `setStorage()`.