### PR TITLE
feat: allow private networks

### DIFF
--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -24,8 +24,8 @@ const versionBytes = {
     'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
   },
   'privatenet': {
-    'p2pkh': 0x70,
-    'p2sh': 0x93,
+    'p2pkh': 0x49,
+    'p2sh': 0x87,
     'xpriv': 0x0434c8c4, // tnpr
     'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
   },

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -141,8 +141,8 @@ class Network {
   validateNetwork() {
     const possibleNetworks = Object.keys(networkOptions);
 
-    if (!possibleNetworks.includes(this.name)) {
-      throw Error(`We currently support only ${possibleNetworks} as network.`);
+	if (possibleNetworks.indexOf(this.name) < 0) {
+      throw new Error(`We currently support only [${possibleNetworks}] as network.`);
     }
   }
 

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -23,6 +23,12 @@ const versionBytes = {
     'xpriv': 0x0434c8c4, // tnpr
     'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
   },
+  'privatenet': {
+    'p2pkh': 0x70,
+    'p2sh': 0x93,
+    'xpriv': 0x0434c8c4, // tnpr
+    'xpub': 0x0488b21e,  // xpub // 0x0434c85b -> tnpb
+  },
 }
 
 /*Networks is an object of the bitcore-lib
@@ -86,9 +92,24 @@ const testnet = Networks.add({
   dnsSeeds: []
 });
 
+const privatenet = Networks.add({
+  name: 'htr-privatenet',
+  alias: 'privatenet',
+  pubkeyhash: versionBytes['privatenet']['p2pkh'],
+  privatekey: 0x80,
+  scripthash: versionBytes['privatenet']['p2sh'],
+  bech32prefix: 'tn',
+  xpubkey: versionBytes['privatenet']['xpub'],
+  xprivkey: versionBytes['privatenet']['xpriv'],
+  networkMagic: 0xf9beb4d9,
+  port: 8333,
+  dnsSeeds: []
+})
+
 const networkOptions = {
   testnet,
-  mainnet
+  mainnet,
+  privatenet
 }
 
 type versionBytesType = {
@@ -118,8 +139,10 @@ class Network {
    * Validate the network name is valid
    */
   validateNetwork() {
-    if (this.name !== 'testnet' && this.name !== 'mainnet') {
-      throw Error('We currently support only mainnet and testnet as network.');
+    const possibleNetworks = Object.keys(networkOptions);
+
+    if (!possibleNetworks.includes(this.name)) {
+      throw Error(`We currently support only ${possibleNetworks} as network.`);
     }
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- [ ] It should be possible to use this version of the lib in our Explorer and make it work with private-networks

### Notes
- We are using the same version bytes as the Testnet for the private networks, because we would have problems with TxMiningService if using different ones, since it validates the addresses.

### TODO
- [ ] Release new version of the Explorer once a new version of this lib is available, which should close https://github.com/HathorNetwork/hathor-explorer/issues/125
- [ ] Also release a new version of the Wallet Headless using the new lib version