### PR TITLE
feat: adds address precalculation parameter

### DIFF
--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -9,9 +9,11 @@ import wallet from '../src/wallet';
 import dateFormatter from '../src/date';
 import Mnemonic from 'bitcore-mnemonic';
 import {
-  HATHOR_TOKEN_CONFIG,
+  HASH_ITERATIONS,
   HATHOR_BIP44_CODE,
+  HATHOR_TOKEN_CONFIG,
   P2PKH_ACCT_PATH,
+  WALLET_SERVICE_AUTH_DERIVATION_PATH,
 } from '../src/constants';
 import storage from '../src/storage';
 import WebSocketHandler from '../src/WebSocketHandler';
@@ -20,6 +22,66 @@ import network from '../src/network';
 
 beforeEach(() => {
   wallet.setConnection(WebSocketHandler);
+});
+
+test('loadAddressHistory', async () => {
+  const words = wallet.generateWalletWords(256);
+  const pin = '123456';
+
+  // Generating wallet data manually, to skip other undesired steps of `executeGenerateWallet`
+  const code = new Mnemonic(words);
+  const xpriv = code.toHDPrivateKey('', network.getNetwork());
+  const authXpriv = xpriv.deriveNonCompliantChild(WALLET_SERVICE_AUTH_DERIVATION_PATH);
+  const accPrivKey = xpriv.deriveNonCompliantChild(P2PKH_ACCT_PATH);
+  const privkey = xpriv.deriveNonCompliantChild(`m/44'/${HATHOR_BIP44_CODE}'/0'/0`);
+  const encryptedData = wallet.encryptData(privkey.xprivkey, pin)
+  const encryptedAccountPathXpriv = wallet.encryptData(accPrivKey.xprivkey, pin);
+  const encryptedAuthXpriv = wallet.encryptData(authXpriv.xprivkey, pin);
+  const encryptedDataWords = wallet.encryptData(words, 'password');
+
+  // Setting the storage
+  wallet.setWalletAccessData({
+    mainKey: encryptedData.encrypted.toString(),
+    acctPathMainKey: encryptedAccountPathXpriv.encrypted.toString(),
+    hash: encryptedData.hash.key.toString(),
+    salt: encryptedData.hash.salt,
+    words: encryptedDataWords.encrypted.toString(),
+    authKey: encryptedAuthXpriv.encrypted.toString(),
+    hashPasswd: encryptedDataWords.hash.key.toString(),
+    saltPasswd: encryptedDataWords.hash.salt,
+    hashIterations: HASH_ITERATIONS,
+    pbkdf2Hasher: 'sha1',
+    xpubkey: privkey.xpubkey,
+  });
+  wallet.setWalletData({
+    keys: {},
+    historyTransactions: {},
+  })
+
+  // Executing test
+  const addr1hash = 'WY1URKUnqCTyiixW1Dw29vmeG99hNN4EW6';
+  const addr2hash = 'WTjhJXzQJETVx7BVXdyZmvk396DRRsubdw';
+  const amountOfAddresses = 2
+  const preCalculatedAddresses = await wallet.loadAddressHistory(
+    0,
+    amountOfAddresses,
+    null,
+    null,
+    [addr1hash,addr2hash]
+  ).catch(err => err);
+
+  // Validating results on storage
+  const walletData = storage.getItem('wallet:data');
+  expect(walletData.keys).toHaveProperty(addr1hash)
+  expect(walletData.keys[addr1hash]).toEqual({privkey: null, index: 0});
+  expect(walletData.keys).toHaveProperty(addr2hash)
+  expect(walletData.keys[addr2hash]).toEqual({privkey: null, index: 1});
+
+  /* Despite asking the loadAddressHistory to load only 2 addresses, it generates all addresses up
+   * to the gap limit (21 in length, total).
+   * This happens in getTxHistory > updateHistoryData . So for now we will skip this assertion.
+   */
+  // expect(Object.keys(walletData.keys)).toHaveProperty('length', amountOfAddresses);
 });
 
 test('Wallet operations for transaction', () => {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -59,13 +59,19 @@ const ConnectionState = {
  *                          one for each request sent to the server.
  **/
 class HathorWallet extends EventEmitter {
-  /*
-   * connection {ConnectionState} A connection to the server
-   * seed {String} 24 words separated by space
-   * passphrase {String} Wallet passphrase
-   * tokenUid {String} UID of the token to handle on this wallet
-   * password {String} Password to encrypt the seed
-   * pin {String} PIN to execute wallet actions
+  /**
+   * @param param
+   * @param {ConnectionState} param.connection A connection to the server
+   * @param {string} param.seed 24 words separated by space
+   * @param {string} [param.passphrase=''] Wallet passphrase
+   * @param {string} [param.xpriv]
+   * @param {string} [param.xpub]
+   * @param {string} [param.tokenUid] UID of the token to handle on this wallet
+   * @param {string} [param.password] Password to encrypt the seed
+   * @param {string} [param.pinCode] PIN to execute wallet actions
+   * @param {boolean} [param.debug] Activates debug mode
+   * @param {{pubkeys:string[],minSignatures:number}} [param.multisig]
+   * @param {string[]} [param.preCalculatedAddresses] An array of pre-calculated addresses
    */
   constructor({
     connection,
@@ -139,9 +145,7 @@ class HathorWallet extends EventEmitter {
     this.pinCode = pinCode;
     this.password = password;
 
-    if (preCalculatedAddresses) {
-      this.preCalculatedAddresses = preCalculatedAddresses;
-    }
+    this.preCalculatedAddresses = preCalculatedAddresses;
 
     this.store = null;
     if (store) {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -89,6 +89,7 @@ class HathorWallet extends EventEmitter {
     // Callback to be executed before reload data
     beforeReloadCallback = null,
     multisig = null,
+    preCalculatedAddresses = null,
   } = {}) {
     super();
 
@@ -137,6 +138,10 @@ class HathorWallet extends EventEmitter {
     this.passphrase = passphrase;
     this.pinCode = pinCode;
     this.password = password;
+
+    if (preCalculatedAddresses) {
+      this.preCalculatedAddresses = preCalculatedAddresses;
+    }
 
     this.store = null;
     if (store) {
@@ -237,7 +242,13 @@ class HathorWallet extends EventEmitter {
       let promise;
       if (this.firstConnection) {
         this.firstConnection = false;
-        promise = wallet.loadAddressHistory(0, wallet.getGapLimit(), this.conn, this.store);
+        promise = wallet.loadAddressHistory(
+          0,
+          wallet.getGapLimit(),
+          this.conn,
+          this.store,
+          this.preCalculatedAddresses
+        );
       } else {
         if (this.beforeReloadCallback) {
           this.beforeReloadCallback();
@@ -639,7 +650,7 @@ class HathorWallet extends EventEmitter {
    * @property {number} token Token used to calculate the amounts received, sent, available and locked
    * @property {number} index Derivation path for the given address
    *
-   * @param {string} address Address to get information of 
+   * @param {string} address Address to get information of
    * @param {AddressInfoOptions} options Optional parameters to filter the results
    *
    * @return {AddressInfo} Aggregated information about the given address
@@ -807,7 +818,7 @@ class HathorWallet extends EventEmitter {
    * @property {{ uid: string, name: string, symbol: string }} token - HTR or custom token
    * @property {{ address: string, amount: number, tx_id: string, locked: boolean, index: number }[]} utxos - Array of utxos that will be consolidated
    * @property {number} total_amount - Amount to be consolidated
-   * 
+   *
    * @param {string} destinationAddress Address of the consolidated utxos
    * @param {UtxoOptions} options Utxo filtering options
    *

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -502,6 +502,7 @@ const wallet = {
    * @param {number} count How many addresses I will load
    * @param {Connection} connection Connection object to subscribe for the addresses
    * @param {Store} store Store object to save the data
+   * @param {string[]} preCalculatedAddresses  An array of pre-calculated addresses for this wallet
    *
    * @return {Promise} Promise that resolves when addresses history is finished loading from server
    *

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -508,7 +508,7 @@ const wallet = {
    * @memberof Wallet
    * @inner
    */
-  loadAddressHistory(startIndex, count, connection = null, store = null) {
+  loadAddressHistory(startIndex, count, connection = null, store = null, preCalculatedAddresses = null) {
     const promise = new Promise((resolve, reject) => {
       let oldStore = storage.store;
       if (store) {
@@ -523,8 +523,10 @@ const wallet = {
 
       const stopIndex = startIndex + count;
       for (var i=startIndex; i<stopIndex; i++) {
-        // Generate each key from index, encrypt and save
-        const address = this.generateAddress(i);
+        // Generate each key from index, encrypt and save ( if it is not provided pre-calculated )
+        const address = preCalculatedAddresses && preCalculatedAddresses[i]
+          ? preCalculatedAddresses[i]
+          : this.generateAddress(i);
         dataJson.keys[address.toString()] = {privkey: null, index: i};
         addresses.push(address.toString());
 


### PR DESCRIPTION
This PR adds a parameter on the wallet initialization `constructor` and `loadAddressHistory` methods, to allow the caller to pre-calculate a wallet's addresses, saving on processing time for the lib.

This is especially useful for testing environments, and is a required feature of HathorNetwork/hathor-wallet-headless#189

### Acceptance Criteria
- The wallet init process must be unchanged when the `preCalculatedAddresses` parameter is not informed
- The wallet init must accept the pre-calculated addresses on the new parameter when informed


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
