### PR TITLE
feat: sign only inputs that belong to the loaded wallet

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -348,9 +348,9 @@ const transaction = {
   },
 
   /*
-   * Add input data to each input of tx data
+   * Add input data to each input of tx data that belongs to the wallet loaded
    *
-   * @param {Object} data Object with inputs and outputs {'inputs': [{'tx_id', 'index', 'token'}], 'outputs': ['address', 'value', 'timelock']}
+   * @param {Object} data Object with inputs and outputs {'inputs': [{'tx_id', 'index', 'token', 'address'}], 'outputs': ['address', 'value', 'timelock']}
    * @param {Buffer} dataToSign data to sign the transaction in bytes
    * @param {string} pin PIN to decrypt the private key
    *
@@ -368,8 +368,11 @@ const transaction = {
     }
     const keys = walletData.keys;
     for (const input of data.inputs) {
-      const index = keys[input.address].index;
-      input['data'] = this.getSignature(index, hashbuf, pin);
+      if (input.address in keys) {
+        // We will only sign the inputs that belong to the loaded wallet
+        const index = keys[input.address].index;
+        input['data'] = this.getSignature(index, hashbuf, pin);
+      }
     }
     return data;
   },


### PR DESCRIPTION
### Questions

- Should we create a new parameter to explicitly say that we expect the tx to have inputs from different wallets? And in case we don't trigger this parameter, then we can raise an error if we find an input that does not belong to the wallet loaded?

### Motivation

Atomic swap transactions have inputs that belong to different wallets and the signTx method expects that all inputs are going to be signed by the loaded wallet.

### Acceptance Criteria
- We must be able to call `signTx` method with a transaction that has inputs from different wallets and the method must sign only the inputs that belong to the loaded wallet.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
