### PR TITLE
feat: add support in the sendtransaction method to support data script outputs

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -476,9 +476,30 @@ const helpers = {
    * @inner
    */
   createNFTOutput(data: string): Output {
+    return this.createDataScriptOutput(data);
+  },
+
+  /**
+   * Create an output with data script
+   *
+   * @memberof Helpers
+   * @inner
+   */
+  createDataScriptOutput(data: string): Output {
     const scriptData = new ScriptData(data);
     // Value 1 and token HTR
     return new Output(1, scriptData.createScript());
+  },
+
+  /**
+   * From the base58 of an address we get the type of it, i.e. 'p2pkh' or 'p2sh'
+   *
+   * @memberof Helpers
+   * @inner
+   */
+  getOutputTypeFromAddress(address: string, network: Network): string {
+    const addressObj = new Address(address, { network });
+    return addressObj.getType();
   },
 }
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -173,6 +173,21 @@ export interface OutputRequestObj {
   timelock?: number | null; // output timelock
 }
 
+export interface DataScriptOutputRequestObj {
+  type: string; // output type (in this case will be 'data')
+  data: string; // data to store in the output script
+}
+
+// This is the output object to be used in the SendTransactionWalletService class
+export interface OutputSendTransaction {
+  type: string; // output type (in this case will be 'data')
+  value: number; // output value. Optional because we add fixed value of 1 to the output.
+  token: string; // output token. Optional because we add fixed value of HTR token to the output.
+  address?: string; // output address. required for p2pkh or p2sh
+  timelock?: number | null; // output timelock
+  data?: string; // data to store in the output script. required for data script.
+}
+
 export interface InputRequestObj {
   txId: string; // transaction id of the output being spent
   index: number; // index of the output being spent using this input
@@ -312,4 +327,10 @@ export enum ConnectionState {
   CLOSED = 0,
   CONNECTING = 1,
   CONNECTED = 2,
+}
+
+export enum OutputType {
+  P2PKH = 'p2pkh',
+  P2SH = 'p2sh',
+  DATA = 'data',
 }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -45,7 +45,10 @@ import {
   SendTxOptionsParam,
   WalletStatus,
   Utxo,
+  OutputType,
+  OutputSendTransaction,
   OutputRequestObj,
+  DataScriptOutputRequestObj,
   InputRequestObj,
   SendTransactionEvents,
   SendTransactionResponse,
@@ -727,14 +730,25 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async sendManyOutputsTransaction(outputs: OutputRequestObj[], options: { inputs?: InputRequestObj[], changeAddress?: string } = {}): Promise<Transaction> {
+  async sendManyOutputsTransaction(outputs: Array<OutputRequestObj | DataScriptOutputRequestObj>, options: { inputs?: InputRequestObj[], changeAddress?: string } = {}): Promise<Transaction> {
     this.failIfWalletNotReady();
     const newOptions = Object.assign({
       inputs: [],
       changeAddress: null
     }, options);
     const { inputs, changeAddress } = newOptions;
-    const sendTransaction = new SendTransactionWalletService(this, { outputs, inputs, changeAddress });
+    const sendTransactionOutputs = outputs.map((output) => {
+      let typedOutput = output as OutputSendTransaction;
+      if (typedOutput.type === OutputType.DATA) {
+        typedOutput.value = 1;
+        typedOutput.token = HATHOR_TOKEN_CONFIG.uid;
+      } else {
+        typedOutput.type = helpers.getOutputTypeFromAddress(typedOutput.address!, this.network);
+      }
+
+      return typedOutput;
+    });
+    const sendTransaction = new SendTransactionWalletService(this, { outputs: sendTransactionOutputs, inputs, changeAddress });
     return sendTransaction.run();
   }
 


### PR DESCRIPTION
### Acceptance Criteria

- We must add support for sending a transaction with one or many data script outputs.
- All other transaction types must continue working as before.
- This feature must be added to both facades.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
