### PR TITLE
test: words valid test was failing eventually

### DIFF
--- a/__tests__/utils/wallet.test.js
+++ b/__tests__/utils/wallet.test.js
@@ -17,6 +17,7 @@ import { hexToBuffer } from '../../src/utils/buffer';
 test('Words', () => {
   const words = wallet.generateWalletWords();
   const wordsArr = words.split(' ');
+  const [lastWord] = wordsArr.slice(-1)
   // 24 words
   expect(wordsArr.length).toBe(24);
   // Words are valid
@@ -38,7 +39,8 @@ test('Words', () => {
   }
 
   // Wrong 24th word
-  invalidArr.push('word');
+  const wordToPush = lastWord === 'word' ? 'work' : 'word';
+  invalidArr.push(wordToPush);
   expect(() => wallet.wordsValid(invalidArr.join(' '))).toThrowError(InvalidWords);
 
   // If the wrong word does not belong to the mnemonic dictionary we return it in the list of invalidWords

--- a/__tests__/utils/wallet.test.js
+++ b/__tests__/utils/wallet.test.js
@@ -39,7 +39,7 @@ test('Words', () => {
   }
 
   // Wrong 24th word
-  const wordToPush = lastWord === 'word' ? 'work' : 'word';
+  const wordToPush = lastWord === 'word' ? 'guitar' : 'word';
   invalidArr.push(wordToPush);
   expect(() => wallet.wordsValid(invalidArr.join(' '))).toThrowError(InvalidWords);
 


### PR DESCRIPTION
### Acceptance Criteria

One of the tests of `wordsValid` method was checking that adding a random word from mnemonic wordlist as the last word of the seed would still be invalid. 

The word we were always adding was "word" but sometimes the last word was actually "word", then the test was failing.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
