### PR TITLE
chore: bump axios version to v0.21.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1855,12 +1855,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
+        "follow-redirects": "^1.14.0"
       }
     },
     "axios-mock-adapter": {
@@ -2476,14 +2475,6 @@
       "integrity": "sha1-mk30v/FYrC80vGN6vbFUcWB+Flk=",
       "dev": true
     },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -2985,12 +2976,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      }
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3920,11 +3908,6 @@
       "requires": {
         "binary-extensions": "^1.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.1.5",
@@ -5055,7 +5038,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "nan": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "/lib"
   ],
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.21.4",
     "bitcore-lib": "^8.25.10",
     "bitcore-mnemonic": "^8.25.10",
     "crypto-js": "^3.1.9-1",


### PR DESCRIPTION
### Motivation

https://github.com/HathorNetwork/hathor-wallet-lib/pull/258

### Summary

With the list of version downloads below, I will run some tests using our lib with axios upgraded version v0.21.4, since it's the most downloaded lately and it's already a huge jump from our current version.

<img width="818" alt="image" src="https://user-images.githubusercontent.com/3298774/180009839-6612424d-345e-4ff3-8897-0ffb7b3118c6.png">

We should have another issue to do another upgrade to the latest version soon.

Tests executed:

- [x] General tests in the wallet, e.g., load wallet, get transaction data, send transactions.
- [x] Set a user agent.
- [x] Capture a client timeout, in order to continue trying to load history.
- [x] Wallet desktop retry request feature.
- [x] Wallet service integration with mobile.

### Acceptance Criteria
- We should use axios in v0.21.4.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
