### PR TITLE
fix: avoid summing the parents size twice when parents are sent in tx…

### DIFF
--- a/__tests__/transaction_utils.test.js
+++ b/__tests__/transaction_utils.test.js
@@ -7,7 +7,7 @@
 
 import transaction from '../src/transaction';
 import wallet from '../src/wallet';
-import { AddressError, OutputValueError } from '../src/errors';
+import { AddressError, OutputValueError, MaximumNumberParentsError } from '../src/errors';
 import buffer from 'buffer';
 import { OP_PUSHDATA1 } from '../src/opcodes';
 import { DEFAULT_TX_VERSION } from '../src/constants';
@@ -18,6 +18,40 @@ beforeEach(() => {
   wallet.setConnection(WebSocketHandler);
 });
 
+
+test('calculate tx weight should fail with > 2 parents', () => {
+  const txData = {
+    "inputs": [{
+      "tx_id": "0000000e340d38d7a5616e3dfb8ac46184b07d59b8e7e61f9ce6e629d7abe8d6",
+      "index": 0,
+      "token": "00",
+      "address": "WR1i8USJWQuaU423fwuFQbezfevmT4vFWX",
+      "data": Buffer.from([71, 48])
+    }],
+    "outputs": [{
+      "address": "WR1i8USJWQuaU423fwuFQbezfevmT4vFWX",
+      "value": 5400,
+      "tokenData": 0,
+      "isChange": true
+    }, {
+      "address": "WR1i8USJWQuaU423fwuFQbezfevmT4vFWX",
+      "value": 1000,
+      "tokenData": 0
+    }],
+    "parents": [
+      "0002d4d2a15def7604688e1878ab681142a7b155cbe52a6b4e031250ae96db0a",
+      "0002ad8d1519daaddc8e1a37b14aac0b045129c01832281fb1c02d873c7abbf9",
+      "0002ad8d1519daaddc8e1a37b14aac0b045129c01832281fb1c02d873c7abbf9"
+    ],
+    "tokens": [],
+    "weight": 18.65677715840935,
+    "nonce": 0,
+    "version": 1,
+    "timestamp": 1610639352
+  };
+
+  expect(() => transaction.calculateTxWeight(txData)).toThrowError(MaximumNumberParentsError);
+});
 
 test('Tx weight constants', () => {
   transaction.updateTransactionWeightConstants(10, 1.5, 8);

--- a/src/errors.js
+++ b/src/errors.js
@@ -76,6 +76,14 @@ export class MaximumNumberInputsError extends Error {}
 export class MaximumNumberOutputsError extends Error {}
 
 /**
+ * Error thrown when transaction has more parents than the maximum allowed
+ *
+ * @memberof Errors
+ * @inner
+ */
+export class MaximumNumberParentsError extends Error {}
+
+/**
  * Error thrown when the wallet type is invalid
  *
  * @memberof Errors

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -434,9 +434,11 @@ const transaction = {
   calculateTxWeight(txData) {
     let txSize = this.txToBytes(txData).length;
 
-    // XXX Parents are calculated only in the server but we need to consider them here
-    // Parents are always two and have 32 bytes each
-    txSize += 64
+    // If parents are not in txData, we need to consider them here
+    if (!txData.parents || !txData.parents.length || txData.parents.length === 0) {
+      // Parents are always two and have 32 bytes each
+      txSize += 64;
+    }
 
     let sumOutputs = this.getOutputsSum(txData.outputs);
     // Preventing division by 0 when handling authority methods that have no outputs

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -8,7 +8,7 @@
 import { OP_GREATERTHAN_TIMESTAMP, OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG, OP_PUSHDATA1 } from './opcodes';
 import { DECIMAL_PLACES, CREATE_TOKEN_TX_VERSION, DEFAULT_TX_VERSION, TOKEN_INFO_VERSION, MAX_OUTPUT_VALUE_32, MAX_OUTPUT_VALUE, TOKEN_AUTHORITY_MASK, STRATUM_TIMEOUT_RETURN_CODE } from './constants';
 import { HDPrivateKey, crypto, encoding, util } from 'bitcore-lib';
-import { AddressError, OutputValueError, ConstantNotSet, CreateTokenTxInvalid, MaximumNumberInputsError, MaximumNumberOutputsError } from './errors';
+import { AddressError, OutputValueError, ConstantNotSet, CreateTokenTxInvalid, MaximumNumberInputsError, MaximumNumberOutputsError, MaximumNumberParentsError } from './errors';
 import dateFormatter from './date';
 import helpers from './helpers';
 import network from './network';
@@ -17,6 +17,7 @@ import storage from './storage';
 import buffer from 'buffer';
 import Long from 'long';
 import walletApi from './api/wallet';
+import { get } from 'lodash';
 
 
 /**
@@ -165,7 +166,7 @@ const transaction = {
 
   /**
    * Validate if the address is valid
-   * 
+   *
    * 1. Address must have 25 bytes
    * 2. Address checksum must be valid
    * 3. Address first byte must match one of the options for P2PKH or P2SH
@@ -201,11 +202,11 @@ const transaction = {
     }
     return true;
   },
-  
+
   /**
    * Return the checksum of the bytes passed
    * Checksum is calculated as the 4 first bytes of the double sha256
-   * 
+   *
    * @param {Buffer} bytes Data from where the checksum is calculated
    *
    * @return {Buffer}
@@ -221,7 +222,7 @@ const transaction = {
    * We push the length of data and the data
    * In case the data has length > 75, we need to push the OP_PUSHDATA1 before the length
    * We always push bytes
-   * 
+   *
    * @param {Array} stack Stack of bytes from the script
    * @param {Buffer} data Data to be pushed to stack
    *
@@ -240,7 +241,7 @@ const transaction = {
 
   /**
    * Create output script
-   * 
+   *
    * @param {string} address Address in base58
    * @param {number} [timelock] Timelock in timestamp
    *
@@ -271,7 +272,7 @@ const transaction = {
 
   /**
    * Create input data
-   * 
+   *
    * @param {Buffer} signature Input signature
    * @param {Buffer} publicKey Input public key
    *
@@ -288,7 +289,7 @@ const transaction = {
 
   /**
    * Return transaction data to sign in inputs
-   * 
+   *
    * @param {Object} txData Object with inputs and outputs {'inputs': [{'tx_id', 'index', 'token'}], 'outputs': ['address', 'value', 'timelock', 'tokenData'], 'tokens': [uid, uid2]}
    *
    * @return {Buffer}
@@ -414,7 +415,7 @@ const transaction = {
 
   /**
    * Calculate the minimum tx weight
-   * 
+   *
    * @param {Object} txData Object with inputs and outputs
    * {
    *  'inputs': [{'tx_id', 'index'}],
@@ -426,6 +427,7 @@ const transaction = {
    * }
    *
    * @throws {ConstantNotSet} If the weight constants are not set yet
+   * @throws {MaximumNumberParentsError} If the tx has more parents than the maximum allowed
    *
    * @return {number} Minimum weight calculated (float)
    * @memberof Transaction
@@ -434,11 +436,11 @@ const transaction = {
   calculateTxWeight(txData) {
     let txSize = this.txToBytes(txData).length;
 
-    // If parents are not in txData, we need to consider them here
-    if (!txData.parents || !txData.parents.length || txData.parents.length === 0) {
-      // Parents are always two and have 32 bytes each
-      txSize += 64;
+    if (txData.parents && txData.parents.length > 2) {
+      throw new MaximumNumberParentsError(`Transaction has ${txData.parents.length} parents and can have at most 2.`);
     }
+
+    txSize += 64 - (32 * (get(txData, 'parents') || 0));
 
     let sumOutputs = this.getOutputsSum(txData.outputs);
     // Preventing division by 0 when handling authority methods that have no outputs
@@ -460,7 +462,7 @@ const transaction = {
 
   /**
    * Calculate the sum of outputs. Authority outputs are ignored.
-   * 
+   *
    * @param {Array} outputs
    * [{
    *  'address': str,
@@ -487,7 +489,7 @@ const transaction = {
    * Complete the txData
    *
    * Add weight, nonce, version, and timestamp to the txData
-   * 
+   *
    * @param {Object} txData Object with inputs and outputs
    * {
    *  'inputs': [{'tx_id', 'index'}],


### PR DESCRIPTION
This is needed by hathor-wallet-service because we need to validate the weight that is being sent via API alongside with the parents.