### PR TITLE
fix: small fixes when sending transactions (mint/melt as well) with new signatures

### DIFF
--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -136,7 +136,14 @@ class SendTransaction extends EventEmitter {
       }
       const token = inputTx.outputs[input.index].token;
 
-      tokensData[input.token].inputs.push({
+      if (!(token in tokensData)) {
+        // The input select is from a token that is not in the outputs
+        const err = new SendTxError(ErrorMessages.INVALID_INPUT);
+        err.errorData = { txId: input.txId, index: input.index };
+        throw err;
+      }
+
+      tokensData[token].inputs.push({
         tx_id: input.txId,
         index: input.index,
         token,


### PR DESCRIPTION
After the merge of the new facade signatures to dev and the refactors that were done, some specific problems were found:

1. Add handling of error when the input sent was from a token that was not in the outputs
2. Mint and melt manual address selection had wrong signature (comparing to new wallet service facade and IHathorWallet interface)
3. Utxo consolidation method was not updated to new sendManyOutputsTransaction method signature and return.

### Acceptance criteria

All APIs of the wallet headless must work fine will all parameter options possible.