### PR TITLE
chore: bump to v0.28.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Library used by Hathor Wallet",
   "jest": {
     "setupFilesAfterEnv": [


### PR DESCRIPTION
### Acceptance Criteria
- Version should be bumped to v0.28.0


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
