### PR TITLE
refactor: removing store clone when using multiples wallets

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -256,7 +256,7 @@ const wallet = {
    */
   loadAddressHistory(startIndex, count, connection = null, store = null) {
     const promise = new Promise((resolve, reject) => {
-      let oldStore = _.clone(storage.store);
+      let oldStore = storage.store;
       if (store) {
         // Using method store because we will call getWalletData and getWalletAccessData, then need to get from correct store
         storage.setStore(store);
@@ -345,7 +345,7 @@ const wallet = {
         } else {
           // If it's the last page, we update the storage and call the next loadAddress (if needed)
           // This is all done on updateHistoryData
-          let oldStore = _.clone(storage.store);
+          let oldStore = storage.store;
           if (store) {
             // Using method store because we will call getWalletData, then need to get from correct store
             storage.setStore(store);
@@ -1542,7 +1542,7 @@ const wallet = {
    * @inner
    */
   saveNewHistoryOnStorage(oldHistoryTransactions, oldAllTokens, newHistory, dataJson, connection = null, store = null) {
-    let oldStore = _.clone(storage.store);
+    let oldStore = storage.store;
     if (store) {
       // Using method store because we will call getWalletData, then need to get from correct store
       storage.setStore(store);
@@ -1649,7 +1649,7 @@ const wallet = {
    * @inner
    */
   updateHistoryData(oldHistoryTransactions, oldAllTokens, newHistory, resolve, dataJson, reject, connection = null, store = null) {
-    let oldStore = _.clone(storage.store);
+    let oldStore = storage.store;
     if (store) {
       // Using method store because we will call getLastGeneratedIndex, then need to get from correct store
       storage.setStore(store);


### PR DESCRIPTION
**The problem**

Using clone was probably creating many instances of the store in memory, which were different from the initial one set in the wallet class.

Wallet class:
```
this.store = store
storage.setStore(this.store)
```

Wallet utils:
```
let oldStore = _.clone(store)
...

storage.setStore(oldStore)
```