### PR TITLE
feat: handle tx-mining rate limit

### DIFF
--- a/__tests__/wallet/mineTransaction.test.ts
+++ b/__tests__/wallet/mineTransaction.test.ts
@@ -1,0 +1,23 @@
+import Network from "../../src/models/network";
+
+import helpers from "../../src/utils/helpers";
+import MineTransaction from "../../src/wallet/mineTransaction";
+
+test('Handle Rate Limit', (done) => {
+  global.mock.onPost('submit-job').replyOnce(() => {
+    return [429];
+  });
+
+  const rawTx = '00010001020082c7dd1f0ceb8867219dcca68540abe77222d11bb2dc67a7af1f04640ea1f701006a473045022100e41968f863dc3372c96a944641f2361ed86849249822b5988804adba1683b3ec02201877dd97d0c85d3754f3378828a4484de407ed2985fcf87782d90cce8f72ec9c2103168e0d873a5bbd75c90c24a68071ea05b9c10996d0cadb543ca650aa76607a260000006400001976a9143f207b6b6fdc624f6c4aff52daf5b80f7f15caf988ac0000001700001976a9143f207b6b6fdc624f6c4aff52daf5b80f7f15caf988ac40200000218def4160dcc22702006f1ebedd590bb5db5c71adbdeaa9b15f7f75c6257c26b11781dc1a5b20f83300b96fdd7a445e063326bbba979919be3b76add5b9cac9ff3330aa2bb804fb0e000000f4';
+
+  const network = new Network('testnet');
+  const tx = helpers.createTxFromHex(rawTx, network);
+
+  const mineTransaction = new MineTransaction(tx, { maxTxMiningRetries: 1 });
+  mineTransaction.start();
+
+  mineTransaction.on('error', (message) => {
+    expect(message).toBe('Too many transactions sent in a short time-span.\n\nAll transactions need to solve a proof-of-work as an anti spam mechanism. Currently, Hathor Labs provides a tx mining service for free, but there are limits to the number of transactions someone can mine using it to avoid abuse.\n\nPlease try again in a few seconds.');
+    done();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
       "<rootDir>/setupTests.js"
     ],
     "collectCoverageFrom": [
-      "<rootDir>/src/*.js",
+      "<rootDir>/src/**/*.js",
+      "<rootDir>/src/**/*.ts",
       "!<rootDir>/node_modules/"
     ],
     "modulePathIgnorePatterns": [

--- a/src/api/txMining.js
+++ b/src/api/txMining.js
@@ -33,8 +33,8 @@ const txMiningApi = {
     }
     return txMiningRequestClient(resolve).post('submit-job', postData).then((res) => {
       resolve(res.data)
-    }, (res) => {
-      return Promise.reject(res);
+    }, (error) => {
+      return Promise.reject(error);
     });
   },
 
@@ -51,8 +51,8 @@ const txMiningApi = {
     const data = {'job-id': job};
     return txMiningRequestClient(resolve).get('job-status', {'params': data}).then((res) => {
       resolve(res.data)
-    }, (res) => {
-      return Promise.reject(res);
+    }, (error) => {
+      return Promise.reject(error);
     });
   },
 
@@ -69,8 +69,8 @@ const txMiningApi = {
     const data = {'job-id': job};
     return txMiningRequestClient(resolve).post('cancel-job', data).then((res) => {
       resolve(res.data)
-    }, (res) => {
-      return Promise.reject(res);
+    }, (error) => {
+      return Promise.reject(error);
     });
   },
 };

--- a/src/new/sendTransaction.js
+++ b/src/new/sendTransaction.js
@@ -10,7 +10,6 @@ import { MIN_POLLING_INTERVAL, SELECT_OUTPUTS_TIMEOUT, HATHOR_TOKEN_CONFIG } fro
 import transaction from '../transaction';
 import helpers from '../utils/helpers';
 import txApi from '../api/txApi';
-import txMiningApi from '../api/txMining';
 import { WalletError, SendTxError, OutputValueError, ConstantNotSet, MaximumNumberOutputsError, MaximumNumberInputsError } from '../errors';
 import { ErrorMessages } from '../errorMessages';
 import wallet from '../wallet';


### PR DESCRIPTION
### Acceptance Criteria
The lib should be able no nicely handle Http Code 429 that it may get from tx-mining-service

### Notes
1. I don't know how I should go about translating the new error message into other languages in wallet-mobile.

2. In wallet-mobile, the message would be stripped:

![mobile_rate_limit](https://user-images.githubusercontent.com/5041650/159997216-8972ad5c-8b05-4e02-a3f9-a2ba727d6fde.png)


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
