### PR TITLE
fix: change password broken on wallet service

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -725,6 +725,7 @@ const wallet = {
     if (!(saltKey in accessData)) {
       // Old wallet, we need to validate with old method and update it to the new method
       hash = this.oldHashPassword(password).toString();
+
       if (hash !== accessData[hashKey]) {
         return false;
       }
@@ -780,7 +781,7 @@ const wallet = {
    * @param {string} oldPassword
    * @param {string} newPassword
    *
-   * @return {boolean} true if the PIN was successfully changed
+   * @return {boolean} true if the password was successfully changed
    *
    * @memberof Wallet
    * @inner
@@ -878,11 +879,11 @@ const wallet = {
       return false;
     }
 
-    if (newPassword && !this.isPasswordCorrect(oldPassword)) {
+    if (newPin && !this.isPinCorrect(oldPin)) {
       return false;
     }
 
-    if (newPin && !this.isPinCorrect(oldPin)) {
+    if (newPassword && !this.isPasswordCorrect(oldPassword)) {
       return false;
     }
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -301,7 +301,6 @@ export interface CreateWalletAuthData {
   authXpubkeySignature: string;
   timestampNow: number;
   firstAddress: string;
-  xprivChangePath: bitcore.HDPrivateKey;
   authDerivedPrivKey: bitcore.HDPrivateKey;
 };
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -208,7 +208,7 @@ export interface TransactionFullObject {
 }
 
 export interface IHathorWallet {
-  start(options: { pinCode: string });
+  start(options: { pinCode: string, password: string });
   getAllAddresses(): AsyncGenerator<GetAddressesObject>;
   getBalance(token: string | null): Promise<GetBalanceObject[]>;
   getTokens(): Promise<string[]>;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -197,7 +197,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof Wallet
    * @inner
    */
-  static initializeAccessData(pin: string, mainKey: string, authKey: string) {
+  static initializeAccessData(pin: string, password: string, mainKey: string, authKey: string) {
     const initialAccessData = wallet.getWalletAccessData() || {};
 
     const encryptedAuthKey = wallet.encryptData(authKey, pin);
@@ -207,6 +207,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     initialAccessData['mainKey'] = encryptedMainKey.encrypted.toString();
 
     wallet.setWalletAccessData(initialAccessData);
+    wallet.storePasswordHash(password, 'Passwd');
   }
 
 
@@ -229,12 +230,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @param {Object} optionsParams Options parameters
    *  {
    *   'pinCode': PIN to encrypt the auth xpriv on storage
+   *   'password': Password to decrypt xpriv information
    *  }
    *
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async start({ pinCode }) {
+  async start({ pinCode, password }) {
     if (!this.seed) {
       throw new Error('Seed should be in memory when starting the wallet.');
     }
@@ -258,6 +260,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     HathorWalletServiceWallet.initializeAccessData(
       pinCode,
+      password,
       xprivChangePath.xprivkey,
       authDerivedPrivKey.xprivkey,
     );

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -188,30 +188,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   }
 
   /**
-   * Encrypt and store wallet data on storage using the wallet's PIN code
-   *
-   * @param {string} pin Pin code to use as password to encrypt the auth key
-   * @param {string} mainKey xpriv of the change level derivation to sign inputs
-   * @param {string} authKey xpriv of the auth specific purpose derivation path
-   *
-   * @memberof Wallet
-   * @inner
-   */
-  static initializeAccessData(pin: string, password: string, mainKey: string, authKey: string) {
-    const initialAccessData = wallet.getWalletAccessData() || {};
-
-    const encryptedAuthKey = wallet.encryptData(authKey, pin);
-    const encryptedMainKey = wallet.encryptData(mainKey, pin);
-
-    initialAccessData['authKey'] = encryptedAuthKey.encrypted.toString();
-    initialAccessData['mainKey'] = encryptedMainKey.encrypted.toString();
-
-    wallet.setWalletAccessData(initialAccessData);
-    wallet.storePasswordHash(password, 'Passwd');
-  }
-
-
-  /**
    * getWalletIdFromXPub: Get the wallet id given the xpubkey
    *
    * @param xpub - The xpubkey
@@ -258,11 +234,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       authDerivedPrivKey,
     } = this.generateCreateWalletAuthData(this.seed);
 
-    HathorWalletServiceWallet.initializeAccessData(
+    wallet.executeGenerateWallet(
+      this.seed,
+      this.passphrase,
       pinCode,
       password,
-      xprivChangePath.xprivkey,
-      authDerivedPrivKey.xprivkey,
+      false,
     );
 
     this.xpub = xpub;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -230,7 +230,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       authXpubkeySignature,
       timestampNow,
       firstAddress,
-      xprivChangePath,
       authDerivedPrivKey,
     } = this.generateCreateWalletAuthData(this.seed);
 
@@ -299,9 +298,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const xpubChangeDerivation = walletUtils.xpubDeriveChild(xpub, 0);
     const firstAddress = walletUtils.getAddressAtIndex(xpubChangeDerivation, 0, this.network.name);
 
-    // Derive the change level path to sign inputs
-    const xprivChangePath = xpriv.deriveNonCompliantChild(`m/44'/${HATHOR_BIP44_CODE}'/0'/0`);
-
     return {
       xpub,
       xpubkeySignature,
@@ -309,7 +305,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       authXpubkeySignature,
       timestampNow,
       firstAddress,
-      xprivChangePath,
       authDerivedPrivKey,
     };
   }


### PR DESCRIPTION
## Motivation
`changePin` on the wallet mobile was failing on the wallet service facade because we use the pin as password and we didn't have the `hashPasswd` and `saltPasswd` stored on the `accessData` to be able to validate if it is correct. 

To solve this, we are using the `executeGenerateWallet` method that already existed on `wallet.js`

### Acceptance Criteria
- `accessData` should be properly initialized with the same data the old facade had
- `changePassword` should be able to validate if the password is correct without crashing


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
