### PR TITLE
feat: HathorWallet emitting its state

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -281,6 +281,7 @@ class HathorWallet extends EventEmitter {
     if (newState === ConnectionState.CONNECTED) {
       storage.setStore(this.store);
       this.setState(HathorWallet.SYNCING);
+      this.emit('state', HathorWallet.SYNCING);
 
       // If it's the first connection we just load the history
       // otherwise we are reloading data, so we must execute some cleans
@@ -304,9 +305,11 @@ class HathorWallet extends EventEmitter {
 
       promise.then(() => {
         this.setState(HathorWallet.READY);
+        this.emit('state', HathorWallet.READY);
       }).catch((error) => {
         this.setState(HathorWallet.ERROR);
         console.error('Error loading wallet', {error});
+        this.emit('state', HathorWallet.ERROR);
       })
     } else {
       this.serverInfo = null;

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -624,17 +624,17 @@ class HathorWallet extends EventEmitter {
   /**
    * Get transaction history
    *
-   * @params {Object} options {token_id, count, skip}
-   *
-   * @return {Promise<Array>} Array of balance for each token
-   * {
-   *   token: {id, name, symbol},
-   *   balance: {unlocked. locked},
-   *   transactions: number,
-   *   lockExpires: number | null,
-   *   tokenAuthorities: {unlocked: {mint, melt}. locked: {mint, melt}}
-   * }
-   *
+   * @param options
+   * @param {string} [options.token_id]
+   * @param {number} [options.count]
+   * @param {number} [options.skip]
+   * @return {Promise<{
+   *   txId:string,
+   *   timestamp:number,
+   *   tokenUid:string,
+   *   balance:number,
+   *   voided:boolean
+   * }[]>} Array of transactions
    * @memberof HathorWallet
    * @inner
    **/
@@ -1187,11 +1187,9 @@ class HathorWallet extends EventEmitter {
    *
    * @param {String} address Output address
    * @param {Number} value Output value
-   * @param {Object} options Options parameters
-   *  {
-   *   'changeAddress': address of the change output
-   *   'token': token uid
-   *  }
+   * @param [options] Options parameters
+   * @param {string} [options.changeAddress] address of the change output
+   * @param {string} [options.token] token uid
    *
    * @return {Promise<Transaction>} Promise that resolves when transaction is sent
    **/

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -745,9 +745,8 @@ const transaction = {
    *  'outputs': ['address', 'value', 'timelock', 'tokenData'],
    * }
    * @param {string} pin Pin to decrypt data
-   * @param {Object} {
-   *   {number} minimumTimestamp Default is 0.
-   * }
+   * @param [options]
+   * @param {number} [options.minimumTimestamp=0] Default is 0
    *
    * @return {Promise}
    * @memberof Transaction


### PR DESCRIPTION
### Summary
The HathorWallet facade currently does not have an event emitter for its state changes. Only pooling is available through the `isReady()` method. This PR adds an event emitter for these state changes.

Some JSDocs were also improved on this PR.

### Motivation
On testing environments pooling is not desirable, since we have potentially dozens of wallets being instantiated in parallel and each test is waiting for the moment it can start interacting with its instance.

Having an event for the wallet ready state allows each test to listen to it and start its assertions as early as possible.

### Acceptance Criteria
- Instances of the HathorWallet class should emit their states on wallet startup

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
