### PR TITLE
fix: ws connection issue

### DIFF
--- a/src/WebSocketHandler.js
+++ b/src/WebSocketHandler.js
@@ -216,7 +216,9 @@ class WS extends EventEmitter {
     if (this.ws) {
       this.ws.onclose = () => {};
       this.ws.close();
+      this.ws = null;
     }
+    clearInterval(this.heartbeat);
   }
 
   /**


### PR DESCRIPTION
`endConnection` is called in `src/wallet.js` in the method `reloadData`, that is called when unlocking the wallet (desktop), resetting wallet and changing server.

`this.ws` was never being set to null, so it would never connect again. 