### PR TITLE
feat: allow setting tx mining service apikey

### DIFF
--- a/src/api/axiosWrapper.ts
+++ b/src/api/axiosWrapper.ts
@@ -20,17 +20,19 @@ import { TIMEOUT } from '../constants';
  * @param {String} url Base URL for the api requests
  * @param {callback} resolve Callback to be stored and used in case of a retry after a fail
  * @param {number} timeout Timeout in milliseconds for the request
+ * @param {Object} additionalHeaders Headers to be sent with the request
  */
-export const axiosWrapperCreateRequestInstance = (url, resolve, timeout) => {
+export const axiosWrapperCreateRequestInstance = (url: string, resolve: Function, timeout?: number, additionalHeaders = {}) => {
   if (timeout === undefined) {
     timeout = TIMEOUT;
   }
+
   const defaultOptions = {
     baseURL: url,
     timeout: timeout,
-    headers: {
+    headers: Object.assign({
       'Content-Type': 'application/json',
-    },
+    }, additionalHeaders),
   }
 
   return axios.create(defaultOptions);

--- a/src/api/txMiningAxios.ts
+++ b/src/api/txMiningAxios.ts
@@ -21,9 +21,17 @@ import config from '../config';
  * @param {callback} resolve Callback to be stored and used in case of a retry after a fail
  * @param {number} timeout Timeout in milliseconds for the request
  */
-const txMiningRequestClient = (resolve, timeout) => {
-  const txMiningURL = config.getTxMiningUrl()
-  return axiosWrapperCreateRequestInstance(txMiningURL, resolve, timeout);
+const txMiningRequestClient = (resolve: Function, timeout?: number) => {
+  const txMiningURL = config.getTxMiningUrl();
+  const txMiningApiKey = config.getTxMiningApiKey();
+
+  const headers = {};
+
+  if (txMiningApiKey) {
+    headers["apikey"] = txMiningApiKey;
+  }
+
+  return axiosWrapperCreateRequestInstance(txMiningURL, resolve, timeout, headers);
 }
 
 export default txMiningRequestClient;

--- a/src/config.ts
+++ b/src/config.ts
@@ -66,7 +66,7 @@ class Config {
     /**
      * Gets the configured api key for tx-mining-service
      * 
-     * @returns The api key
+     * @returns {string} The api key
      */
     getTxMiningApiKey() {
         return this.TX_MINING_API_KEY;

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ const EXPLORER_SERVICE_TESTNET_BASE_URL  = 'https://explorer-service.testnet.hat
 
 class Config {
     TX_MINING_URL?: string;
+    TX_MINING_API_KEY?: string;
     WALLET_SERVICE_BASE_URL?: string;
     WALLET_SERVICE_BASE_WS_URL?: string;
     EXPLORER_SERVICE_BASE_URL?: string;
@@ -51,6 +52,24 @@ class Config {
         } else {
             throw new Error(`Network ${networkInstance.name} doesn't have a correspondent tx mining service url. You should set it explicitly.`);
         }
+    }
+
+    /**
+    * Sets the tx mining service api key that will be returned by the config object.
+    *
+    * @param {string} apiKey - The api key to be set
+    */
+    setTxMiningApiKey(apiKey: string) {
+        this.TX_MINING_API_KEY = apiKey;
+    }
+
+    /**
+     * Gets the configured api key for tx-mining-service
+     * 
+     * @returns The api key
+     */
+    getTxMiningApiKey() {
+        return this.TX_MINING_API_KEY;
     }
 
     /**


### PR DESCRIPTION
### Acceptance Criteria
- The lib should allow setting an api-key to be used in requests for tx-mining-service


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
