### PR TITLE
fix: move xpubkey to wallet:accessData on storage

### DIFF
--- a/__tests__/wallet_utils.test.js
+++ b/__tests__/wallet_utils.test.js
@@ -25,8 +25,8 @@ test('Loaded', () => {
 });
 
 test('Clean local storage', () => {
-  storage.setItem('wallet:accessData', {});
-  storage.setItem('wallet:data', {});
+  wallet.setWalletAccessData({});
+  wallet.setWalletData({});
   storage.setItem('wallet:address', '171hK8MaRpG2SqQMMQ34EdTharUmP1Qk4r');
   storage.setItem('wallet:lastSharedIndex', 1);
   storage.setItem('wallet:lastGeneratedIndex', 19);
@@ -35,8 +35,8 @@ test('Clean local storage', () => {
 
   wallet.cleanLoadedData();
 
-  expect(storage.getItem('wallet:accessData')).toBeNull();
-  expect(storage.getItem('wallet:data')).toBeNull();
+  expect(wallet.getWalletAccessData()).toBeNull();
+  expect(wallet.getWalletData()).toBeNull();
   expect(storage.getItem('wallet:address')).toBeNull();
   expect(storage.getItem('wallet:lastSharedIndex')).toBeNull();
   expect(storage.getItem('wallet:lastGeneratedIndex')).toBeNull();
@@ -223,10 +223,10 @@ test('Get wallet words', async () => {
 test('Reload data', async () => {
   const words = wallet.generateWalletWords(256);
   await wallet.executeGenerateWallet(words, '', '123456', 'password', true);
-  const accessData = storage.getItem('wallet:accessData');
-  const keys = storage.getItem('wallet:data').keys;
+  const accessData = wallet.getWalletAccessData();
+  const keys = wallet.getWalletData().keys;
   wallet.reloadData();
-  expect(storage.getItem('wallet:accessData')).toEqual(accessData);
+  expect(wallet.getWalletAccessData()).toEqual(accessData);
 });
 
 test('Started', () => {
@@ -252,8 +252,8 @@ test('Reset all data', async () => {
   expect(storage.getItem('wallet:started')).toBeNull();
   expect(storage.getItem('wallet:server')).toBeNull();
   expect(storage.getItem('wallet:locked')).toBeNull();
-  expect(storage.getItem('wallet:accessData')).toBeNull();
-  expect(storage.getItem('wallet:data')).toBeNull();
+  expect(wallet.getWalletAccessData()).toBeNull();
+  expect(wallet.getWalletData()).toBeNull();
   expect(storage.getItem('wallet:defaultServer')).toBe(defaultServer);
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Library used by Hathor Wallet",
   "jest": {
     "setupFilesAfterEnv": [

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -31,6 +31,7 @@ import _ from 'lodash';
  *   . hash: string with hash of pin
  *   . words: string with encrypted words
  *   . hashPasswd: string with hash of password
+ *   . xpubkey: string with wallet xpubkey
  * - address: string with last shared address to show on screen
  * - lastSharedIndex: number with the index of the last shared address
  * - lastGeneratedIndex: number with the index of the last generated address
@@ -132,15 +133,15 @@ const wallet = {
       saltPasswd: encryptedDataWords.hash.salt,
       hashIterations: HASH_ITERATIONS,
       pbkdf2Hasher: 'sha1', // For now we are only using SHA1
+      xpubkey: privkey.xpubkey,
     }
 
     let walletData = {
       keys: {},
-      xpubkey: privkey.xpubkey,
       historyTransactions: {},
     }
 
-    storage.setItem('wallet:accessData', access);
+    this.setWalletAccessData(access);
     this.setWalletData(walletData);
 
     let promise = null;
@@ -193,6 +194,30 @@ const wallet = {
   },
 
   /**
+   * Get wallet access data already parsed from JSON
+   *
+   * @return {Object} wallet access data
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  getWalletAccessData() {
+    return storage.getItem('wallet:accessData');
+  },
+
+  /**
+   * Set wallet access data
+   *
+   * @param {Object} wallet access data
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  setWalletAccessData(data) {
+    storage.setItem('wallet:accessData', data);
+  },
+
+  /**
    * Load the history for each of the addresses of a new generated wallet
    * We always search until the GAP_LIMIT. If we have any history in the middle of the searched addresses
    * we search again until we have the GAP_LIMIT of addresses without any transactions
@@ -211,8 +236,9 @@ const wallet = {
       // First generate all private keys and its addresses, then get history
       let addresses = [];
       let dataJson = this.getWalletData();
+      let accessData = this.getWalletAccessData();
 
-      const xpub = HDPublicKey(dataJson.xpubkey);
+      const xpub = HDPublicKey(accessData.xpubkey);
       const stopIndex = startIndex + count;
       for (var i=startIndex; i<stopIndex; i++) {
         // Generate each key from index, encrypt and save
@@ -397,7 +423,7 @@ const wallet = {
    * @inner
    */
   hashValidation(password, hashKey, saltKey) {
-    const accessData = storage.getItem('wallet:accessData');
+    const accessData = this.getWalletAccessData();
     let hash;
     if (!(saltKey in accessData)) {
       // Old wallet, we need to validate with old method and update it to the new method
@@ -411,7 +437,7 @@ const wallet = {
       accessData['hashIterations'] = HASH_ITERATIONS;
       accessData['pbkdf2Hasher'] = 'sha1'; // For now we are only using SHA1
       // Updating access data with new hash data
-      storage.setItem('wallet:accessData', accessData);
+      this.setWalletAccessData(accessData);
       return true;
     } else {
       // Already a wallet with new hash algorithm, so only validate
@@ -437,7 +463,7 @@ const wallet = {
       return false;
     }
 
-    const accessData = storage.getItem('wallet:accessData');
+    const accessData = this.getWalletAccessData();
 
     // Get new PIN hash
     const newHash = this.hashPassword(newPin);
@@ -450,7 +476,7 @@ const wallet = {
     const encryptedData = this.encryptData(decryptedData, newPin);
     accessData['mainKey'] = encryptedData.encrypted.toString();
 
-    storage.setItem('wallet:accessData', accessData);
+    this.setWalletAccessData(accessData);
 
     return true;
   },
@@ -524,8 +550,8 @@ const wallet = {
    * @inner
    */
   generateNewAddress() {
-    const dataJson = this.getWalletData();
-    const xpub = HDPublicKey(dataJson.xpubkey);
+    const accessData = this.getWalletAccessData();
+    const xpub = HDPublicKey(accessData.xpubkey);
 
     // Get last shared index to discover new index
     const lastSharedIndex = this.getLastSharedIndex();
@@ -1121,7 +1147,7 @@ const wallet = {
    * @inner
    */
   getWalletWords(password) {
-    const accessData = storage.getItem('wallet:accessData');
+    const accessData = this.getWalletAccessData();
     return this.decryptData(accessData.words, password);
   },
 
@@ -1165,12 +1191,8 @@ const wallet = {
    */
   reloadData() {
     // Get old access data
-    const accessData = storage.getItem('wallet:accessData');
+    const accessData = this.getWalletAccessData();
     const walletData = this.getWalletData();
-
-    if (walletData === null) {
-      return Promise.reject();
-    }
 
     this.cleanWallet();
     // Restart websocket connection
@@ -1178,11 +1200,10 @@ const wallet = {
 
     let newWalletData = {
       keys: {},
-      xpubkey: walletData.xpubkey,
       historyTransactions: {},
     }
 
-    storage.setItem('wallet:accessData', accessData);
+    this.setWalletAccessData(accessData);
     this.setWalletData(newWalletData);
 
     // Load history from new server
@@ -1460,7 +1481,7 @@ const wallet = {
       // Setting last shared address, if necessary
       const candidateIndex = maxIndex + 1;
       if (candidateIndex > lastSharedIndex) {
-        const xpub = HDPublicKey(dataJson.xpubkey);
+        const xpub = HDPublicKey(this.getWalletAccessData().xpubkey);
         const key = xpub.derive(candidateIndex);
         const address = Address(key.publicKey, network.getNetwork()).toString();
         newSharedIndex = candidateIndex;


### PR DESCRIPTION
We actually need xpubkey to always be persisted. As with the latest change in the wallet, `wallet:data` is kept in memory, so it would not persist across restarts.