### PR TITLE
chore: protect getAllSignatures method from xpub wallet access

### DIFF
--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import HathorWallet from "../src/new/wallet";
+import { WalletFromXPubGuard } from '../src/errors';
+
+class FakeHathorWallet {
+  constructor() {
+    // Will bind all methods to this instance
+    for (const method of Object.getOwnPropertyNames(HathorWallet.prototype)) {
+        if (method === 'constructor' || !(method && HathorWallet.prototype[method])) {
+            continue;
+        }
+        this[method] = HathorWallet.prototype[method].bind(this);
+    }
+  }
+}
+
+test('Protected xpub wallet methods', async () => {
+  const hWallet = new FakeHathorWallet();
+  hWallet.isFromXPub = () => true;
+  // Validating that methods that require the private key will throw on call
+  await expect(hWallet.consolidateUtxos()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.sendTransaction()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.sendManyOutputsTransaction()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.prepareCreateNewToken()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.prepareMintTokensData()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.prepareMeltTokensData()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.prepareDelegateAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.prepareDestroyAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.getAllSignatures).toThrow(WalletFromXPubGuard);
+});

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -348,6 +348,7 @@ describe('start', () => {
     await expect(hWallet.prepareMeltTokensData()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.prepareDelegateAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.prepareDestroyAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
+    await expect(hWallet.getAllSignatures()).rejects.toThrow(WalletFromXPubGuard);
 
     // Validating that the address generation works as intended
     for (let i=0; i < 21; ++i) {

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -348,7 +348,7 @@ describe('start', () => {
     await expect(hWallet.prepareMeltTokensData()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.prepareDelegateAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.prepareDestroyAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
-    await expect(hWallet.getAllSignatures).toThrow(WalletFromXPubGuard);
+    await expect(() => { hWallet.getAllSignatures() }).toThrow(WalletFromXPubGuard);
 
     // Validating that the address generation works as intended
     for (let i=0; i < 21; ++i) {

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -348,7 +348,7 @@ describe('start', () => {
     await expect(hWallet.prepareMeltTokensData()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.prepareDelegateAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.prepareDestroyAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
-    await expect(hWallet.getAllSignatures()).rejects.toThrow(WalletFromXPubGuard);
+    await expect(hWallet.getAllSignatures).toThrow(WalletFromXPubGuard);
 
     // Validating that the address generation works as intended
     for (let i=0; i < 21; ++i) {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -335,6 +335,9 @@ class HathorWallet extends EventEmitter {
    * @inner
    */
   getAllSignatures(txHex, pin) {
+    if (this.isFromXPub()) {
+      throw new WalletFromXPubGuard('getAllSignatures');
+    }
     storage.setStore(this.store);
     const tx = helpers.createTxFromHex(txHex, this.getNetworkObject());
     const walletData = wallet.getWalletData();


### PR DESCRIPTION
### Acceptance Criteria
- throw error if an xpub wallet calls `getAllSignatures`


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
