### PR TITLE
fix: clearing storage and reseting wallet when stop() is called

### DIFF
--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -207,6 +207,10 @@ export interface TransactionFullObject {
   parents: string[];
 }
 
+export interface IStopWalletParams {
+  cleanStorage?: boolean;
+};
+
 export interface IHathorWallet {
   start(options: { pinCode: string, password: string });
   getAllAddresses(): AsyncGenerator<GetAddressesObject>;
@@ -215,7 +219,7 @@ export interface IHathorWallet {
   getTxHistory(options: { token_id?: string, count?: number, skip?: number }): Promise<GetHistoryObject[]>;
   sendManyOutputsTransaction(outputs: OutputRequestObj[], options: { inputs?: InputRequestObj[], changeAddress?: string }): Promise<Transaction>;
   sendTransaction(address: string, value: number, options: { token?: string, changeAddress?: string }): Promise<Transaction>;
-  stop();
+  stop(params?: IStopWalletParams);
   getAddressAtIndex(index: number): string;
   getCurrentAddress({ markAsUsed: boolean }): AddressInfoObject;
   getNextAddress(): AddressInfoObject;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -807,9 +807,20 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  stop() {
+  stop({ cleanStorage = true } = {}) {
     this.walletId = null;
     this.state = walletState.NOT_STARTED;
+    this.firstConnection = true;
+    this.removeAllListeners();
+
+    if (cleanStorage) {
+      wallet.cleanWallet({
+        endConnection: false,
+        connection: this.conn,
+      });
+    }
+
+    this.conn.stop();
   }
 
   /**


### PR DESCRIPTION
### Acceptance Criteria
- Reset wallet on the wallet mobile should reset the wallet after a app re-open
- Local storage data should be cleared when the `stop` facade method is called with no params or with `cleanStorage` option set to true


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
