### PR TITLE
feat: allow private networks

### DIFF
--- a/__tests__/models/network.test.js
+++ b/__tests__/models/network.test.js
@@ -41,4 +41,80 @@ test('Get and set network', () => {
     // Invalid network
     const network2 = new Network('abc');
   }).toThrowError();
-})
+});
+
+test("register new network successfully", () => {
+  Network.registerNetwork({
+    name: 'jestnet',
+    alias: 'jestnet',
+    pubkeyhash: 0x70,
+    privatekey: 0x80,
+    scripthash: 0x93,
+    bech32prefix: 'tn',
+    xpubkey: 0x0488b21e,
+    xprivkey: 0x0434c8c4,
+    networkMagic: 0xf9beb4d9,
+    port: 8333,
+    dnsSeeds: []
+  });
+
+  // This shouldn't throw error
+  const network = new Network('jestnet');
+
+  expect(network.getVersionBytes()).toEqual({
+    'p2pkh': 0x70,
+    'p2sh': 0x93,
+    'xpub': 0x0488b21e,
+    'xpriv': 0x0434c8c4
+  })
+});
+
+const getNetworkConfig = (override) => {
+  return Object.assign({
+    name: 'jestnet',
+    alias: 'jestnet',
+    pubkeyhash: 0x70,
+    privatekey: 0x80,
+    scripthash: 0x93,
+    bech32prefix: 'tn',
+    xpubkey: 0x0488b21e,
+    xprivkey: 0x0434c8c4,
+    networkMagic: 0xf9beb4d9,
+    port: 8333,
+    dnsSeeds: []
+  }, override);
+}
+
+test("register invalid network config", () => {
+  Object.entries({
+    'name': undefined,
+    'alias': undefined,
+    'pubkeyhash': undefined,
+    'pubkeyhash': 'abc',
+    'pubkeyhash': 0x111,
+    'privatekey': undefined,
+    'privatekey': 'abc',
+    'privatekey': 0x111,
+    'scripthash': undefined,
+    'bech32prefix': undefined,
+    'xpubkey': undefined,
+    'xpubkey': 'abc',
+    'xprivkey': undefined,
+    'xprivkey': 'abc',
+    'networkMagic': undefined,
+    'networkMagic': 'abc',
+    'port': undefined,
+    'port': 'abc',
+    'dnsSeeds': undefined,
+    'dnsSeeds': 'abc',
+    'dnsSeeds': 123
+  }).forEach(([key, value]) => {
+    expect(() => {
+      Network.registerNetwork(
+        getNetworkConfig({
+          [key]: value,
+        })
+      );
+    }).toThrowError(`Validation errors in network definition: Error: ${key} is invalid.`)
+  })
+});

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -24,8 +24,8 @@ const versionBytes = {
     'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
   },
   'privatenet': {
-    'p2pkh': 0x70,
-    'p2sh': 0x93,
+    'p2pkh': 0x49,
+    'p2sh': 0x87,
     'xpriv': 0x0434c8c4, // tnpr
     'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
   },

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -23,6 +23,12 @@ const versionBytes = {
     'xpriv': 0x0434c8c4, // tnpr
     'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
   },
+  'privatenet': {
+    'p2pkh': 0x70,
+    'p2sh': 0x93,
+    'xpriv': 0x0434c8c4, // tnpr
+    'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
+  },
 }
 
 /*Networks is an object of the bitcore-lib
@@ -86,9 +92,24 @@ const testnet = Networks.add({
   dnsSeeds: []
 });
 
+const privatenet = Networks.add({
+  name: 'htr-privatenet',
+  alias: 'privatenet',
+  pubkeyhash: versionBytes['privatenet']['p2pkh'],
+  privatekey: 0x80,
+  scripthash: versionBytes['privatenet']['p2sh'],
+  bech32prefix: 'tn',
+  xpubkey: versionBytes['privatenet']['xpub'],
+  xprivkey: versionBytes['privatenet']['xpriv'],
+  networkMagic: 0xf9beb4d9,
+  port: 8333,
+  dnsSeeds: []
+})
+
 const networkOptions = {
   testnet,
-  mainnet
+  mainnet,
+  privatenet
 }
 
 type versionBytesType = {
@@ -118,8 +139,10 @@ class Network {
    * Validate the network name is valid
    */
   validateNetwork() {
-    if (this.name !== 'testnet' && this.name !== 'mainnet') {
-      throw Error('We currently support only mainnet and testnet as network.');
+    const possibleNetworks = Object.keys(networkOptions);
+
+    if (!possibleNetworks.includes(this.name)) {
+      throw Error(`We currently support only ${possibleNetworks} as network.`);
     }
   }
 

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -117,6 +117,42 @@ type versionBytesType = {
   p2sh: number,
 }
 
+// TODO I'm not sure if those are the best rules
+const networkSchema = {
+  name: value => typeof value === 'string' && /^([a-z\-])+$/.test(value),  // Only lower-case and dashes allowed
+  alias: value => typeof value === 'string' && /^([a-z\-])+$/.test(value),  // Only lower-case and dashes allowed
+  pubkeyhash: value => typeof value === 'number' && value < 0x100,
+  privatekey: value => typeof value === 'number' && value < 0x100,
+  scripthash: value => typeof value === 'number' && value < 0x100,
+  bech32prefix: value => typeof value === 'string',
+  xpubkey: value => typeof value === 'number', // TODO How to validate valid xpubkey?
+  xprivkey: value => typeof value === 'number', // TODO How to validate valid xprivkey?,
+  networkMagic: value => typeof value === 'number', // TODO How to validate this?,
+  port: value => typeof value === 'number',
+  dnsSeeds: value => Array.isArray(value)
+};
+
+type networkConfigType = {
+  name: string,
+  alias: string,
+  pubkeyhash: number,
+  privatekey: number,
+  scripthash: number,
+  bech32prefix: string,
+  xpubkey: number,
+  xprivkey: number,
+  networkMagic: number,
+  port: number,
+  dnsSeeds: string[]
+}
+
+function validateNetworkConfig(networkConfig: networkConfigType) {
+  return Object
+    .keys(networkSchema)
+    .filter(key => !networkSchema[key](networkConfig[key]))
+    .map(key => new Error(`${key} is invalid.`));
+}
+
 
 class Network {
   // Network name (currently supports only 'testnet' and 'mainnet')
@@ -126,7 +162,7 @@ class Network {
   versionBytes: versionBytesType;
 
   // bitcore-lib Networks object with all network options
-  bitcoreNetwork: Networks;
+  bitcoreNetwork: Networks.Network;
 
   constructor(name: string) {
     this.name = name;
@@ -136,20 +172,49 @@ class Network {
   }
 
   /**
+   * Registers a new network configuration.
+   *
+   * We validate the configuration before registering.
+   */
+  static registerNetwork(networkConfig: networkConfigType) {
+    const errors = validateNetworkConfig(networkConfig);
+
+    if (errors.length > 0) {
+      throw new Error(`Validation errors in network definition: ${errors}`);
+    }
+
+    const name: string = networkConfig['name'];
+
+    if (name in Object.keys(networkOptions)) {
+      throw new Error(`The network name ${name} is a reserved name.`);
+    } else if (name.startsWith('htr')) {
+      throw new Error(`You can't use the prefix 'htr' in network names`);
+    }
+
+    networkOptions[name] = Networks.add(networkConfig);
+    versionBytes[name] = {
+      'p2pkh': networkConfig['pubkeyhash'],
+      'p2sh': networkConfig['scripthash'],
+      'xpriv': networkConfig['xprivkey'],
+      'xpub': networkConfig['xpubkey']
+    }
+  }
+
+  /**
    * Validate the network name is valid
    */
   validateNetwork() {
     const possibleNetworks = Object.keys(networkOptions);
 
-    if (!possibleNetworks.includes(this.name)) {
-      throw Error(`We currently support only ${possibleNetworks} as network.`);
+    if (possibleNetworks.indexOf(this.name) < 0) {
+      throw new Error(`We currently support only [${possibleNetworks}] as network.`);
     }
   }
 
   /**
    * Method created to keep compatibility with old Network class
    */
-  getNetwork(): Networks {
+  getNetwork(): Networks.Network {
     return this.bitcoreNetwork;
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- [ ] It should be possible to use this version of the lib in our Explorer and make it work with private-networks
- [ ] Allow dynamically adding more network configuration options

### Notes
- We are using the same version bytes as the Testnet for the private networks, because we would have problems with TxMiningService if using different ones, since it validates the addresses.

### TODO
- [ ] Release new version of the Explorer once a new version of this lib is available, which should close https://github.com/HathorNetwork/hathor-explorer/issues/125
- [ ] Also release a new version of the Wallet Headless using the new lib version