### PR TITLE
fix: select authority utxo returning invalid results when the wallet has at least one spent output

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1394,28 +1394,22 @@ class HathorWallet extends EventEmitter {
           continue;
         }
 
-        const ret = {tx_id, index, address: output.decoded.address, authorities: output.value};
         // If output was already used, we can't use it, unless requested in options
-        if (output.spent_by) {
-          if (skipSpent) {
-            continue;
-          }
-
-          if (many) {
-            // If many we push to the array to be returned later
-            utxos.push(ret);
-          } else {
-            return [ret];
-          }
+        if (output.spent_by && skipSpent) {
+          continue;
         }
 
-        if (filterUTXOs(output)) {
-          if (many) {
-            // If many we push to the array to be returned later
-            utxos.push(ret);
-          } else {
-            return [ret];
-          }
+        if (!filterUTXOs(output)) {
+          continue;
+        }
+
+        const ret = {tx_id, index, address: output.decoded.address, authorities: output.value};
+
+        if (many) {
+          // If many we push to the array to be returned later
+          utxos.push(ret);
+        } else {
+          return [ret];
         }
       }
     }


### PR DESCRIPTION
# Motivation

There was a bug in the `selectAuthorityUtxo` logic, if the wallet had at least one spent output for a given token and the method was called with `skipSpent: false`, it would return that spent tx output as if it were a authority utxo

### Acceptance Criteria
- `selectAuthorityUtxo` should correctly return an empty list if the wallet has no authority utxos and `skipSpent` is false


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
