### PR TITLE
feat: separate method to show prettyValue to use a prettyIntegerValue used by NFTs

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -59,9 +59,23 @@ const helpers = {
     const fixedPlaces = (value/10**DECIMAL_PLACES).toFixed(DECIMAL_PLACES);
     const integerPart = fixedPlaces.split('.')[0];
     const decimalPart = fixedPlaces.split('.')[1];
-    const integerFormated = new Intl.NumberFormat('en-US').format(Math.abs(parseInt(integerPart)));
+    return `${this.prettyIntegerValue(parseInt(integerPart))}.${decimalPart}`;
+  },
+
+  /**
+   * Get the formatted value for an integer number
+   *
+   * @param {number} value Amount to be formatted
+   *
+   * @return {string} Formatted value
+   *
+   * @memberof Helpers
+   * @inner
+   */
+  prettyIntegerValue(value: number): string {
+    const integerFormated = new Intl.NumberFormat('en-US').format(Math.abs(value));
     const signal = value < 0 ? '-' : '';
-    return `${signal}${integerFormated}.${decimalPart}`;
+    return `${signal}${integerFormated}`;
   },
 
   /**


### PR DESCRIPTION
### Motivation

NFTs amounts must be shown as integers instead of decimals. Even showing as integer we still need to format them to show thousand separator, i.e. we must show "10,000" instead of "10000".

### Acceptance criteria

We must have a method to show pretty integer value (integer with thousand separator) and this method must be reused by prettyValue method.