### PR TITLE
feat: wallet service facade should be able to start from a xprivkey on the account path derivation

### DIFF
--- a/__tests__/wallet/api/walletServiceAxios.test.ts
+++ b/__tests__/wallet/api/walletServiceAxios.test.ts
@@ -3,14 +3,18 @@ import Network from '../../../src/models/network';
 import HathorWalletServiceWallet from '../../../src/wallet/wallet';
 import config from '../../../src/config';
 
-const words = 'connect sunny silent cabin leopard start turtle tortoise dial timber woman genre pave tuna rice indicate gown draft palm collect retreat meadow assume spray';
+const seed = 'connect sunny silent cabin leopard start turtle tortoise dial timber woman genre pave tuna rice indicate gown draft palm collect retreat meadow assume spray';
 
 test('use testnet tx mining when network is testnet', async () => {
   config.setWalletServiceBaseUrl('https://wallet-service.testnet.hathor.network/');
 
   const requestPassword = jest.fn();
   const network = new Network('testnet');
-  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+  });
 
   const client = await axiosInstance(wallet, false);
 
@@ -22,7 +26,11 @@ test('use mainnet tx mining when network is mainnet', async () => {
 
   const requestPassword = jest.fn();
   const network = new Network('mainnet');
-  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network
+  });
 
   const client = await axiosInstance(wallet, false);
 
@@ -34,7 +42,11 @@ test('use explicitly configured tx mining', async () => {
 
   const requestPassword = jest.fn();
   const network = new Network('mainnet');
-  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+  });
 
   const client = await axiosInstance(wallet, false);
 

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -30,8 +30,12 @@ const MOCK_TX = {
 test('getTxBalance', async () => {
   const requestPassword = jest.fn();
   const network = new Network('testnet');
-  const words = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
-  const wallet = new HathorWalletServiceWallet(requestPassword, words, network);
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+  });
 
   const getAllAddressesMock = async function* () {
     const addresses: GetAddressesObject[] = [{

--- a/src/constants.js
+++ b/src/constants.js
@@ -311,3 +311,9 @@ export const MAX_TOKEN_SYMBOL_SIZE = 5;
  * account is the last hardened level
  */
 export const P2SH_ACCT_PATH = `m/45'/${HATHOR_BIP44_CODE}'/0'`;
+
+/**
+ * Account path for P2PKH
+ * account is the last hardened level
+ */
+export const P2PKH_ACCT_PATH = `m/44'/${HATHOR_BIP44_CODE}'/0'`;

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1842,6 +1842,35 @@ class HathorWallet extends EventEmitter {
     }
   }
 
+  /**
+   * Call get token details API
+   *
+   * @param tokenId Token uid to get the token details
+   *
+   * @return {Promise} token details
+   */
+  async getTokenDetails(tokenId) {
+    const result = await new Promise((resolve) => {
+      return walletApi.getGeneralTokenInfo(tokenId, resolve);
+    });
+
+    const { name, symbol, mint, melt, total, transactions_count } = result;
+
+    // Transform to the same format the wallet service facade responds
+    return {
+      totalSupply: total,
+      totalTransactions: transactions_count,
+      tokenInfo: {
+        name,
+        symbol,
+      },
+      authorities: {
+        mint: mint.length > 0,
+        melt: melt.length > 0,
+      },
+    };
+  }
+
   isReady() {
     return this.state === HathorWallet.READY;
   }

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -201,7 +201,9 @@ const wallet = {
   },
 
   /**
-   * Get root xpriv from seed
+   * Get root privateKey from seed
+   *
+   * TODO: Change method name as we are not returning a xpriv
    *
    * @param {String} seed 24 words
    * @param {Object} options Options with passphrase, networkName
@@ -221,6 +223,8 @@ const wallet = {
 
   /**
    * Derive xpriv from root to account derivation path
+   *
+   * TODO: Method name is misleading as we are returning a HDPrivateKey and not a xpriv, we should change it
    *
    * @param {string} accountDerivationIndex String with derivation index of account (can be hardened)
    *

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -22,6 +22,7 @@ import {
   LOAD_WALLET_MAX_RETRY,
   LOAD_WALLET_RETRY_SLEEP,
   WALLET_SERVICE_AUTH_DERIVATION_PATH,
+  P2PKH_ACCT_PATH,
   P2SH_ACCT_PATH,
 } from './constants';
 import Mnemonic from 'bitcore-mnemonic';
@@ -276,20 +277,25 @@ const wallet = {
   executeGenerateWallet(words, passphrase, pin, password, loadHistory, multisig) {
     let code = new Mnemonic(words);
     let xpriv = code.toHDPrivateKey(passphrase, network.getNetwork());
-    let authXpriv = xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
+    const authXpriv = xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
+    const accPrivKey = xpriv.deriveNonCompliantChild(P2PKH_ACCT_PATH);
+
     let privkey;
     if (multisig) {
       privkey = xpriv.deriveNonCompliantChild(`${P2SH_ACCT_PATH}/0`);
     } else {
       privkey = xpriv.deriveNonCompliantChild(`m/44'/${HATHOR_BIP44_CODE}'/0'/0`);
     }
+
     let encryptedData = this.encryptData(privkey.xprivkey, pin)
-    let encryptedAuthXpriv = this.encryptData(authXpriv.xprivkey, pin)
-    let encryptedDataWords = this.encryptData(words, password)
+    let encryptedAccountPathXpriv = this.encryptData(accPrivKey.xprivkey, pin);
+    let encryptedAuthXpriv = this.encryptData(authXpriv.xprivkey, pin);
+    let encryptedDataWords = this.encryptData(words, password);
 
     // Save in storage the encrypted private key and the hash of the pin and password
     let access = {
       mainKey: encryptedData.encrypted.toString(),
+      acctPathMainKey: encryptedAccountPathXpriv.encrypted.toString(),
       hash: encryptedData.hash.key.toString(),
       salt: encryptedData.hash.salt,
       words: encryptedDataWords.encrypted.toString(),
@@ -903,7 +909,18 @@ const wallet = {
       hash: newHash.key.toString(),
       salt: newHash.salt,
       mainKey: encryptedMainKey.encrypted.toString(),
+      acctPathMainKey: encryptedAccPathMainKey.encrypted.toString(),
     };
+
+    if (accessData.acctPathMainKey) {
+      const decryptedAccPathMainKey = this.decryptData(accessData.acctPathMainKey, oldPin);
+      const encryptedAccPathMainKey = this.encryptData(decryptedAccPathMainKey, newPin);
+
+      newAccessData = {
+        ...newAccessData,
+        acctPathMainKey: encryptedAccPathMainKey,
+      };
+    }
 
     if (accessData.authKey) {
       const decryptedAuthKey = this.decryptData(accessData.authKey, oldPin);
@@ -2794,6 +2811,25 @@ const wallet = {
 
     const encryptedXPriv = accessData.mainKey;
     const privateKeyStr = wallet.decryptData(encryptedXPriv, pin);
+    return privateKeyStr;
+  },
+
+  /**
+   * Get account path xprivkey from storage
+   *
+   * @param {String} pin User PIN used to encrypt the account path xpriv on storage
+   *
+   * @return {String} Wallet account path xprivkey
+   */
+  getAcctPathXprivKey(pin) {
+    if (this.isFromXPub()) {
+      throw WalletFromXPubGuard('getAcctPathXprivKey');
+    }
+
+    const accessData = this.getWalletAccessData();
+    const encryptedXPriv = accessData.acctPathMainKey;
+    const privateKeyStr = wallet.decryptData(encryptedXPriv, pin);
+
     return privateKeyStr;
   },
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -276,8 +276,8 @@ const wallet = {
    * @inner
    */
   executeGenerateWallet(words, passphrase, pin, password, loadHistory, multisig) {
-    let code = new Mnemonic(words);
-    let xpriv = code.toHDPrivateKey(passphrase, network.getNetwork());
+    const code = new Mnemonic(words);
+    const xpriv = code.toHDPrivateKey(passphrase, network.getNetwork());
     const authXpriv = xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
     const accPrivKey = xpriv.deriveNonCompliantChild(P2PKH_ACCT_PATH);
 
@@ -288,13 +288,13 @@ const wallet = {
       privkey = xpriv.deriveNonCompliantChild(`m/44'/${HATHOR_BIP44_CODE}'/0'/0`);
     }
 
-    let encryptedData = this.encryptData(privkey.xprivkey, pin)
-    let encryptedAccountPathXpriv = this.encryptData(accPrivKey.xprivkey, pin);
-    let encryptedAuthXpriv = this.encryptData(authXpriv.xprivkey, pin);
-    let encryptedDataWords = this.encryptData(words, password);
+    const encryptedData = this.encryptData(privkey.xprivkey, pin)
+    const encryptedAccountPathXpriv = this.encryptData(accPrivKey.xprivkey, pin);
+    const encryptedAuthXpriv = this.encryptData(authXpriv.xprivkey, pin);
+    const encryptedDataWords = this.encryptData(words, password);
 
     // Save in storage the encrypted private key and the hash of the pin and password
-    let access = {
+    const access = {
       mainKey: encryptedData.encrypted.toString(),
       acctPathMainKey: encryptedAccountPathXpriv.encrypted.toString(),
       hash: encryptedData.hash.key.toString(),

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -209,7 +209,7 @@ const wallet = {
   },
 
   /**
-   * Start a new HD wallet from an xpriv.
+   * Start a new HD wallet from a xprivkey.
    * Encrypt this private key and save data in storage
    *
    * @param {string} xpriv Extended private-key to start wallet
@@ -223,6 +223,7 @@ const wallet = {
    */
   executeGenerateWalletFromXPriv(xprivkey, pin, loadHistory, multisig) {
     const xpriv = HDPrivateKey(xprivkey);
+
     let initialAccessData;
     let privkey;
     if (xpriv.depth === 0) {

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -909,7 +909,6 @@ const wallet = {
       hash: newHash.key.toString(),
       salt: newHash.salt,
       mainKey: encryptedMainKey.encrypted.toString(),
-      acctPathMainKey: encryptedAccPathMainKey.encrypted.toString(),
     };
 
     if (accessData.acctPathMainKey) {

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -18,7 +18,8 @@ import {
   TxProposalCreateResponseData,
   TxProposalUpdateResponseData,
   UtxoResponseData,
-  AuthTokenResponseData
+  AuthTokenResponseData,
+  TokenDetailsResponseData,
 } from '../types';
 import HathorWalletServiceWallet from '../wallet';
 import { WalletRequestError } from '../../errors';
@@ -90,6 +91,17 @@ const walletApi = {
       return response.data;
     } else {
       throw new WalletRequestError('Error getting wallet addresses to use.');
+    }
+  },
+
+  async getTokenDetails(wallet: HathorWalletServiceWallet, tokenId: string): Promise<TokenDetailsResponseData> {
+    const axios = await axiosInstance(wallet, true);
+    const response = await axios.get(`wallet/tokens/${tokenId}/details`);
+
+    if (response.status === 200 && response.data.success === true) {
+      return response.data;
+    } else {
+      throw new WalletRequestError('Error getting token details.');
     }
   },
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -237,7 +237,6 @@ export interface IHathorWallet {
   getFullHistory(): TransactionFullObject[];
   getTxBalance(tx: WsTransaction, optionsParams): Promise<{[tokenId: string]: number}>;
   onConnectionChangedState(newState: ConnectionState): void;
-  generateCreateWalletAuthData(pinCode: string): CreateWalletAuthData;
 }
 
 export interface ISendTransaction {

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -212,14 +212,14 @@ export interface IStopWalletParams {
 };
 
 export interface IHathorWallet {
-  start(options: { pinCode: string, password: string });
+  start(options: { pinCode: string, password: string }): Promise<void>;
   getAllAddresses(): AsyncGenerator<GetAddressesObject>;
   getBalance(token: string | null): Promise<GetBalanceObject[]>;
   getTokens(): Promise<string[]>;
   getTxHistory(options: { token_id?: string, count?: number, skip?: number }): Promise<GetHistoryObject[]>;
   sendManyOutputsTransaction(outputs: OutputRequestObj[], options: { inputs?: InputRequestObj[], changeAddress?: string }): Promise<Transaction>;
   sendTransaction(address: string, value: number, options: { token?: string, changeAddress?: string }): Promise<Transaction>;
-  stop(params?: IStopWalletParams);
+  stop(params?: IStopWalletParams): void;
   getAddressAtIndex(index: number): string;
   getCurrentAddress({ markAsUsed: boolean }): AddressInfoObject;
   getNextAddress(): AddressInfoObject;
@@ -237,6 +237,7 @@ export interface IHathorWallet {
   getFullHistory(): TransactionFullObject[];
   getTxBalance(tx: WsTransaction, optionsParams): Promise<{[tokenId: string]: number}>;
   onConnectionChangedState(newState: ConnectionState): void;
+  generateCreateWalletAuthData(pinCode: string): CreateWalletAuthData;
 }
 
 export interface ISendTransaction {

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -91,6 +91,23 @@ export interface BalanceResponseData {
   balances: GetBalanceObject[];
 }
 
+export interface TokenDetailsResponseData {
+  success: boolean;
+  details: TokenDetailsObject;
+}
+
+export interface TokenDetailsAuthoritiesObject {
+  mint: boolean;
+  melt: boolean;
+}
+
+export interface TokenDetailsObject {
+  tokenInfo: TokenInfo;
+  totalSupply: number;
+  totalTransactions: number;
+  authorities: TokenDetailsAuthoritiesObject;
+}
+
 export interface HistoryResponseData {
   success: boolean;
   history: GetHistoryObject[];
@@ -237,6 +254,7 @@ export interface IHathorWallet {
   getFullHistory(): TransactionFullObject[];
   getTxBalance(tx: WsTransaction, optionsParams): Promise<{[tokenId: string]: number}>;
   onConnectionChangedState(newState: ConnectionState): void;
+  getTokenDetails(tokenId: string): Promise<TokenDetailsObject>;
 }
 
 export interface ISendTransaction {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -260,7 +260,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         password,
         false,
       );
-    } else if(this.xpriv) {
+    } else if (this.xpriv) {
       wallet.executeGenerateWalletFromXPriv(
         this.xpriv,
         pinCode,
@@ -512,10 +512,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   private async onWalletReady() {
+    // We should wait for new addresses before setting wallet to ready
+    await this.getNewAddresses(true);
+
     this.setupConnection();
     this.setState(walletState.READY);
-
-    await this.getNewAddresses();
   }
 
   setupConnection() {
@@ -575,8 +576,10 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  private async getNewAddresses() {
-    this.failIfWalletNotReady();
+  private async getNewAddresses(ignoreWalletReady = false) {
+    if (!ignoreWalletReady) {
+      this.failIfWalletNotReady();
+    }
     const data = await walletApi.getNewAddresses(this);
     this.newAddresses = data.addresses;
     this.indexToUse = 0;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -55,6 +55,7 @@ import {
   TxOutput,
   CreateWalletAuthData,
   ConnectionState,
+  TokenDetailsObject,
 } from './types';
 import { SendTxError, UtxoError, WalletRequestError, WalletError } from '../errors';
 import { ErrorMessages } from '../errorMessages';
@@ -1223,6 +1224,21 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.failIfWalletNotReady();
     const tx = await this.prepareMintTokensData(token, amount, options);
     return this.handleSendPreparedTransaction(tx);
+  }
+
+  /**
+   * Call get token details API
+   *
+   * @param tokenId Token uid to get the token details
+   *
+   * @memberof HathorWalletServiceWallet
+   * @inner
+   */
+  async getTokenDetails(tokenId: string): Promise<TokenDetailsObject> {
+    const response = await walletApi.getTokenDetails(this, tokenId);
+    const details: TokenDetailsObject = response.details;
+
+    return details;
   }
 
   /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -261,8 +261,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         false,
       );
     } else if (this.xpriv) {
+      // executeGenerateWalletFromXPriv expects a xpriv on the change level path
+      const accountLevelPrivKey = new bitcore.HDPrivateKey(this.xpriv);
+      const changeLevelPrivKey = accountLevelPrivKey.deriveNonCompliantChild(0);
+
       wallet.executeGenerateWalletFromXPriv(
-        this.xpriv,
+        changeLevelPrivKey.xprivkey,
         pinCode,
         false,
         false, // multisig not yet implemented on wallet service

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -205,9 +205,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   static deriveAuthPrivateKey(xpriv: bitcore.HDPrivateKey): bitcore.HDPrivateKey {
-    const ret = xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
-
-    return ret;
+    return xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
   }
 
   /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -574,11 +574,16 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * Get the new addresses to be used by this wallet, i.e. the last GAP LIMIT unused addresses
    * Then it updates this.newAddresses and this.indexToUse that handle the addresses to use
    *
+   * @param ignoreWalletReady Will download new addresses even if the wallet is not set to ready
+   *
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  private async getNewAddresses(ignoreWalletReady = false) {
+  private async getNewAddresses(ignoreWalletReady: boolean = false) {
+    // If the user is sure the wallet service has already loaded his wallet, he can ignore the check
     if (!ignoreWalletReady) {
+      // We should fail if the wallet is not ready because the wallet service address load mechanism is
+      // asynchronous, so we will get an empty or partial array of addresses if they are not all loaded.
       this.failIfWalletNotReady();
     }
     const data = await walletApi.getNewAddresses(this);


### PR DESCRIPTION
## Motivation
Currently, the wallet service facade expects to always receive a seed to be able to derive the change level path private key it uses to identify each wallet (we use a double sha256 encoded hash of the xpubkey on that path as a `wallet-id`).

The problem is that the `wallet-desktop` expects to be able to start the wallet using an `xprivkey` when restoring an already loaded wallet and a `xpubkey` when using the Hardware Wallet and currently, the `mainKey` stored on the device's local storage is on the change level path, making it impossible for the wallet-service to get the account level path

The idea here is to store a account level path xprivkey on storage, encrypted using the PIN code, every time the wallet is started from the seed and use it when needed

### Acceptance Criteria
- We should be able to load a wallet from a `xprivkey` on the account path derivation
- We should store a `xprivkey` on the account path derivation when starting from the seed

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
