### PR TITLE
refactor: rename minSignatures to numSignatures

### DIFF
--- a/__tests__/new_wallet.test.js
+++ b/__tests__/new_wallet.test.js
@@ -122,7 +122,7 @@ test('Generate new MultiSig wallet', (done) => {
   const xpub1 = walletUtils.getMultiSigXPubFromWords(words1);
   const xpub2 = walletUtils.getMultiSigXPubFromWords(words2);
 
-  const multisigData = {minSignatures: 2, pubkeys: [xpub, xpub1, xpub2]};
+  const multisigData = {numSignatures: 2, pubkeys: [xpub, xpub1, xpub2]};
 
   // Generate new wallet and save data in storage
   const promise = wallet.executeGenerateWallet(words, '', pin, 'password', true, multisigData);
@@ -132,7 +132,7 @@ test('Generate new MultiSig wallet', (done) => {
   check('multisig' in accessData, true, done);
   check('pubkey' in accessData.multisig, true, done);
   check('pubkeys' in accessData.multisig, true, done);
-  check('minSignatures' in accessData.multisig, true, done);
+  check('numSignatures' in accessData.multisig, true, done);
   done();
 
 }, 15000); // 15s to timeout if case done() is not called

--- a/__tests__/utils/wallet.test.js
+++ b/__tests__/utils/wallet.test.js
@@ -410,13 +410,13 @@ test('createP2SHRedeemScript', () => {
     'xpub6ChkMiCikMrqKCQtZqzuVJCnfsaBKMsnTerc1o6XFU6GrZqbG1HqyWsHapksyp8iq68LkzU94fqk6rjzF1NPbKzTL6okbTvFp9GJVhxsZD2',
     'xpub6BvZyQQRCQ37AKuxfTMUWSU929fkqQPwmTbTBSvgq2FSUgbc5FPGYYuv2FzcpBNtE8qyjU7kRktibZrwZ7VgiBTCvJ7B6gE9FKuZr869Rzd',
   ];
-  const minSignatures = 2;
+  const numSignatures = 2;
 
   const redeemScript0 = '5221027105a304d7f3935b64824303687cf96a2400a29a9a69fcfc286a090e71f5acf92102374bba4d4a3d19222db84b5334527fe49e746e3aeac7d18ae14c9ac5a1c1bd0721027892436f6b36eb31edaee157cfa029b1735525626cf7247eb17de5a3db2427ad53ae';
-  expect(wallet.createP2SHRedeemScript(xpubs, minSignatures, 0).toString('hex')).toBe(redeemScript0);
+  expect(wallet.createP2SHRedeemScript(xpubs, numSignatures, 0).toString('hex')).toBe(redeemScript0);
 
   const redeemScript1 = '522103483dd29818452ddcc11eaa04e00a84f0d733102caa1b124b349c7d4e8f6226972103262d9d3d2339298a0fdee45553ca60765a3486c872271dd1b56e6224ee7ec0d621027af464c0c85f656544bb0b34b3e3e525b7b76a9ab9faa3bbec8d0ceeed62647b53ae';
-  expect(wallet.createP2SHRedeemScript(xpubs, minSignatures, 1).toString('hex')).toBe(redeemScript1);
+  expect(wallet.createP2SHRedeemScript(xpubs, numSignatures, 1).toString('hex')).toBe(redeemScript1);
 });
 
 test('getP2SHInputData', () => {
@@ -435,7 +435,7 @@ test('getP2SHInputData', () => {
   expect(wallet.getP2SHInputData([signature, signature], Buffer.from(redeemScript1, 'hex')).toString('hex')).toBe(sig1);
 
   // The script is a Multisig 2/3
-  // Test passing less than minSignatures
+  // Test passing less than numSignatures
   expect(() => wallet.getP2SHInputData([signature], Buffer.from(redeemScript0, 'hex'))).toThrow();
   // Test passing more than maxSignatures
   expect(() => wallet.getP2SHInputData([signature, signature, signature, signature], Buffer.from(redeemScript0, 'hex'))).toThrow();

--- a/__tests__/wallet.test.js
+++ b/__tests__/wallet.test.js
@@ -513,7 +513,7 @@ test('isWalletMultiSig', () => {
 test('executeGenerateWallet multisig', () => {
   const words = 'mutual property noodle reason reform leisure roof foil siren basket decide above offer rate outdoor board input depend sort twenty little veteran code plunge';
   const multisigData = {
-      minSignatures: 2,
+      numSignatures: 2,
       pubkeys: [
         'xpub6BnoFhDySfUAaJQveYx1YvB8YcLdnnGdz19twSXRh6byEfZSWS4ewinKVDVJcvp6m17mAkQiBuhUgytwS561AkyCFXTvSjRXatueS2E4s3K',
         'xpub6ChkMiCikMrqKCQtZqzuVJCnfsaBKMsnTerc1o6XFU6GrZqbG1HqyWsHapksyp8iq68LkzU94fqk6rjzF1NPbKzTL6okbTvFp9GJVhxsZD2',
@@ -815,7 +815,7 @@ test('getAddressAtIndex', () => {
 test('getAddressAtIndex multisig', () => {
   const words = 'mutual property noodle reason reform leisure roof foil siren basket decide above offer rate outdoor board input depend sort twenty little veteran code plunge';
   const multisigData = {
-      minSignatures: 2,
+      numSignatures: 2,
       pubkeys: [
         'xpub6BnoFhDySfUAaJQveYx1YvB8YcLdnnGdz19twSXRh6byEfZSWS4ewinKVDVJcvp6m17mAkQiBuhUgytwS561AkyCFXTvSjRXatueS2E4s3K',
         'xpub6ChkMiCikMrqKCQtZqzuVJCnfsaBKMsnTerc1o6XFU6GrZqbG1HqyWsHapksyp8iq68LkzU94fqk6rjzF1NPbKzTL6okbTvFp9GJVhxsZD2',

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -70,7 +70,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [param.password] Password to encrypt the seed
    * @param {string} [param.pinCode] PIN to execute wallet actions
    * @param {boolean} [param.debug] Activates debug mode
-   * @param {{pubkeys:string[],minSignatures:number}} [param.multisig]
+   * @param {{pubkeys:string[],numSignatures:number}} [param.multisig]
    * @param {string[]} [param.preCalculatedAddresses] An array of pre-calculated addresses
    */
   constructor({
@@ -120,9 +120,9 @@ class HathorWallet extends EventEmitter {
     }
 
     if (multisig) {
-      if (!(multisig.pubkeys && multisig.minSignatures)) {
-        throw Error('Multisig configuration requires both pubkeys and minSignatures.');
-      } else if (multisig.pubkeys.length < multisig.minSignatures) {
+      if (!(multisig.pubkeys && multisig.numSignatures)) {
+        throw Error('Multisig configuration requires both pubkeys and numSignatures.');
+      } else if (multisig.pubkeys.length < multisig.numSignatures) {
         throw Error('Multisig configuration invalid.');
       }
     }
@@ -182,7 +182,7 @@ class HathorWallet extends EventEmitter {
     if (multisig) {
       this.multisig = {
         pubkeys: multisig.pubkeys,
-        minSignatures: multisig.minSignatures,
+        numSignatures: multisig.numSignatures,
       };
     }
   }
@@ -412,7 +412,7 @@ class HathorWallet extends EventEmitter {
         continue;
       }
 
-      const redeemScript = walletUtils.createP2SHRedeemScript(multisigData.pubkeys, multisigData.minSignatures, addressIndex);
+      const redeemScript = walletUtils.createP2SHRedeemScript(multisigData.pubkeys, multisigData.numSignatures, addressIndex);
       const sigs = [];
       for (const p2shSig of p2shSignatures) {
         try {

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -188,7 +188,7 @@ const wallet = {
    *
    * @param {string} xpub Extended public-key to start wallet
    * @param {boolean} loadHistory if should load the history from the generated addresses
-   * @param {object} multisig MultiSig data including minSignatures and xpubs of participants
+   * @param {object} multisig MultiSig data including numSignatures and xpubs of participants
    *
    * @return {Promise} Promise that resolves when finishes loading address history, in case loadHistory = true, else returns null
    * @memberof Wallet
@@ -215,7 +215,7 @@ const wallet = {
    * @param {string} xpriv Extended private-key to start wallet
    * @param {string} pin
    * @param {boolean} loadHistory if should load the history from the generated addresses
-   * @param {object} multisig MultiSig data including minSignatures and xpubs of participants
+   * @param {object} multisig MultiSig data including numSignatures and xpubs of participants
    *
    * @return {Promise} Promise that resolves when finishes loading address history, in case loadHistory = true, else returns null
    * @memberof Wallet
@@ -269,7 +269,7 @@ const wallet = {
    * @param {string} pin
    * @param {string} password
    * @param {boolean} loadHistory if should load the history from the generated addresses
-   * @param {object} multisig MultiSig data including minSignatures and xpubs of participants
+   * @param {object} multisig MultiSig data including numSignatures and xpubs of participants
    *
    * @return {Promise} Promise that resolves when finishes loading address history, in case loadHistory = true, else returns null
    * @memberof Wallet
@@ -488,7 +488,7 @@ const wallet = {
   getAddressMultisig(index) {
     const accessData = this.getWalletAccessData();
     const multisigData = accessData.multisig;
-    const redeemScript = walletUtils.createP2SHRedeemScript(multisigData.pubkeys, multisigData.minSignatures, index);
+    const redeemScript = walletUtils.createP2SHRedeemScript(multisigData.pubkeys, multisigData.numSignatures, index);
     return Address.payingTo(Script.fromBuffer(redeemScript), network.getNetwork());
   },
 


### PR DESCRIPTION
### Acceptance Criteria
- Rename `minSignatures` to `numSignatures`
- Change the requirement of having minimum of (formerly known as) `minSignatures` to only allowing `numSignatures` when creating a P2SH input data.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
