### PR TITLE
fix: getTokenDetails should throw if success is false

### DIFF
--- a/__tests__/integration/atomic_swap.test.js
+++ b/__tests__/integration/atomic_swap.test.js
@@ -11,6 +11,7 @@ import { HATHOR_TOKEN_CONFIG } from '../../src/constants';
 import SendTransaction from '../../src/new/sendTransaction';
 import PartialTxProposal from '../../src/wallet/partialTxProposal';
 import storage from '../../src/storage';
+import { delay } from './utils/core.util';
 
 describe('partial tx proposal', () => {
   afterEach(async () => {
@@ -102,6 +103,7 @@ describe('partial tx proposal', () => {
     expect(tx.hash).toBeDefined();
 
     await waitForTxReceived(hWallet1, tx.hash);
+    await delay(1000); // This transaction seems to take longer than usual to complete
 
     // Get the balance states before the exchange
     const w1HTRAfter = await hWallet1.getBalance(HATHOR_TOKEN_CONFIG.uid);

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -2191,7 +2191,7 @@ describe('getToken methods', () => {
     await GenesisWalletHelper.injectFunds(hWallet.getAddressAtIndex(0), 10);
 
     // Validating `getTokenDetails` for custom token not in this wallet
-    expect(hWallet.getTokenDetails(fakeTokenUid)).rejects.toThrow();
+    expect(hWallet.getTokenDetails(fakeTokenUid)).rejects.toThrow('Unknown token');
 
     // Validating `getTokens` for no custom tokens
     let getTokensResponse = await hWallet.getTokens();

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -2191,7 +2191,7 @@ describe('getToken methods', () => {
     await GenesisWalletHelper.injectFunds(hWallet.getAddressAtIndex(0), 10);
 
     // Validating `getTokenDetails` for custom token not in this wallet
-    expect(hWallet.getTokenDetails(fakeTokenUid)).rejects.toThrow('Unknown token');
+    await expect(hWallet.getTokenDetails(fakeTokenUid)).rejects.toThrow('Unknown token');
 
     // Validating `getTokens` for no custom tokens
     let getTokensResponse = await hWallet.getTokens();

--- a/__tests__/token_details.test.js
+++ b/__tests__/token_details.test.js
@@ -17,7 +17,7 @@ jest.mock('../src/api/wallet', () => {
   };
 });
 
-describe('Get token details teta', () => {
+describe('Get token details', () => {
   const hathorWallet = new FakeHathorWallet();
 
   test('Message thrown by token details should be the same received from the API', () => {

--- a/__tests__/token_details.test.js
+++ b/__tests__/token_details.test.js
@@ -1,0 +1,30 @@
+import HathorWallet from '../src/new/wallet';
+
+class FakeHathorWallet {
+  getTokenDetails(...args) {
+    return HathorWallet.prototype.getTokenDetails.call(this, ...args);
+  }
+}
+
+jest.mock('../src/api/wallet', () => {
+  const walletApi = require.requireActual('../src/api/wallet').default;
+
+  return {
+    ...walletApi,
+    getGeneralTokenInfo: () => {
+      throw new Error('Unknown token');
+    },
+  };
+});
+
+describe('Get token details teta', () => {
+  const hathorWallet = new FakeHathorWallet();
+
+  test('Message thrown by token details should be the same received from the API', () => {
+    try {
+      hathorWallet.getTokenDetails('00a19c16466ffa0c2a93b76255d5f85a9df33cdb22c59ac2246c2d6a1497096f');
+    } catch (error) {
+      expect(error.message).toBe('Unknown token');
+    }
+  });
+});

--- a/__tests__/token_details.test.js
+++ b/__tests__/token_details.test.js
@@ -9,27 +9,32 @@ class FakeHathorWallet {
 
 describe('Get token details', () => {
   const hathorWallet = new FakeHathorWallet();
+  const walletApiSpy = jest.spyOn(walletApi, 'getGeneralTokenInfo');
+
+  afterEach(() => {
+    walletApiSpy.mockReset();
+  })
+
+  afterAll(() => {
+    walletApiSpy.mockRestore();
+  })
 
   test('Message thrown by token details should be the same received from the API', async () => {
     expect.assertions(1);
 
-    const walletApiSpy = jest.spyOn(walletApi, 'getGeneralTokenInfo')
-      .mockImplementationOnce(() => {
+    walletApiSpy.mockImplementationOnce(() => {
         throw new Error('Mocked API error');
       });
 
     await expect(hathorWallet.getTokenDetails('tokenUid'))
       .rejects
       .toThrow('Mocked API error');
-
-    walletApiSpy.mockRestore();
   });
 
   test('Should throw when the api results are unsuccessful', async () => {
     expect.assertions(1);
 
-    const walletApiSpy = jest.spyOn(walletApi, 'getGeneralTokenInfo')
-      .mockImplementationOnce((tokenId, resolve) => {
+    walletApiSpy.mockImplementationOnce((tokenId, resolve) => {
         resolve({
           success: false,
           message: 'Mocked non-success message',
@@ -45,15 +50,12 @@ describe('Get token details', () => {
     await expect(hathorWallet.getTokenDetails('tokenUid'))
       .rejects
       .toThrow('Mocked non-success message');
-
-    walletApiSpy.mockRestore();
   });
 
   test('Should return the same values received from the API on success', async () => {
     expect.assertions(1);
 
-    const walletApiSpy = jest.spyOn(walletApi, 'getGeneralTokenInfo')
-      .mockImplementationOnce((tokenId, resolve) => {
+    walletApiSpy.mockImplementationOnce((tokenId, resolve) => {
         resolve({
           success: true,
           name: 'Mocked Name',
@@ -79,8 +81,6 @@ describe('Get token details', () => {
           melt: false,
         },
       })
-
-    walletApiSpy.mockRestore();
   });
 
 });

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2155,6 +2155,10 @@ class HathorWallet extends EventEmitter {
       return walletApi.getGeneralTokenInfo(tokenId, resolve);
     });
 
+    if (!result.success) {
+      throw new Error(result.message);
+    }
+
     const { name, symbol, mint, melt, total, transactions_count } = result;
 
     // Transform to the same format the wallet service facade responds


### PR DESCRIPTION
### Acceptance Criteria
- `getTokenDetails` should throw an error with the message received from the API if `success` is false


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
