### PR TITLE
feat: emit reload event after a reconnection

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -13,17 +13,12 @@ import helpers from './helpers';
 import wallet from './wallet';
 import WalletWebSocket from './websocket';
 import WalletServiceWebSocket from './wallet/websocket';
+import { ConnectionState } from './wallet/types';
 
 export const DEFAULT_PARAMS = {
   network: 'mainnet',
   servers: [],
   connectionTimeout: 5000,
-};
-
-export enum ConnectionState {
-  CLOSED = 0,
-  CONNECTING = 1,
-  CONNECTED = 2,
 };
 
 export type ConnectionParams = {

--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -11,8 +11,10 @@ import config from '../config';
 import helpers from '../helpers';
 import BaseConnection, {
   ConnectionParams,
-  ConnectionState,
 } from '../connection';
+import {
+  ConnectionState,
+} from '../wallet/types';
 
 /**
  * This is a Connection that may be shared by one or more wallets.

--- a/src/wallet/connection.ts
+++ b/src/wallet/connection.ts
@@ -14,13 +14,8 @@ import BaseConnection, {
 } from '../connection';
 import {
   WsTransaction,
+  ConnectionState,
 } from './types';
-
-export enum ConnectionState {
-  CLOSED = 0,
-  CONNECTING = 1,
-  CONNECTED = 2,
-}
 
 export interface WalletServiceConnectionParams extends ConnectionParams {
   walletId: string;

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -232,6 +232,7 @@ export interface IHathorWallet {
   destroyAuthority(token: string, type: string, count: number): Promise<Transaction>;
   getFullHistory(): TransactionFullObject[];
   getTxBalance(tx: WsTransaction, optionsParams): Promise<{[tokenId: string]: number}>;
+  onConnectionChangedState(newState: ConnectionState): void;
 }
 
 export interface ISendTransaction {
@@ -303,3 +304,9 @@ export interface CreateWalletAuthData {
   xprivChangePath: bitcore.HDPrivateKey;
   authDerivedPrivKey: bitcore.HDPrivateKey;
 };
+
+export enum ConnectionState {
+  CLOSED = 0,
+  CONNECTING = 1,
+  CONNECTED = 2,
+}

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -504,6 +504,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.conn.setWalletId(this.walletId);
     this.conn.on('new-tx', (newTx: WsTransaction) => this.onNewTx(newTx));
     this.conn.on('update-tx', (updatedTx) => this.onUpdateTx(updatedTx));
+    this.conn.on('state', (newState: ConnectionState) => this.onConnectionChangedState(newState));
     this.conn.start();
   }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -31,7 +31,7 @@ import Address from '../models/address';
 import Network from '../models/network';
 import networkInstance from '../network';
 import assert from 'assert';
-import WalletServiceConnection, { ConnectionState } from './connection';
+import WalletServiceConnection from './connection';
 import MineTransaction from './mineTransaction';
 import SendTransactionWalletService from './sendTransactionWalletService';
 import { shuffle } from 'lodash';
@@ -54,6 +54,7 @@ import {
   WsTransaction,
   TxOutput,
   CreateWalletAuthData,
+  ConnectionState,
 } from './types';
 import { SendTxError, UtxoError, WalletRequestError, WalletError } from '../errors';
 import { ErrorMessages } from '../errorMessages';
@@ -98,6 +99,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   private indexToUse: number;
   // WalletService-ready connection class
   private conn: WalletServiceConnection;
+  // Flag to indicate if the wallet was already connected when the webscoket conn is established
+  private firstConnection: boolean;
 
   constructor(requestPassword: Function, seed: string, network: Network, options = { passphrase: '' }) {
     super();
@@ -110,7 +113,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     // Setup the connection so clients can listen to its events before it is started
     this.conn = new WalletServiceConnection();
-
     this.state = walletState.NOT_STARTED;
 
     // It will throw InvalidWords error in case is not valid
@@ -131,6 +133,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     networkInstance.setNetwork(this.network.name);
 
     this.authToken = null;
+    this.firstConnection = true;
 
     this.newAddresses = [];
     this.indexToUse = -1;
@@ -502,6 +505,29 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.conn.on('new-tx', (newTx: WsTransaction) => this.onNewTx(newTx));
     this.conn.on('update-tx', (updatedTx) => this.onUpdateTx(updatedTx));
     this.conn.start();
+  }
+
+  /**
+   * Called when the connection to the websocket changes.
+   * It is also called if the network is down.
+   *
+   * Since the wallet service facade holds no data (as opposed to
+   * the old facade, where the wallet facade receives a storage object),
+   * the client needs to handle the data reload, so we just emit an event
+   * to indicate that a reload is necessary.
+   *
+   * @param {Number} newState Enum of new state after change
+   **/
+  onConnectionChangedState(newState: ConnectionState) {
+    if (newState === ConnectionState.CONNECTED) {
+      // We don't need to reload data if this is the first
+      // connection
+      if (!this.firstConnection) {
+        this.emit('reload-data');
+      }
+
+      this.firstConnection = false;
+    }
   }
 
   /**


### PR DESCRIPTION
## Motivation

Currently, the old wallet facade reloads the data from the connected full-node every time the WebSocket is re-established. This is needed because it might have lost a transaction at the time it has been disconnected.

The new wallet-service facade is not doing this at the moment and we can't use the same mechanism the old facade uses as we don't have control of the storage on the new facade on the wallet-lib, so I've created a `reload-data` event that is currently only implemented on the new wallet service facade to indicate to clients that data must be reloaded

### Acceptance Criteria
- The wallet service facade should emit a `reload-data` event every time the WebSocket connection is re-established.
- The wallet service facade should not emit a `reload-data` event if the connection established event is the first connection.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
