### PR TITLE
refactor: remove sensitive data (seed) from memory after it is used

### DIFF
--- a/__tests__/wallet/api/walletServiceAxios.test.ts
+++ b/__tests__/wallet/api/walletServiceAxios.test.ts
@@ -8,8 +8,9 @@ const words = 'connect sunny silent cabin leopard start turtle tortoise dial tim
 test('use testnet tx mining when network is testnet', async () => {
   config.setWalletServiceBaseUrl('https://wallet-service.testnet.hathor.network/');
 
+  const requestPassword = jest.fn();
   const network = new Network('testnet');
-  const wallet = new HathorWalletServiceWallet(words, network);
+  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
 
   const client = await axiosInstance(wallet, false);
 
@@ -19,8 +20,9 @@ test('use testnet tx mining when network is testnet', async () => {
 test('use mainnet tx mining when network is mainnet', async () => {
   config.setWalletServiceBaseUrl('https://wallet-service.hathor.network/');
 
+  const requestPassword = jest.fn();
   const network = new Network('mainnet');
-  const wallet = new HathorWalletServiceWallet(words, network);
+  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
 
   const client = await axiosInstance(wallet, false);
 
@@ -29,8 +31,10 @@ test('use mainnet tx mining when network is mainnet', async () => {
 
 test('use explicitly configured tx mining', async () => {
   config.setWalletServiceBaseUrl('wallet.service.url');
+
+  const requestPassword = jest.fn();
   const network = new Network('mainnet');
-  const wallet = new HathorWalletServiceWallet(words, network);
+  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
 
   const client = await axiosInstance(wallet, false);
 

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -28,9 +28,10 @@ const MOCK_TX = {
 
 
 test('getTxBalance', async () => {
+  const requestPassword = jest.fn();
   const network = new Network('testnet');
   const words = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
-  const wallet = new HathorWalletServiceWallet(words, network);
+  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
 
   const getAllAddressesMock = async function* () {
     const addresses: GetAddressesObject[] = [{

--- a/src/constants.js
+++ b/src/constants.js
@@ -62,6 +62,11 @@ export const LIMIT_ADDRESS_GENERATION = true;
 export const HATHOR_BIP44_CODE = 280;
 
 /**
+ * Auth derivation path used for auth on the Wallet Service facade
+ */
+export const WALLET_SERVICE_AUTH_DERIVATION_PATH = `m/${HATHOR_BIP44_CODE}'/${HATHOR_BIP44_CODE}'`;
+
+/**
  * Server options for the user to choose which one to connect
  *
  * @deprecated since version 0.25.0.

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -7,7 +7,6 @@
 
 
 import { crypto, HDPublicKey, HDPrivateKey, Address } from 'bitcore-lib';
-import { createHash, HexBase64Latin1Encoding } from 'crypto';
 import Mnemonic from 'bitcore-mnemonic';
 import { HD_WALLET_ENTROPY, HATHOR_BIP44_CODE } from '../constants';
 import { XPubError, InvalidWords, UncompressedPubKeyError } from '../errors';

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -7,6 +7,7 @@
 
 
 import { crypto, HDPublicKey, HDPrivateKey, Address } from 'bitcore-lib';
+import { createHash, HexBase64Latin1Encoding } from 'crypto';
 import Mnemonic from 'bitcore-mnemonic';
 import { HD_WALLET_ENTROPY, HATHOR_BIP44_CODE } from '../constants';
 import { XPubError, InvalidWords, UncompressedPubKeyError } from '../errors';
@@ -332,7 +333,7 @@ const wallet = {
 
     const derivedXpub = xpub.deriveChild(derivationIndex);
     return derivedXpub.xpubkey;
-  }
+  },
 }
 
 export default wallet;

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -794,13 +794,13 @@ const wallet = {
 
     // Get and update data encrypted with PIN
     const decryptedMainKey = this.decryptData(accessData.mainKey, oldPin);
-    const encryptedMainKey = this.encryptData(decryptedData, newPin);
+    const encryptedMainKey = this.encryptData(decryptedMainKey, newPin);
 
     // Create a new object (without mutating the old one) with the updated data
     let newAccessData = {
       hash: newHash.key.toString(),
       salt: newHash.salt,
-      mainKey: encryptedData.encrypted.toString(),
+      mainKey: encryptedMainKey.encrypted.toString(),
     };
 
     if (accessData.authKey) {

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -2712,7 +2712,7 @@ const wallet = {
    */
   getXprivKey(pin) {
     if (this.isFromXPub()) {
-        throw WalletFromXPubGuard('getXprivKey');
+      throw WalletFromXPubGuard('getXprivKey');
     }
 
     const accessData = this.getWalletAccessData();

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -5,7 +5,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { MAX_ADDRESSES_GET, GAP_LIMIT, LIMIT_ADDRESS_GENERATION, HATHOR_BIP44_CODE, TOKEN_MINT_MASK, TOKEN_MELT_MASK, TOKEN_INDEX_MASK, HATHOR_TOKEN_INDEX, HATHOR_TOKEN_CONFIG, MAX_OUTPUT_VALUE, HASH_KEY_SIZE, HASH_ITERATIONS, HD_WALLET_ENTROPY, LOAD_WALLET_MAX_RETRY, LOAD_WALLET_RETRY_SLEEP } from './constants';
+import {
+  MAX_ADDRESSES_GET,
+  GAP_LIMIT,
+  LIMIT_ADDRESS_GENERATION,
+  HATHOR_BIP44_CODE,
+  TOKEN_MINT_MASK,
+  TOKEN_MELT_MASK,
+  TOKEN_INDEX_MASK,
+  HATHOR_TOKEN_INDEX,
+  HATHOR_TOKEN_CONFIG,
+  MAX_OUTPUT_VALUE,
+  HASH_KEY_SIZE,
+  HASH_ITERATIONS,
+  HD_WALLET_ENTROPY,
+  LOAD_WALLET_MAX_RETRY,
+  LOAD_WALLET_RETRY_SLEEP,
+  WALLET_SERVICE_AUTH_DERIVATION_PATH,
+} from './constants';
 import Mnemonic from 'bitcore-mnemonic';
 import { HDPrivateKey, HDPublicKey, Address, crypto } from 'bitcore-lib';
 import CryptoJS from 'crypto-js';
@@ -227,7 +244,7 @@ const wallet = {
     let code = new Mnemonic(words);
     let xpriv = code.toHDPrivateKey(passphrase, network.getNetwork());
     let privkey = xpriv.deriveNonCompliantChild(`m/44'/${HATHOR_BIP44_CODE}'/0'/0`);
-    let authXpriv = xpriv.deriveNonCompliantChild(`m/${HATHOR_BIP44_CODE}'/${HATHOR_BIP44_CODE}'`);
+    let authXpriv = xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
 
     let encryptedData = this.encryptData(privkey.xprivkey, pin)
     let encryptedAuthXpriv = this.encryptData(authXpriv.xprivkey, pin)

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1786,7 +1786,7 @@ const wallet = {
    * @memberof Wallet
    * @inner
    */
-  getAuthKey(pin) {
+  getAuthPrivKey(pin) {
     const accessData = this.getWalletAccessData();
     return HDPrivateKey(this.decryptData(accessData.authKey, pin));
   },

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -86,7 +86,6 @@ const walletApi = {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get('wallet/balances', data);
     if (response.status === 200 && response.data.success === true) {
-      console.log('Response data: ', response.data);
       return response.data;
     } else {
       throw new WalletRequestError('Error getting wallet balance.');
@@ -143,7 +142,6 @@ const walletApi = {
     if (response.status === 200) {
       return response.data;
     } else {
-      console.log('What', response.data);
       throw new WalletRequestError('Error sending tx proposal.');
     }
   },
@@ -160,7 +158,6 @@ const walletApi = {
     if (response.status === 200 && response.data.success === true) {
       return response.data;
     } else {
-      console.log('response', response.data);
       throw new WalletRequestError('Error requesting auth token.');
     }
   },

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -86,6 +86,7 @@ const walletApi = {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get('wallet/balances', data);
     if (response.status === 200 && response.data.success === true) {
+      console.log('Response data: ', response.data);
       return response.data;
     } else {
       throw new WalletRequestError('Error getting wallet balance.');
@@ -142,6 +143,7 @@ const walletApi = {
     if (response.status === 200) {
       return response.data;
     } else {
+      console.log('What', response.data);
       throw new WalletRequestError('Error sending tx proposal.');
     }
   },
@@ -158,6 +160,7 @@ const walletApi = {
     if (response.status === 200 && response.data.success === true) {
       return response.data;
     } else {
+      console.log('response', response.data);
       throw new WalletRequestError('Error requesting auth token.');
     }
   },

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -41,8 +41,23 @@ const walletApi = {
     }
   },
 
-  async createWallet(wallet: HathorWalletServiceWallet, xpubkey: string, firstAddress: string | null = null): Promise<WalletStatusResponseData> {
-    const data = { xpubkey };
+  async createWallet(
+    wallet: HathorWalletServiceWallet,
+    xpubkey: string,
+    xpubkeySignature: string,
+    authXpubkey: string,
+    authXpubkeySignature: string,
+    timestamp: number,
+    firstAddress: string | null = null,
+  ): Promise<WalletStatusResponseData> {
+    const data = {
+      xpubkey,
+      xpubkeySignature,
+      authXpubkey,
+      authXpubkeySignature,
+      timestamp,
+    };
+
     if (firstAddress) {
       data['firstAddress'] = firstAddress;
     }
@@ -152,7 +167,12 @@ const walletApi = {
       xpub: string,
       sign: string,
   ): Promise<AuthTokenResponseData> {
-    const data = { ts: timestamp, xpub, sign };
+    const data = {
+      ts: timestamp,
+      xpub,
+      sign,
+      walletId: wallet.walletId,
+    };
     const axios = await axiosInstance(wallet, false);
     const response = await axios.post('auth/token', data);
     if (response.status === 200 && response.data.success === true) {

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -257,6 +257,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       const inputData = this.wallet.getInputData(
         xprivkey,
         dataToSignHash,
+        // the wallet service returns the full BIP44 path, but we only need the address path:
         HathorWalletServiceWallet.getAddressIndexFromFullPath(utxosAddressPath[idx]),
       );
       inputObj.setData(inputData);

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -251,10 +251,14 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     }
     this.emit('sign-tx-start');
     const dataToSignHash = this.transaction.getDataToSignHash();
-    const seed = wallet.getWalletWords(this.pin);
+    const xprivkey = wallet.getXprivKey(this.pin);
 
     for (const [idx, inputObj] of this.transaction.inputs.entries()) {
-      const inputData = this.wallet.getInputData(seed, dataToSignHash, utxosAddressPath[idx]);
+      const inputData = this.wallet.getInputData(
+        xprivkey,
+        dataToSignHash,
+        HathorWalletServiceWallet.getAddressIndexFromFullPath(utxosAddressPath[idx]),
+      );
       inputObj.setData(inputData);
     }
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -207,7 +207,7 @@ export interface TransactionFullObject {
 }
 
 export interface IHathorWallet {
-  start();
+  start(options: { pinCode: string });
   getAllAddresses(): AsyncGenerator<GetAddressesObject>;
   getBalance(token: string | null): Promise<GetBalanceObject[]>;
   getTokens(): Promise<string[]>;

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -10,6 +10,7 @@ import CreateTokenTransaction from '../models/create_token_transaction';
 import SendTransactionWalletService from './sendTransactionWalletService';
 import Input from '../models/input';
 import Output from '../models/output';
+import bitcore from 'bitcore-lib';
 
 export interface GetAddressesObject {
   address: string; // Address in base58
@@ -291,3 +292,14 @@ export interface WsTransaction {
   // eslint-disable-next-line camelcase
   token_symbol?: string;
 }
+
+export interface CreateWalletAuthData {
+  xpub: bitcore.HDPublicKey;
+  xpubkeySignature: string;
+  authXpub: string;
+  authXpubkeySignature: string;
+  timestampNow: number;
+  firstAddress: string;
+  xprivChangePath: bitcore.HDPrivateKey;
+  authDerivedPrivKey: bitcore.HDPrivateKey;
+};

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -68,6 +68,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   walletId: string | null;
   // Network in which the wallet is connected ('mainnet' or 'testnet')
   network: Network;
+  // Method to request the password from the client
   private requestPassword: Function;
   // Xpub of the wallet
   private xpub: string | null;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -513,7 +513,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         seed = wallet.getWalletWords(password);
       }
 
-      // @ts-ignore
+      if (!seed) throw new Error('Seed cant be null');
+
       const sign = this.signMessage(seed, timestampNow);
       const data = await walletApi.createAuthToken(this, timestampNow, this.xpub!, sign);
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -644,13 +644,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         privKey = wallet.getAuthPrivKey(password);
       }
 
-      await this.renewToken(privKey, timestampNow);
+      await this.renewAuthToken(privKey, timestampNow);
     } else {
       // If we have received the user PIN, we should renew the token anyway
       // without blocking this method's promise
       if (usePassword) {
         const privKey = wallet.getAuthPrivKey(usePassword);
-        this.renewToken(privKey, timestampNow);
+        this.renewAuthToken(privKey, timestampNow);
       }
     }
   }
@@ -665,7 +665,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async renewToken(privKey: bitcore.HDPrivateKey, timestamp: number) {
+  async renewAuthToken(privKey: bitcore.HDPrivateKey, timestamp: number) {
     if (!this.walletId) {
       throw new Error('Wallet not ready yet.');
     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -611,7 +611,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async validateAndRenewAuthToken(usePassword?: string) {
+  async validateAndRenewAuthToken(usePassword?: string): Promise<void> {
     if (!this.walletId) {
       throw new Error('Wallet not ready yet.');
     }
@@ -619,7 +619,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const now = new Date();
     const timestampNow = Math.floor(now.getTime() / 1000);
 
-    const validateJWTExpireDate = (token: string) => {
+    const validateJWTExpireDate = (token: string): boolean => {
       const base64Url = token.split('.')[1];
       const base64 = base64Url.replace('-', '+').replace('_', '/');
       const decodedData = JSON.parse(Buffer.from(base64, 'base64').toString('binary'));
@@ -631,7 +631,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       }
 
       return true;
-    }
+    };
 
     if (!this.authToken || !validateJWTExpireDate(this.authToken)) {
       let privKey = this.authPrivKey;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -627,7 +627,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         const password = usePassword ? usePassword : await this.requestPassword();
 
         // Use it to get the words from the storage
-        privKey = wallet.getAuthKey(password);
+        privKey = wallet.getAuthPrivKey(password);
       }
 
       await this.renewToken(privKey, timestampNow);
@@ -635,7 +635,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       // If we have received the user PIN, we should renew the token anyway
       // without blocking this method's promise
       if (usePassword) {
-        const privKey = wallet.getAuthKey(usePassword);
+        const privKey = wallet.getAuthPrivKey(usePassword);
         this.renewToken(privKey, timestampNow);
       }
     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -249,7 +249,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     });
 
     const now = new Date();
-    const timestampNow = Math.floor(now.getTime() / 1000);
+    const timestampNow = Math.floor(now.getTime() / 1000); // in seconds
     const walletId = HathorWalletServiceWallet.getWalletIdFromXPub(xpub);
 
     // prove we own the xpubkey

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -630,13 +630,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         privKey = wallet.getAuthKey(password);
       }
 
-      await this.renewToken(privKey, timestampNow, this.walletId);
+      await this.renewToken(privKey, timestampNow);
     } else {
       // If we have received the user PIN, we should renew the token anyway
       // without blocking this method's promise
       if (usePassword) {
         const privKey = wallet.getAuthKey(usePassword);
-        this.renewToken(privKey, timestampNow, this.walletId);
+        this.renewToken(privKey, timestampNow);
       }
     }
   }
@@ -651,8 +651,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async renewToken(privKey: bitcore.HDPrivateKey, timestamp: number, walletId: string) {
-    // @ts-ignore
+  async renewToken(privKey: bitcore.HDPrivateKey, timestamp: number) {
+    if (!this.walletId) {
+      throw new Error('Wallet not ready yet.');
+    }
+
     const sign = this.signMessage(privKey, timestamp, this.walletId);
     const data = await walletApi.createAuthToken(this, timestamp, privKey.xpubkey, sign);
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -897,7 +897,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const dataToSignHash = tx.getDataToSignHash();
 
     if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareCreateNewToken options');
+      throw new Error('PIN not specified in prepareMintTokensData options');
     }
 
     const seed = wallet.getWalletWords(newOptions.pinCode);
@@ -1010,7 +1010,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const dataToSignHash = tx.getDataToSignHash();
 
     if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareCreateNewToken options');
+      throw new Error('PIN not specified in prepareMeltTokensData options');
     }
 
     const seed = wallet.getWalletWords(newOptions.pinCode);
@@ -1106,7 +1106,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     tx.tokens = [token];
 
     if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareCreateNewToken options');
+      throw new Error('PIN not specified in prepareDelegateAuthorityData options');
     }
 
     const seed = wallet.getWalletWords(newOptions.pinCode);
@@ -1181,7 +1181,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const dataToSignHash = tx.getDataToSignHash();
 
     if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareCreateNewToken options');
+      throw new Error('PIN not specified in prepareDestroyAuthorityData options');
     }
 
     const seed = wallet.getWalletWords(newOptions.pinCode);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -149,7 +149,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   }
 
   /**
-   * Get auth xpubkey in the 280' purpose path from seed
+   * Get auth xpubkey from seed
    *
    * @param {String} seed 24 words
    * @param {Object} options Options with passphrase and networkName

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -30,6 +30,7 @@ import Input from '../models/input';
 import Address from '../models/address';
 import Network from '../models/network';
 import networkInstance from '../network';
+import assert from 'assert';
 import WalletServiceConnection, { ConnectionState } from './connection';
 import MineTransaction from './mineTransaction';
 import SendTransactionWalletService from './sendTransactionWalletService';
@@ -969,7 +970,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   static getAddressIndexFromFullPath(fullPath: string): number {
-    return parseInt(fullPath.split('/')[5], 10);
+    const parts = fullPath.split('/');
+
+    assert.equal(6, parts.length);
+
+    return parseInt(parts[5], 10);
   }
 
   /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -946,7 +946,15 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     return tx;
   }
 
-  static getAddressIndexFromFullPath(fullPath: string) {
+  /**
+   * Expects a BIP44 path at the address level and returns the address index
+   *
+   * @param {string} fullPath - The full BIP44 path for the address index
+   *
+   * @memberof HathorWalletServiceWallet
+   * @inner
+   */
+  static getAddressIndexFromFullPath(fullPath: string): number {
     return parseInt(fullPath.split('/')[5], 10);
   }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -205,6 +205,20 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     wallet.setWalletAccessData(initialAccessData);
   }
 
+
+  /**
+   * getWalletIdFromXPub: Get the wallet id given the xpubkey
+   *
+   * @param xpub - The xpubkey
+   * @returns The wallet id
+   *
+   * @memberof HathorWalletServiceWallet
+   * @inner
+   */
+  static getWalletIdFromXPub(xpub: string) {
+    return crypto.Hash.sha256sha256(Buffer.from(xpub)).toString('hex');
+  }
+
   /**
    * Start wallet: load the wallet data, update state and start polling wallet status until it's ready
    *
@@ -236,7 +250,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const now = new Date();
     const timestampNow = Math.floor(now.getTime() / 1000);
-    const walletId = crypto.Hash.sha256sha256(Buffer.from(xpub)).toString('hex');
+    const walletId = HathorWalletServiceWallet.getWalletIdFromXPub(xpub);
 
     // prove we own the xpubkey
     const xprivAccountPath = walletUtils.deriveXpriv(xpriv, '0\'');


### PR DESCRIPTION
### Acceptance Criteria
- The wallet service facade should remove the seed from memory after the wallet is started
- The wallet service facade should receive a async method to request the pin from the client and use it when needed
- We should renew the auth token everytime the user inputs his PIN, even if it is not expired

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
