### PR TITLE
fix: error handling when sending transaction

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -290,3 +290,13 @@ export const METADATA_RETRY_LIMIT = 3;
  * Interval between metadata download retries in milliseconds
  */
 export const DOWNLOAD_METADATA_RETRY_INTERVAL = 5000;
+
+/**
+ * Maximum characters of created token name
+ */
+export const MAX_TOKEN_NAME_SIZE = 30;
+
+/**
+ * Maximum characters of created token symbol
+ */
+export const MAX_TOKEN_SYMBOL_SIZE = 5;

--- a/src/errors.js
+++ b/src/errors.js
@@ -164,6 +164,14 @@ export class UtxoError extends WalletError {}
 export class SendTxError extends WalletError {}
 
 /**
+ * Error thrown when mining tx
+ *
+ * @memberof Errors
+ * @inner
+ */
+export class MineTxError extends WalletError {}
+
+/**
  * Error thrown when calling a protected method on an xpub inited wallet
  * Some methods require access to the words or private key
  *

--- a/src/models/create_token_transaction.ts
+++ b/src/models/create_token_transaction.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { CREATE_TOKEN_TX_VERSION, TOKEN_INFO_VERSION } from '../constants';
+import { CREATE_TOKEN_TX_VERSION, TOKEN_INFO_VERSION, MAX_TOKEN_NAME_SIZE, MAX_TOKEN_SYMBOL_SIZE } from '../constants';
 import { encoding, util } from 'bitcore-lib';
 import { unpackToInt, unpackLen } from '../utils/buffer';
 import helpers from '../utils/helpers';
@@ -123,6 +123,14 @@ class CreateTokenTransaction extends Transaction {
       throw new CreateTokenTxInvalid('Token name and symbol are required when creating a new token');
     }
 
+    if (this.name.length > MAX_TOKEN_NAME_SIZE) {
+      throw new CreateTokenTxInvalid(`Token name size is ${this.name.length} but maximum size is ${MAX_TOKEN_NAME_SIZE}`);
+    }
+
+    if (this.symbol.length > MAX_TOKEN_SYMBOL_SIZE) {
+      throw new CreateTokenTxInvalid(`Token symbol size is ${this.symbol.length} but maximum size is ${MAX_TOKEN_SYMBOL_SIZE}`);
+    }
+
     const nameBytes = buffer.Buffer.from(this.name, 'utf8');
     const symbolBytes = buffer.Buffer.from(this.symbol, 'utf8');
     // Token info version
@@ -143,15 +151,25 @@ class CreateTokenTransaction extends Transaction {
     [tokenInfoVersion, buf] = unpackToInt(1, false, buf);
 
     if (tokenInfoVersion !== TOKEN_INFO_VERSION) {
-      throw new Error(`Unknown token info version: ${tokenInfoVersion}`);
+      throw new CreateTokenTxInvalid(`Unknown token info version: ${tokenInfoVersion}`);
     }
 
     [lenName, buf] = unpackToInt(1, false, buf);
+
+    if (lenName > MAX_TOKEN_NAME_SIZE) {
+      throw new CreateTokenTxInvalid(`Token name size is ${lenName} but maximum size is ${MAX_TOKEN_NAME_SIZE}`);
+    }
+
     [bufName, buf] = unpackLen(lenName, buf);
     this.name = bufName.toString('utf-8');
 
 
     [lenSymbol, buf] = unpackToInt(1, false, buf);
+
+    if (lenSymbol > MAX_TOKEN_SYMBOL_SIZE) {
+      throw new CreateTokenTxInvalid(`Token symbol size is ${lenSymbol} but maximum size is ${MAX_TOKEN_SYMBOL_SIZE}`);
+    }
+
     [bufSymbol, buf] = unpackLen(lenSymbol, buf);
     this.symbol = bufSymbol.toString('utf-8');
 

--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -272,10 +272,10 @@ class SendTransaction extends EventEmitter {
           const err = new SendTxError(response.message);
           reject(err);
         }
-      }).catch(() => {
+      }).catch((e) => {
         this.updateOutputSelected(false);
-        const err = new SendTxError(this.unexpectedPushTxError);
-        reject(err);
+        this.emit('send-error', e.message);
+        reject(e);
       });
     });
 

--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -232,10 +232,6 @@ class SendTransaction extends EventEmitter {
     })
 
     this.mineTransaction.on('success', (data) => {
-      this.transaction.parents = data.parents;
-      this.transaction.timestamp = data.timestamp;
-      this.transaction.nonce = data.nonce;
-      this.transaction.weight = data.weight;
       this.emit('mine-tx-ended', data);
     })
 
@@ -301,7 +297,11 @@ class SendTransaction extends EventEmitter {
         // This will await until mine tx is fully completed
         // mineTx method returns a promise that resolves when
         // mining succeeds or rejects when there is an error
-        await this.mineTx();
+        const mineData = await this.mineTx();
+        this.transaction.parents = mineData.parents;
+        this.transaction.timestamp = mineData.timestamp;
+        this.transaction.nonce = mineData.nonce;
+        this.transaction.weight = mineData.weight;
 
         if (until === 'mine-tx') {
           resolve(this.transaction);

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -17,6 +17,7 @@ import helpers from '../utils/helpers';
 import MemoryStore from '../memory_store';
 import Connection from './connection';
 import SendTransaction from './sendTransaction';
+import Network from '../models/network';
 import { AddressError, WalletError } from '../errors';
 import { ErrorMessages } from '../errorMessages';
 
@@ -158,6 +159,13 @@ class HathorWallet extends EventEmitter {
    */
   getNetwork() {
     return this.conn.getCurrentNetwork();
+  }
+
+  /**
+   * Gets the network model object
+   */
+  getNetworkObject() {
+    return new Network(this.getNetwork());
   }
 
   /**
@@ -1015,7 +1023,7 @@ class HathorWallet extends EventEmitter {
       return {success: false, message: ERROR_MESSAGE_PIN_REQUIRED, error: ERROR_CODE_PIN_REQUIRED};
     }
     const { inputs, changeAddress } = newOptions;
-    const sendTransaction = new SendTransaction({ outputs, inputs, changeAddress, pin });
+    const sendTransaction = new SendTransaction({ outputs, inputs, changeAddress, pin, network: this.getNetworkObject() });
     return sendTransaction.run();
   }
 
@@ -1118,7 +1126,7 @@ class HathorWallet extends EventEmitter {
    * @inner
    */
   async handleSendPreparedTransaction(transaction) {
-    const sendTransaction = new SendTransaction({ transaction });
+    const sendTransaction = new SendTransaction({ transaction, network: this.getNetworkObject() });
     return sendTransaction.runFromMining();
   }
 
@@ -1173,7 +1181,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject(ret);
     }
 
-    return helpers.createTxFromData(ret.preparedData);
+    return helpers.createTxFromData(ret.preparedData, this.getNetworkObject());
   }
 
   /**
@@ -1355,7 +1363,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject(ret);
     }
 
-    return helpers.createTxFromData(ret.preparedData);
+    return helpers.createTxFromData(ret.preparedData, this.getNetworkObject());
   }
 
   /**
@@ -1433,7 +1441,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject(ret);
     }
 
-    return helpers.createTxFromData(ret.preparedData);
+    return helpers.createTxFromData(ret.preparedData, this.getNetworkObject());
   }
 
   /**
@@ -1514,7 +1522,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject(ret);
     }
 
-    return helpers.createTxFromData(ret.preparedData);
+    return helpers.createTxFromData(ret.preparedData, this.getNetworkObject());
   }
 
   /**
@@ -1600,7 +1608,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject(ret);
     }
 
-    return helpers.createTxFromData(ret.preparedData);
+    return helpers.createTxFromData(ret.preparedData, this.getNetworkObject());
   }
 
   /**

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -12,6 +12,7 @@ import transaction from './transaction';
 import wallet from './wallet';
 import storage from './storage';
 import helpers from './helpers';
+import network from './network';
 import helpersUtils from './utils/helpers';
 import walletApi from './api/wallet';
 import SendTransaction from './new/sendTransaction';
@@ -414,7 +415,7 @@ const tokens = {
       return ret;
     }
 
-    const sendTransaction = new SendTransaction({ transaction: helpersUtils.createTxFromData(ret.preparedData) });
+    const sendTransaction = new SendTransaction({ transaction: helpersUtils.createTxFromData(ret.preparedData, network), network });
 
     const promise = new Promise((resolve, reject) => {
       sendTransaction.on('send-tx-success', (tx) => {
@@ -971,7 +972,7 @@ const tokens = {
    * @inner
    */
   handleSendTransaction(data) {
-    const sendTransaction = new SendTransaction({ transaction: helpersUtils.createTxFromData(data) });
+    const sendTransaction = new SendTransaction({ transaction: helpersUtils.createTxFromData(data, network), network });
     // Promise that resolves when push tx finishes with success
     // or rejects in case of an error
     // we need this promise and this method to keep compatibility in case

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -248,6 +248,8 @@ const transaction = {
    *
    * @param {Object} output Output object with {address, timelock} or {data}
    *
+   * @throws {AddressError} If the address of the P2PKH output is invalid
+   *
    * @return {Buffer}
    * @memberof Transaction
    * @inner
@@ -260,7 +262,9 @@ const transaction = {
     } else if (output.type === 'p2pkh' || output.type === undefined) {
       // P2PKH
       // for compatibility reasons we will accept an output without type as p2pkh as fallback
-      const address = new Address(output.address);
+      const address = new Address(output.address, { network });
+      // This will throw AddressError in case the address is invalid
+      address.validateAddress();
       const p2pkh = new P2PKH(address, { timelock: output.timelock });
       return p2pkh.createScript();
     } else {

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -358,32 +358,28 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
    * @inner
    */
   async runFromMining(until: string | null = null): Promise<Transaction> {
-    const promise: Promise<Transaction> = new Promise(async (resolve, reject) => {
-      try {
-        // This will await until mine tx is fully completed
-        // mineTx method returns a promise that resolves when
-        // mining succeeds or rejects when there is an error
-        const mineData = await this.mineTx();
-        this.transaction!.parents = mineData.parents;
-        this.transaction!.timestamp = mineData.timestamp;
-        this.transaction!.nonce = mineData.nonce;
-        this.transaction!.weight = mineData.weight;
+    try {
+      // This will await until mine tx is fully completed
+      // mineTx method returns a promise that resolves when
+      // mining succeeds or rejects when there is an error
+      const mineData = await this.mineTx();
+      this.transaction!.parents = mineData.parents;
+      this.transaction!.timestamp = mineData.timestamp;
+      this.transaction!.nonce = mineData.nonce;
+      this.transaction!.weight = mineData.weight;
 
-        if (until === 'mine-tx') {
-          resolve(this.transaction!);
-          return;
-        }
-
-        await this.handleSendTxProposal();
-        resolve(this.transaction!);
-      } catch (err) {
-        if (err instanceof WalletError) {
-          this.emit('send-error', err.message);
-        }
-        reject(err);
+      if (until === 'mine-tx') {
+        return this.transaction!;
       }
-    });
-    return promise;
+
+      const tx = await this.handleSendTxProposal();
+      return tx;
+    } catch (err) {
+      if (err instanceof WalletError) {
+        this.emit('send-error', err.message);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -396,34 +392,25 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
    * @inner
    */
   async run(until: string | null = null): Promise<Transaction> {
-    const promise: Promise<Transaction> = new Promise(async (resolve, reject) => {
-      try {
-        const preparedData = await this.prepareTx();
-        if (until === 'prepare-tx') {
-          resolve(this.transaction!);
-          return;
-        }
-
-        this.signTx(preparedData.utxosAddressPath);
-        if (until === 'sign-tx') {
-          resolve(this.transaction!);
-          return;
-        }
-
-        const promiseFromMining = this.runFromMining(until);
-        promiseFromMining.then((tx) => {
-          resolve(tx);
-        }, (err) => {
-          reject(err);
-        });
-      } catch (err) {
-        if (err instanceof WalletError) {
-          this.emit('send-error', err.message);
-        }
-        reject(err);
+    try {
+      const preparedData = await this.prepareTx();
+      if (until === 'prepare-tx') {
+        return this.transaction!;
       }
-    });
-    return promise;
+
+      this.signTx(preparedData.utxosAddressPath);
+      if (until === 'sign-tx') {
+        return this.transaction!;
+      }
+
+      const tx = await this.runFromMining(until);
+      return tx;
+    } catch (err) {
+      if (err instanceof WalletError) {
+        this.emit('send-error', err.message);
+      }
+      throw err;
+    }
   }
 }
 

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -306,10 +306,6 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     })
 
     this.mineTransaction.on('success', (data) => {
-      this.transaction!.parents = data.parents;
-      this.transaction!.timestamp = data.timestamp;
-      this.transaction!.nonce = data.nonce;
-      this.transaction!.weight = data.weight;
       this.emit('mine-tx-ended', data);
     })
 
@@ -367,7 +363,11 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         // This will await until mine tx is fully completed
         // mineTx method returns a promise that resolves when
         // mining succeeds or rejects when there is an error
-        await this.mineTx();
+        const mineData = await this.mineTx();
+        this.transaction!.parents = mineData.parents;
+        this.transaction!.timestamp = mineData.timestamp;
+        this.transaction!.nonce = mineData.nonce;
+        this.transaction!.weight = mineData.weight;
 
         if (until === 'mine-tx') {
           resolve(this.transaction!);

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -236,3 +236,10 @@ export interface ISendTransaction {
   run(until: string | null): Promise<Transaction>;
   runFromMining(until: string | null): Promise<Transaction>;
 }
+
+export interface MineTxSuccessData {
+  nonce: number,
+  weight: number,
+  timestamp: number,
+  parents: string[],
+}


### PR DESCRIPTION
### Acceptance criteria

I've done 3 different things in this PR

1. fix: error handling in `SendTransaction` class is now working. If we have an error when mining or pushing tx, it will be handled by the promise.
2. feat: add validation for name/symbol size in the CreateTokenTransaction object
3. feat: add address validation in some places we hadn't added it (especially this one will require some changes in the wallets)