### PR TITLE
refactor: using auth xpubkey to authenticate wallet service requests

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -62,6 +62,11 @@ export const LIMIT_ADDRESS_GENERATION = true;
 export const HATHOR_BIP44_CODE = 280;
 
 /**
+ * Auth derivation path used for auth on the Wallet Service facade
+ */
+export const WALLET_SERVICE_AUTH_DERIVATION_PATH = `m/${HATHOR_BIP44_CODE}'/${HATHOR_BIP44_CODE}'`;
+
+/**
  * Server options for the user to choose which one to connect
  *
  * @deprecated since version 0.25.0.

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -198,6 +198,39 @@ const wallet = {
   },
 
   /**
+   * Get auth xpubkey in the 280' purpose path from seed
+   *
+   * @param {String} seed 24 words
+   * @param {Object} options Options with passphrase and networkName
+   *
+   * @return {String} Wallet xpubkey
+   * @memberof Wallet
+   * @inner
+   */
+  getAuthXPubKeyFromSeed(seed: string, options: { passphrase?: string, networkName?: string } = {}): string {
+    const methodOptions = Object.assign({passphrase: '', networkName: 'mainnet', accountDerivationIndex: '0\''}, options);
+    const { accountDerivationIndex } = methodOptions;
+
+    const xpriv = this.getXPrivKeyFromSeed(seed, methodOptions);
+    const privkey = this.deriveAuthXpriv(xpriv);
+
+    return privkey.xpubkey;
+  },
+
+  /**
+   * Derive xpriv from root to the auth specific purpose derivation path
+   *
+   * @param {string} accountDerivationIndex String with derivation index of account (can be hardened)
+   *
+   * @return {HDPrivateKey} Derived private key
+   * @memberof Wallet
+   * @inner
+   */
+  deriveAuthXpriv(xpriv: HDPrivateKey): HDPrivateKey {
+    return xpriv.deriveNonCompliantChild(`m/${HATHOR_BIP44_CODE}'/${HATHOR_BIP44_CODE}'`);
+  },
+
+  /**
    * Get root xpriv from seed
    *
    * @param {String} seed 24 words

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -345,7 +345,7 @@ const wallet = {
  * @param encoding - The encoding of the returned object
  * @returns The sha256d hash of the data
  */
-  sha256d(data: string, encoding: HexBase64Latin1Encoding): string {
+  sha256d(data: string, encoding: HexBase64Latin1Encoding): string | Buffer {
     const hash1 = createHash('sha256');
     hash1.update(data);
     const hash2 = createHash('sha256');

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -334,24 +334,6 @@ const wallet = {
     const derivedXpub = xpub.deriveChild(derivationIndex);
     return derivedXpub.xpubkey;
   },
-
-  /**
- * Calculate the double sha256 hash of the data.
- *
- * @remarks
- * If encoding is provided a string will be returned; otherwise a Buffer is returned.
- *
- * @param data - Data to be hashed
- * @param encoding - The encoding of the returned object
- * @returns The sha256d hash of the data
- */
-  sha256d(data: string, encoding: HexBase64Latin1Encoding): string | Buffer {
-    const hash1 = createHash('sha256');
-    hash1.update(data);
-    const hash2 = createHash('sha256');
-    hash2.update(hash1.digest());
-    return hash2.digest(encoding);
-  },
 }
 
 export default wallet;

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -837,7 +837,7 @@ const wallet = {
    */
   changePinAndPassword({ oldPin, newPin, oldPassword, newPassword }) {
     if (this.isFromXPub()) {
-        throw WalletFromXPubGuard('changePinAndPassword');
+      throw WalletFromXPubGuard('changePinAndPassword');
     }
 
     if (oldPassword && !newPassword) {

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1774,9 +1774,9 @@ const wallet = {
   /**
    * Get the privKey of the auth derivation
    *
-   * @param {string} pin Pin to decrypt the words
+   * @param {string} pin Pin to decrypt the auth key
    *
-   * @return {string} The auth private key
+   * @return {HDPrivateKey} The auth private key
    *
    * @memberof Wallet
    * @inner

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -1749,6 +1749,21 @@ const wallet = {
     return this.decryptData(accessData.words, password);
   },
 
+  /**
+   * Get the privKey of the auth derivation
+   *
+   * @param {string} pin Pin to decrypt the words
+   *
+   * @return {string} The auth private key
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  getAuthKey(pin) {
+    const accessData = this.getWalletAccessData();
+    return HDPrivateKey(this.decryptData(accessData.authKey, pin));
+  },
+
   /*
    * Save backup done in storage
    *

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -272,15 +272,15 @@ const wallet = {
    * Encrypt a auth xpriv to be used for auth on the Wallet Service facade with
    * a password and save it on localStorage
    *
-   * @param {string} key Key to be encrypted
-   * @param {string} password Password to encrypt
+   * @param {string} key Auth key to be encrypted
+   * @param {string} pin Pin code to use as password to encrypt the auth key
    *
    * @memberof Wallet
    * @inner
    */
-  storeEncryptedAuthKey(key, password) {
+  storeEncryptedAuthKey(key, pin) {
     const initialAccessData = this.getWalletAccessData() || {};
-    const encryptedAuthKey = this.encryptData(key, password);
+    const encryptedAuthKey = this.encryptData(key, pin);
 
     initialAccessData['authKey'] = encryptedAuthKey.encrypted.toString();
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -227,9 +227,11 @@ const wallet = {
     let code = new Mnemonic(words);
     let xpriv = code.toHDPrivateKey(passphrase, network.getNetwork());
     let privkey = xpriv.deriveNonCompliantChild(`m/44'/${HATHOR_BIP44_CODE}'/0'/0`);
+    let authXpriv = xpriv.deriveNonCompliantChild(`m/${HATHOR_BIP44_CODE}'/${HATHOR_BIP44_CODE}'`);
 
     let encryptedData = this.encryptData(privkey.xprivkey, pin)
     let encryptedDataWords = this.encryptData(words, password)
+    let encryptedAuthXpriv = this.encryptData(authXpriv, pin)
 
     // Save in storage the encrypted private key and the hash of the pin and password
     let access = {
@@ -237,6 +239,7 @@ const wallet = {
       hash: encryptedData.hash.key.toString(),
       salt: encryptedData.hash.salt,
       words: encryptedDataWords.encrypted.toString(),
+      authKey: encryptedAuthXpriv.encrypted.toString(),
       hashPasswd: encryptedDataWords.hash.key.toString(),
       saltPasswd: encryptedDataWords.hash.salt,
       hashIterations: HASH_ITERATIONS,

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -269,25 +269,6 @@ const wallet = {
   },
 
   /**
-   * Encrypt a auth xpriv to be used for auth on the Wallet Service facade with
-   * a password and save it on localStorage
-   *
-   * @param {string} key Auth key to be encrypted
-   * @param {string} pin Pin code to use as password to encrypt the auth key
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  storeEncryptedAuthKey(key, pin) {
-    const initialAccessData = this.getWalletAccessData() || {};
-    const encryptedAuthKey = this.encryptData(key, pin);
-
-    initialAccessData['authKey'] = encryptedAuthKey.encrypted.toString();
-
-    this.setWalletAccessData(initialAccessData);
-  },
-
-  /**
    * Stores hash of password/PIN on localStorage
    *
    * @param {string} password Password to store hash
@@ -814,16 +795,23 @@ const wallet = {
     // Get and update data encrypted with PIN
     const decryptedMainKey = this.decryptData(accessData.mainKey, oldPin);
     const encryptedMainKey = this.encryptData(decryptedData, newPin);
-    const decryptedAuthKey = this.decryptData(accessData.authKey, oldPin);
-    const encryptedAuthKey = this.encryptData(decryptedAuthKey, newPin);
 
     // Create a new object (without mutating the old one) with the updated data
-    const newAccessData = {
+    let newAccessData = {
       hash: newHash.key.toString(),
       salt: newHash.salt,
       mainKey: encryptedData.encrypted.toString(),
-      authKey: encryptedAuthKey.encrypted.toString(),
     };
+
+    if (accessData.authKey) {
+      const decryptedAuthKey = this.decryptData(accessData.authKey, oldPin);
+      const encryptedAuthKey = this.encryptData(decryptedAuthKey, newPin);
+
+      newAccessData = {
+        ...newAccessData,
+        authKey: encryptedAuthKey.encrypted.toString(),
+      };
+    }
 
     return newAccessData;
   },

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -41,13 +41,23 @@ const walletApi = {
     }
   },
 
-  async createWallet(wallet: HathorWalletServiceWallet, xpubkey: string, firstAddress: string | null = null): Promise<WalletStatusResponseData> {
-    const data = { xpubkey };
+  async createWallet(
+    wallet: HathorWalletServiceWallet,
+    xpubkey: string,
+    authXpub: string,
+    firstAddress: string | null = null,
+  ): Promise<WalletStatusResponseData> {
+    const data = {
+      xpubkey,
+      authXpubkey: authXpub,
+    };
+
     if (firstAddress) {
       data['firstAddress'] = firstAddress;
     }
     const axios = await axiosInstance(wallet, false);
     const response = await axios.post('wallet/init', data);
+    console.log('respoauthXpubnse: ', response);
     if (response.status === 200 && response.data.success) {
       return response.data;
     } else if (response.status === 400 && response.data.error === 'wallet-already-loaded') {
@@ -155,6 +165,7 @@ const walletApi = {
     const data = { ts: timestamp, xpub, sign };
     const axios = await axiosInstance(wallet, false);
     const response = await axios.post('auth/token', data);
+    console.log('Request auth token; ', response);
     if (response.status === 200 && response.data.success === true) {
       return response.data;
     } else {

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -1,4 +1,4 @@
-/**
+/**
  * Copyright (c) Hathor Labs and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
@@ -44,12 +44,18 @@ const walletApi = {
   async createWallet(
     wallet: HathorWalletServiceWallet,
     xpubkey: string,
-    authXpub: string,
+    xpubkeySignature: string,
+    authXpubkey: string,
+    authXpubkeySignature: string,
+    timestamp: number,
     firstAddress: string | null = null,
   ): Promise<WalletStatusResponseData> {
     const data = {
       xpubkey,
-      authXpubkey: authXpub,
+      xpubkeySignature,
+      authXpubkey,
+      authXpubkeySignature,
+      timestamp,
     };
 
     if (firstAddress) {

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -1,4 +1,4 @@
-/**
+/**
  * Copyright (c) Hathor Labs and its affiliates.
  *
  * This source code is licensed under the MIT license found in the
@@ -63,7 +63,6 @@ const walletApi = {
     }
     const axios = await axiosInstance(wallet, false);
     const response = await axios.post('wallet/init', data);
-    console.log('respoauthXpubnse: ', response);
     if (response.status === 200 && response.data.success) {
       return response.data;
     } else if (response.status === 400 && response.data.error === 'wallet-already-loaded') {
@@ -171,7 +170,6 @@ const walletApi = {
     const data = { ts: timestamp, xpub, sign };
     const axios = await axiosInstance(wallet, false);
     const response = await axios.post('auth/token', data);
-    console.log('Request auth token; ', response);
     if (response.status === 200 && response.data.success === true) {
       return response.data;
     } else {

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -167,7 +167,12 @@ const walletApi = {
       xpub: string,
       sign: string,
   ): Promise<AuthTokenResponseData> {
-    const data = { ts: timestamp, xpub, sign };
+    const data = {
+      ts: timestamp,
+      xpub,
+      sign,
+      walletId: wallet.walletId,
+    };
     const axios = await axiosInstance(wallet, false);
     const response = await axios.post('auth/token', data);
     if (response.status === 200 && response.data.success === true) {

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -207,7 +207,7 @@ export interface TransactionFullObject {
 }
 
 export interface IHathorWallet {
-  start();
+  start(options: { pinCode: string });
   getAllAddresses(): AsyncGenerator<GetAddressesObject>;
   getBalance(token: string | null): Promise<GetBalanceObject[]>;
   getTokens(): Promise<string[]>;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -154,13 +154,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @param {String} seed 24 words
    * @param {Object} options Options with passphrase and networkName
    *
-   * @return {String} Wallet xpubkey
+   * @return {String} auth xpubkey
    * @memberof HathorWalletServiceWallet
    * @inner
    */
   static getAuthXPubKeyFromSeed(seed: string, options: { passphrase?: string, networkName?: string } = {}): string {
     const methodOptions = Object.assign({passphrase: '', networkName: 'mainnet', accountDerivationIndex: '0\''}, options);
-    const { accountDerivationIndex } = methodOptions;
 
     const xpriv = walletUtils.getXPrivKeyFromSeed(seed, methodOptions);
     const privkey = HathorWalletServiceWallet.deriveAuthXpriv(xpriv);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -201,14 +201,14 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     // prove we own the xpubkey
     const xpubAccountPath = walletUtils.deriveXpriv(xpriv, '0\'')
     const address = xpubAccountPath.publicKey.toAddress(this.network.getNetwork()).toString();
-    const message = new bitcore.Message(String(timestampNow).concat(walletId).concat(address));
+    const message = new bitcore.Message(String(timestampNow).concat(walletId as string).concat(address));
     const xpubkeySignature = message.sign(xpubAccountPath.privateKey);
 
     // prove we own the auth_xpubkey
     const authDerivedPrivKey = HathorWalletServiceWallet.deriveAuthXpriv(xpriv);
     const authAddress = authDerivedPrivKey.publicKey.toAddress(this.network.getNetwork());
 
-    const authMessage = new bitcore.Message(String(timestampNow).concat(walletId).concat(authAddress));
+    const authMessage = new bitcore.Message(String(timestampNow).concat(walletId as string).concat(authAddress));
     const authXpubkeySignature = authMessage.sign(authDerivedPrivKey.privateKey);
 
     const xpubChangeDerivation = walletUtils.xpubDeriveChild(xpub, 0);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -184,6 +184,25 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   }
 
   /**
+   * Encrypt a auth xpriv to be used for auth on the Wallet Service facade with
+   * a password and save it on localStorage
+   *
+   * @param {string} key Auth key to be encrypted
+   * @param {string} pin Pin code to use as password to encrypt the auth key
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  static storeEncryptedAuthKey(key: string, pin: string) {
+    const initialAccessData = wallet.getWalletAccessData() || {};
+    const encryptedAuthKey = wallet.encryptData(key, pin);
+
+    initialAccessData['authKey'] = encryptedAuthKey.encrypted.toString();
+
+    wallet.setWalletAccessData(initialAccessData);
+  }
+
+  /**
    * Start wallet: load the wallet data, update state and start polling wallet status until it's ready
    *
    * @param {Object} optionsParams Options parameters
@@ -231,7 +250,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.authPrivKey = authDerivedPrivKey;
 
     // store the authPrivKey on the storage
-    wallet.storeEncryptedAuthKey(authDerivedPrivKey.xprivkey, pinCode);
+    HathorWalletServiceWallet.storeEncryptedAuthKey(authDerivedPrivKey.xprivkey, pinCode);
 
     const handleCreate = async (data: WalletStatus) => {
       this.walletId = data.walletId;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -173,9 +173,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   /**
    * Derive xpriv from root to the auth specific purpose derivation path
    *
-   * @param {string} accountDerivationIndex String with derivation index of account (can be hardened)
+   * @param {HDPrivateKey} xpriv The wallet's root xpriv
    *
-   * @return {HDPrivateKey} Derived private key
+   * @return {HDPrivateKey} Derived private key at the auth derivation path
    * @memberof HathorWalletServiceWallet
    * @inner
    */
@@ -186,12 +186,21 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   /**
    * Start wallet: load the wallet data, update state and start polling wallet status until it's ready
    *
+   * @param {Object} optionsParams Options parameters
+   *  {
+   *   'pinCode': PIN to encrypt the auth xpriv on storage
+   *  }
+   *
    * @memberof HathorWalletServiceWallet
    * @inner
    */
   async start({ pinCode }) {
     if (!this.seed) {
       throw new Error('Seed should be in memory when starting the wallet.');
+    }
+
+    if (!pinCode) {
+      throw new Error('Pin code is required when starting the wallet.');
     }
 
     this.setState(walletState.LOADING);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -200,12 +200,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       networkName: this.network.name,
     });
 
-    const walletId = walletUtils.sha256d(xpub, 'hex');
+    const walletId = crypto.Hash.sha256sha256(Buffer.from(xpub)).toString('hex');
     const now = new Date();
     const timestampNow = Math.floor(now.getTime() / 1000);
 
     // prove we own the xpubkey
-    const xpubAccountPath = walletUtils.deriveXpriv(xpriv, '0\'')
+    const xpubAccountPath = walletUtils.deriveXpriv(xpriv, '0\'');
     const address = xpubAccountPath.publicKey.toAddress(this.network.getNetwork()).toString();
     const message = new bitcore.Message(String(timestampNow).concat(walletId as string).concat(address));
     const xpubkeySignature = message.sign(xpubAccountPath.privateKey);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -180,7 +180,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async start() {
+  async start({ pinCode }) {
     if (!this.seed) {
       throw new Error('Seed should be in memory when starting the wallet.');
     }
@@ -216,6 +216,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     this.xpub = xpub;
     this.authXpriv = authDerivedPrivKey;
+
+    // store the authXpriv on the storage
+    wallet.storeEncryptedAuthKey(authDerivedPrivKey.xprivkey, pinCode);
 
     const handleCreate = async (data: WalletStatus) => {
       this.walletId = data.walletId;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -159,7 +159,10 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   static getAuthXPubKeyFromSeed(seed: string, options: { passphrase?: string, networkName?: string } = {}): string {
-    const methodOptions = Object.assign({passphrase: '', networkName: 'mainnet', accountDerivationIndex: '0\''}, options);
+    const methodOptions = Object.assign({
+      passphrase: '',
+      networkName: 'mainnet',
+    }, options);
 
     const xpriv = walletUtils.getXPrivKeyFromSeed(seed, methodOptions);
     const privkey = HathorWalletServiceWallet.deriveAuthXpriv(xpriv);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -6,7 +6,14 @@
  */
 
 import { EventEmitter } from 'events';
-import { HATHOR_BIP44_CODE, HATHOR_TOKEN_CONFIG, TOKEN_MINT_MASK, AUTHORITY_TOKEN_DATA, TOKEN_MELT_MASK } from '../constants';
+import { 
+  HATHOR_BIP44_CODE,
+  HATHOR_TOKEN_CONFIG,
+  TOKEN_MINT_MASK,
+  AUTHORITY_TOKEN_DATA,
+  TOKEN_MELT_MASK,
+  WALLET_SERVICE_AUTH_DERIVATION_PATH,
+} from '../constants';
 import Mnemonic from 'bitcore-mnemonic';
 import { crypto, util, Address as bitcoreAddress } from 'bitcore-lib';
 import wallet from '../wallet';
@@ -171,7 +178,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   static deriveAuthXpriv(xpriv: bitcore.HDPrivateKey): bitcore.HDPrivateKey {
-    return xpriv.deriveNonCompliantChild(`m/${HATHOR_BIP44_CODE}'/${HATHOR_BIP44_CODE}'`);
+    return xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
   }
 
   /**


### PR DESCRIPTION
## Summary
Implements https://github.com/HathorNetwork/internal-issues/issues/76

### Acceptance Criteria
- We should use a different derivation from the one used to start the wallet to authenticate requests on the wallet service
- We should prove we own both `xpubs` (the wallet's account level and the auth_xpubkey) on the start wallet API
- We should use the `auth_xpubkey` to request a JWT token from the wallet service

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
