### PR TITLE
feat: creating method to send a transaction from an array of outputs

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -347,6 +347,7 @@ class HathorWallet extends EventEmitter {
 
   /**
    * Send a transaction from its outputs
+   * Currently does not have support to send custom tokens, only HTR
    *
    * @param {Array} outputs Array of outputs with each element as an object with {'address', 'value'}
    *


### PR DESCRIPTION
Even though it's more logical to use `sendTransaction` I didn't want to break compatibility with the other method in case other projects are already using it. 