### PR TITLE
feat: split prepare and sign tx

### DIFF
--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -64,16 +64,16 @@ class SendTransaction extends EventEmitter {
 
   /**
    * Prepare transaction data from inputs and outputs
-   * Fill the inputs if needed, create output change if needed and sign inputs
+   * Fill the inputs if needed, create output change if needed
    *
    * @throws SendTxError
    *
-   * @return {Transaction} Transaction object prepared to be mined
+   * @return {Object} fullTxData with tokens array, inputs and outputs
    *
    * @memberof SendTransaction
    * @inner
    */
-  prepareTx() {
+  prepareTxData() {
     const tokensData = {};
     const HTR_UID = HATHOR_TOKEN_CONFIG.uid;
 
@@ -168,6 +168,22 @@ class SendTransaction extends EventEmitter {
       fullTxData.outputs = [...fullTxData.outputs, ...ret.data.outputs];
     }
 
+    return fullTxData;
+  }
+
+  /**
+   * Prepare transaction data from inputs and outputs
+   * Fill the inputs if needed, create output change if needed and sign inputs
+   *
+   * @throws SendTxError
+   *
+   * @return {Transaction} Transaction object prepared to be mined
+   *
+   * @memberof SendTransaction
+   * @inner
+   */
+  prepareTx() {
+    const fullTxData = this.prepareTxData();
     let preparedData = null;
     try {
       preparedData = transaction.prepareData(fullTxData, this.pin);

--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -211,8 +211,10 @@ class SendTransaction extends EventEmitter {
    * @inner
    */
   prepareTxFrom(signatures) {
-    if (!this.fullTxData) {
-      this.prepareTxData();
+    if (this.fullTxData === null) {
+      // This method can only be called with a prepared tx data
+      // because prepareTxData may modify the inputs and outputs
+      throw new SendTxError(ErrorMessages.TRANSACTION_IS_NULL);
     }
 
     // add each input data from signature

--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -205,6 +205,9 @@ class SendTransaction extends EventEmitter {
    * The full tx data should already be prepared
    * since the signatures have already been made
    *
+   * @params {Array<Buffer>} Array of Buffer, each being a signature of the tx data
+   * The order of the signatures must match the inputs (private key used to sign should solve the input)
+   *
    * @throws SendTxError
    *
    * @return {Transaction} Transaction object prepared to be mined
@@ -222,7 +225,7 @@ class SendTransaction extends EventEmitter {
     // add each input data from signature
     const keys = wallet.getWalletData().keys;
     for (const [index, input] of this.fullTxData.inputs.entries()) {
-      const signature = Buffer.from(signatures[index]);
+      const signature = signatures[index];
       const keyIndex = keys[input.address].index;
       const pubkey = wallet.getPublicKey(keyIndex);
       input['data'] = transaction.createInputData(signature, pubkey);

--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -200,8 +200,10 @@ class SendTransaction extends EventEmitter {
   }
 
   /**
-   * Prepare transaction data from inputs, outputs and signatures
-   * Fill the inputs if needed, create output change if needed
+   * Prepare transaction to be mined from signatures
+   *
+   * The full tx data should already be prepared
+   * since the signatures have already been made
    *
    * @throws SendTxError
    *


### PR DESCRIPTION
### Summary

The `sendTransaction` class prepares and signs the transaction on the same method.

To use this with the hardware wallet we implement the preparation on the wallet and instantiate the `sendTransaction` with the prepared transaction with the signatures from the hardware wallet.

This PR aims to unify this preparation on the wallet-lib, creating the `prepareTxData` that will be used to send the tx to the hardware wallet and `prepareTxFrom` to create the tx from the signatures from the hardware wallet while keeping the same functionality at the `prepareTx` (as to not disturb the functionality of the other wallets that use this method).

### Acceptance Criteria

- Create a method to prepare the tx data without signing so it can be used by a hardware wallet.
- Create a method to complete the tx with the signatures from the hardware wallet
- Update the `prepareTx` method to use the same method to prepare the tx data.
  - Keep the same usage to not create issues with the software wallets using this method

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
