### PR TITLE
fix: typo using utxo type

### DIFF
--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -597,8 +597,9 @@ export class PartialTxInputData {
   addSignatures(serialized: string) {
     const arr = serialized.split('|');
     if (arr.length < 2 || arr[0] != PartialTxInputDataPrefix || arr[1] !== this.hash) {
-      // Only the first 2 parts are required
-      // The third onward are the signatures, which can be an empty array
+      // Only the first 2 parts are required, the third onward are the signatures which can be empty
+      // When collecting the input data from atomic-swap participants a participant may not have inputs to sign
+      // allowing the empty input data array case will make this a noop instead of throwing an error.
       throw new SyntaxError('Invalid PartialTxInputData');
     }
     for (const part of arr.slice(2)) {

--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -597,6 +597,8 @@ export class PartialTxInputData {
   addSignatures(serialized: string) {
     const arr = serialized.split('|');
     if (arr.length < 2 || arr[0] != PartialTxInputDataPrefix || arr[1] !== this.hash) {
+      // Only the first 2 parts are required
+      // The third onward are the signatures, which can be an empty array
       throw new SyntaxError('Invalid PartialTxInputData');
     }
     for (const part of arr.slice(2)) {

--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -596,7 +596,7 @@ export class PartialTxInputData {
    */
   addSignatures(serialized: string) {
     const arr = serialized.split('|');
-    if (arr.length < 3 || arr[0] != 'PartialTxInputData' || arr[1] !== this.hash) {
+    if (arr.length < 2 || arr[0] != 'PartialTxInputData' || arr[1] !== this.hash) {
       throw new SyntaxError('Invalid PartialTxInputData');
     }
     for (const part of arr.slice(2)) {

--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -596,7 +596,7 @@ export class PartialTxInputData {
    */
   addSignatures(serialized: string) {
     const arr = serialized.split('|');
-    if (arr.length < 2 || arr[0] != 'PartialTxInputData' || arr[1] !== this.hash) {
+    if (arr.length < 2 || arr[0] != PartialTxInputDataPrefix || arr[1] !== this.hash) {
       throw new SyntaxError('Invalid PartialTxInputData');
     }
     for (const part of arr.slice(2)) {

--- a/src/wallet/partialTxProposal.ts
+++ b/src/wallet/partialTxProposal.ts
@@ -85,7 +85,7 @@ class PartialTxProposal {
         utxo.index,
         utxo.value,
         utxo.address,
-        { token: utxo.token, tokenData: txout.token_data, markAsSelected },
+        { token: utxo.tokenId, tokenData: txout.token_data, markAsSelected },
       );
     }
 


### PR DESCRIPTION
### Acceptance Criteria
- token field is called `tokenId` on `Utxo` type
- allow deserializing `PartialTxInputData` with no signatures

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
