### PR TITLE
refactor: keep only one websocket connection when using new Hathor Wallet code

### DIFF
--- a/__tests__/address.test.js
+++ b/__tests__/address.test.js
@@ -19,9 +19,10 @@ beforeEach(() => {
   // This useFakeTimers allow to handle setTimeout calls
   // With it we can run all pending calls
   jest.useFakeTimers();
-  WebSocketHandler.ws = new WS({ wsURL: helpers.getWSServerURL() });
-  WebSocketHandler.ws.WebSocket = WebSocket;
-  WebSocketHandler.ws.setup();
+  wallet.setConnection(WebSocketHandler);
+  WebSocketHandler.websocket = new WS({ wsURL: helpers.getWSServerURL() });
+  WebSocketHandler.websocket.WebSocket = WebSocket;
+  WebSocketHandler.websocket.setup();
   jest.runOnlyPendingTimers();
 });
 
@@ -128,7 +129,7 @@ test('Last used index', async () => {
 
 test('Subscribe address to websocket', (done) => {
   let address = '171hK8MaRpG2SqQMMQ34EdTharUmP1Qk4r';
-  WebSocketHandler.ws.on('subscribe_success', (wsData) => {
+  WebSocketHandler.websocket.on('subscribe_success', (wsData) => {
     if (wsData.address === address) {
       // If got here test was successful, so ending it
       done();
@@ -156,7 +157,7 @@ test('Subscribe all addresses to websocket', (done) => {
     keys[address] = {};
   }
   storage.setItem('wallet:data', {keys: keys});
-  WebSocketHandler.ws.on('subscribe_success', function handler(wsData) {
+  WebSocketHandler.websocket.on('subscribe_success', function handler(wsData) {
     let foundIndex = -1;
     for (let [idx, address] of addresses.entries()) {
       if (address === wsData.address) {
@@ -171,7 +172,7 @@ test('Subscribe all addresses to websocket', (done) => {
 
     if (addresses.length === 0) {
       // If got here test was successful, so ending it
-      WebSocketHandler.ws.removeListener('subscribe_success', handler);
+      WebSocketHandler.websocket.removeListener('subscribe_success', handler);
       done();
     }
   });

--- a/__tests__/new_wallet.test.js
+++ b/__tests__/new_wallet.test.js
@@ -10,6 +10,10 @@ import wallet from '../src/wallet';
 import WebSocketHandler from '../src/WebSocketHandler';
 import storage from '../src/storage';
 
+beforeEach(() => {
+  wallet.setConnection(WebSocketHandler);
+});
+
 
 var addressUsed = '';
 var addressShared = '';

--- a/__tests__/tokens_utils.js
+++ b/__tests__/tokens_utils.js
@@ -23,6 +23,7 @@ const token1 = {'name': '1234', 'uid': '1234', 'symbol': '1234'};
 
 beforeEach(() => {
   WebSocketHandler.started = true;
+  wallet.setConnection(WebSocketHandler);
   wallet.resetAllData();
 });
 

--- a/__tests__/transaction_utils.test.js
+++ b/__tests__/transaction_utils.test.js
@@ -12,6 +12,11 @@ import buffer from 'buffer';
 import { OP_PUSHDATA1 } from '../src/opcodes';
 import { DEFAULT_TX_VERSION } from '../src/constants';
 import storage from '../src/storage';
+import WebSocketHandler from '../src/WebSocketHandler';
+
+beforeEach(() => {
+  wallet.setConnection(WebSocketHandler);
+});
 
 
 test('Tx weight constants', () => {

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -9,6 +9,11 @@ import wallet from '../src/wallet';
 import dateFormatter from '../src/date';
 import { HATHOR_TOKEN_CONFIG } from '../src/constants';
 import storage from '../src/storage';
+import WebSocketHandler from '../src/WebSocketHandler';
+
+beforeEach(() => {
+  wallet.setConnection(WebSocketHandler);
+});
 
 
 test('Wallet operations for transaction', () => {

--- a/__tests__/wallet_utils.test.js
+++ b/__tests__/wallet_utils.test.js
@@ -15,6 +15,7 @@ import WebSocketHandler from '../src/WebSocketHandler';
 
 
 beforeEach(() => {
+  wallet.setConnection(WebSocketHandler);
   wallet.resetAllData();
   WebSocketHandler.setup();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Library used by Hathor Wallet",
   "jest": {
     "setupFilesAfterEnv": [

--- a/setupTests.js
+++ b/setupTests.js
@@ -103,8 +103,9 @@ mock.onGet('version').reply((config) => {
 import WebSocketHandler from './src/WebSocketHandler';
 import WS from './src/websocket';
 
-WebSocketHandler.ws = new WS({ wsURL });
-WebSocketHandler.ws.WebSocket = WebSocket;
-WebSocketHandler.ws.setup();
+WebSocketHandler.websocket = new WS({ wsURL });
+WebSocketHandler.websocket.WebSocket = WebSocket;
+WebSocketHandler.websocket.setup();
+
 
 global.window = {};

--- a/src/WebSocketHandler.js
+++ b/src/WebSocketHandler.js
@@ -15,12 +15,12 @@ class WebSocketHandler extends EventEmitter {
   constructor() {
     super();
 
-    this.ws = null;
+    this.websocket = null;
   }
 
   setup() {
-    if (this.ws === null) {
-      this.ws = new WS({ wsURL: helpers.getWSServerURL });
+    if (this.websocket === null) {
+      this.websocket = new WS({ wsURL: helpers.getWSServerURL });
 
       this.on('is_online', this.handleIsOnline);
 
@@ -28,23 +28,23 @@ class WebSocketHandler extends EventEmitter {
        * This class still exists for compatibility reasons
        * it is used in some wallets and in our old lib code
        * In the wallets we capture some events from it, so
-       * this following code is to emit all events emitted from this.ws
+       * this following code is to emit all events emitted from this.websocket
        */
-      this.oldEmit = this.ws.emit;
-      this.ws.emit = (type, data) => {
+      this.oldEmit = this.websocket.emit;
+      this.websocket.emit = (type, data) => {
         this.emit(type, data);
         return this.oldEmit(type, data);
       }
     }
 
     // To keep compatibility with methods previously used in this singleton
-    return this.ws.setup();
+    return this.websocket.setup();
   }
 
   handleIsOnline(value) {
     if (value) {
       wallet.onWebsocketOpened();
-      this.ws.emit('reload_data');
+      this.websocket.emit('reload_data');
     } else {
       wallet.onWebsocketBeforeClose();
     }
@@ -52,10 +52,10 @@ class WebSocketHandler extends EventEmitter {
 
   endConnection() {
     // To keep compatibility with methods previously used in this singleton
-    if (this.ws !== null) {
-      this.ws.endConnection();
-      this.ws.emit = () => {};
-      this.ws = null;
+    if (this.websocket !== null) {
+      this.websocket.endConnection();
+      this.websocket.emit = () => {};
+      this.websocket = null;
       this.removeListener('is_online', this.handleIsOnline);
     }
   }

--- a/src/new/connection.js
+++ b/src/new/connection.js
@@ -10,6 +10,7 @@ import networkInstance from '../network';
 import { DEFAULT_SERVERS } from '../constants';
 import version from '../version';
 import helpers from '../helpers';
+import wallet from '../wallet';
 import WS from '../websocket';
 
 /**
@@ -51,6 +52,7 @@ class Connection extends EventEmitter {
     this.currentServer = this.servers[0];
 
     this.websocket = new WS({ wsURL: helpers.getWSServerURL(this.currentServer) });
+    wallet.setConnection(this);
   }
 
   /**
@@ -105,6 +107,22 @@ class Connection extends EventEmitter {
     this.websocket.removeListener('is_online', this.onConnectionChange);
     this.websocket.removeListener('wallet', this.handleWalletMessage);
     this.setState(Connection.CLOSED);
+  }
+
+  /**
+   * Call websocket endConnection
+   * Needed for compatibility with old src/wallet code
+   **/
+  endConnection() {
+    this.websocket.endConnection();
+  }
+
+  /**
+   * Call websocket setup
+   * Needed for compatibility with old src/wallet code
+   **/
+  setup() {
+    this.websocket.setup();
   }
 }
 

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -17,7 +17,6 @@ import helpers from '../helpers';
 import MemoryStore from '../memory_store';
 import Connection from './connection';
 import SendTransaction from './sendTransaction';
-import WebSocketHandler from '../WebSocketHandler';
 
 /**
  * This is a Wallet that is supposed to be simple to be used by a third-party app.
@@ -100,6 +99,8 @@ class HathorWallet extends EventEmitter {
 
     this.onConnectionChangedState = this.onConnectionChangedState.bind(this);
     this.handleWebsocketMsg = this.handleWebsocketMsg.bind(this);
+
+    this.firstConnection = true;
   }
 
   /**
@@ -113,14 +114,18 @@ class HathorWallet extends EventEmitter {
       storage.setStore(this.store);
       this.setState(HathorWallet.SYNCING);
 
-      // After the websocket connection is lost, we must reload the wallet data.
-      // Before that we must clean the storage (last generated address index), so we
-      // start loading again from the first index.
-      // I could create a variable to know if this is the first connection or a reload
-      // but the reload method only adds a clean up on storage and that is not a problem on the
-      // first connection (because everything is already empty).
-      // So I just call the reload method every time I connect to the websocket
-      wallet.reloadData({connection: this.conn, store: this.store}).then(() => {
+      // If it's the first connection we just load the history
+      // otherwise we are reloading data, so we must execute some cleans
+      // before loading the full data again
+      let promise;
+      if (this.firstConnection) {
+        this.firstConnection = false;
+        promise = wallet.loadAddressHistory(0, GAP_LIMIT, this.conn, this.store);
+      } else {
+        promise = wallet.reloadData({connection: this.conn, store: this.store});
+      }
+
+      promise.then(() => {
         this.setState(HathorWallet.READY);
       }).catch((error) => {
         throw error;
@@ -461,6 +466,7 @@ class HathorWallet extends EventEmitter {
 
     this.serverInfo = null;
     this.setState(HathorWallet.CLOSED);
+    this.firstConnection = true;
   }
 
   /**


### PR DESCRIPTION
**The problem:**

We were getting some weird logs with two websocket connections in a single wallet headless, where one of the connections was opened and receiving messages while the other was closed for a long time.

**The change:**

I changed the old code to use a specific connection, which can be changed by a method. By default it uses the `WebSocketHandler` to continue supporting wallets desktop and mobile, while the new code sets the Connection object to be used in the old code, so only one websocket connection is created.

**Future refactor:**

With this change the wallet headless will not work with more than one wallet anymore, which might not be a problem because nowadays we are having problems even with only one wallet. So after this change I would like to continue debug Euroline's logs while I execute the next refactor, which is to support more than one wallet connected at the same time in the headless, while each one has only one connection.