### PR TITLE
fix: return null for no authority utxos

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1426,7 +1426,7 @@ class HathorWallet extends EventEmitter {
    *    'skipSpent': if should not include spent utxos (default true)
    *  }
    *
-   * @return {Array} Array of objects with {tx_id, index, address, authorities} of the authority output. Returns null in case there are no utxos for this type
+   * @return {Array|null} Array of objects with {tx_id, index, address, authorities} of the authority output. Returns null in case there are no utxos for this type
    **/
   selectAuthorityUtxo(tokenUid, filterUTXOs, options = {}) {
     const newOptions = Object.assign({many: false, skipSpent: true}, options);
@@ -1472,8 +1472,9 @@ class HathorWallet extends EventEmitter {
     }
 
     if (many) {
-      return utxos;
+      return utxos || null;
     }
+    return null;
   }
 
   /**


### PR DESCRIPTION
### Summary

If no authority utxos are found nothing was returned, this meant the caller would get an `undefined`.
The problem is some methods use `!== null` to check if there are any authority utxos and `undefined` makes it true.

### Acceptance Criteria
- Actually return `null` if no authority utxos are found


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
