### PR TITLE
feat: emitting connection_error if a connection fails

### DIFF
--- a/__tests__/websocket.test.js
+++ b/__tests__/websocket.test.js
@@ -28,7 +28,6 @@ test('Ping', (done) => {
 }, 10000)
 
 test('Close', () => {
-
   expect(WebSocketHandler.ws.started).toBe(true);
   expect(WebSocketHandler.ws.connected).toBe(true);
   expect(WebSocketHandler.ws.isOnline).toBe(true);
@@ -37,4 +36,14 @@ test('Close', () => {
   expect(WebSocketHandler.ws.started).toBe(false);
   expect(WebSocketHandler.ws.connected).toBe(false);
   expect(WebSocketHandler.ws.isOnline).toBe(false);
+})
+
+test('Error on ws should emit connection_error event', () => {
+  expect.hasAssertions();
+
+  WebSocketHandler.ws.on('connection_error', (evt) => {
+    expect(evt.message).toStrictEqual('expect-me');
+  });
+
+  WebSocketHandler.ws.onError(new Error('expect-me'));
 })

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -208,6 +208,7 @@ class WS extends EventEmitter {
    * @param {Object} evt Event that contains the error
    */
   onError(evt) {
+    this.emit('connection_error', evt);
     this.onClose();
     // console.log('ws error', window.navigator.onLine, evt);
   }


### PR DESCRIPTION
# Motivation

On the daemon we get no information when a websocket connection fails, the `Connection` class will just silently keep retrying the connection to the fullnode.

On this PR, I will emit a `connection_error` event so the daemon can listen to it and log the connection error