### PR TITLE
fix: we should calculate tx weight after adding input data

### DIFF
--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -119,7 +119,6 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     // Create the transaction object, add weight and timestamp
     this.transaction = new Transaction(inputsObj, outputsObj);
     this.transaction.tokens = tokens;
-    this.transaction.prepareToSend();
 
     this.emit('prepare-tx-end', this.transaction);
     return { transaction: this.transaction, utxosAddressPath };
@@ -251,6 +250,10 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       const inputData = this.wallet.getInputData(dataToSignHash, utxosAddressPath[idx]);
       inputObj.setData(inputData);
     }
+
+    // Now that the tx is completed with the data of the input
+    // we can add the timestamp and calculate the weight
+    this.transaction.prepareToSend();
 
     this.emit('sign-tx-end', this.transaction);
   }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -634,7 +634,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     }
 
     const tx = new CreateTokenTransaction(name, symbol, inputsObj, outputsObj);
-    tx.prepareToSend();
 
     const dataToSignHash = tx.getDataToSignHash();
 
@@ -642,6 +641,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       const inputData = this.getInputData(dataToSignHash, utxosAddressPath[idx]);
       inputObj.setData(inputData);
     }
+
+    tx.prepareToSend();
     return tx;
   }
 
@@ -734,7 +735,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new Transaction(inputsObj, outputsObj);
     tx.tokens = [token];
-    tx.prepareToSend();
     const dataToSignHash = tx.getDataToSignHash();
 
     for (const [idx, inputObj] of tx.inputs.entries()) {
@@ -744,6 +744,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       inputObj.setData(inputData);
     }
 
+    tx.prepareToSend();
     return tx;
   }
 
@@ -839,7 +840,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new Transaction(inputsObj, outputsObj);
     tx.tokens = [token];
-    tx.prepareToSend();
     const dataToSignHash = tx.getDataToSignHash();
 
     for (const [idx, inputObj] of tx.inputs.entries()) {
@@ -849,6 +849,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       inputObj.setData(inputData);
     }
 
+    tx.prepareToSend();
     return tx;
   }
 
@@ -928,13 +929,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new Transaction(inputsObj, outputsObj);
     tx.tokens = [token];
-    tx.prepareToSend();
 
     // Set input data
     const dataToSignHash = tx.getDataToSignHash();
     const inputData = this.getInputData(dataToSignHash, utxo.addressPath);
     inputsObj[0].setData(inputData);
 
+    tx.prepareToSend();
     return tx;
   }
 
@@ -985,7 +986,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new Transaction(inputsObj, []);
     tx.tokens = [token];
-    tx.prepareToSend();
 
     // Set input data
     const dataToSignHash = tx.getDataToSignHash();
@@ -995,6 +995,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       inputObj.setData(inputData);
     }
 
+    tx.prepareToSend();
     return tx;
   }
 


### PR DESCRIPTION
### Motivation

We are executing `calculateWeight` method before setting the input data (with signatures), then the tx weight is smaller than it should be. This error happens only on the wallet service facade and was not happening before because the tests were made only on the testnet and the min_weight is 8 there.

### Acceptance criteria

The weight should be calculated fine for the transaction and we must be able to send a transaction using the wallet service on the mainnet.