### PR TITLE
fix: version on tx history + createAnother on prepareDelegateAuthority

### DIFF
--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -510,3 +510,26 @@ test('onTxArrived', async () => {
     A: { unlocked: 5, locked: 5, transactions: 1 }
   });
 });
+
+test('getTokenHistoryObject', () => {
+  const tx = {
+    tx_id: '00000000000000000de747d135fd7e7b6a918678a41076ab63be751624e8e339',
+    timestamp: 1671025539,
+    version: 3,
+    is_voided: false,
+  };
+
+  const tokenTxBalance = {
+    '00': 0,
+    '01': 5,
+  };
+
+  const historyObj = HathorWallet.getTokenHistoryObject(tx, '00', tokenTxBalance);
+
+  expect(historyObj.txId).toStrictEqual(tx.tx_id);
+  expect(historyObj.timestamp).toStrictEqual(tx.timestamp);
+  expect(historyObj.version).toStrictEqual(tx.version);
+  expect(historyObj.voided).toStrictEqual(tx.is_voided);
+  expect(historyObj.balance['00']).toStrictEqual(0);
+  expect(historyObj.balance['01']).toStrictEqual(5);
+});

--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -499,7 +499,7 @@ test('onTxArrived', async () => {
     inputs: [],
   };
 
-  await hWallet.onTxArrived(tx, false);
+  await hWallet.onTxArrived(tx, true);
 
   expect(hWallet.getPreProcessedData('tokens')).toEqual(['A']);
   expect(hWallet.getPreProcessedData('historyByToken')).toEqual({

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -403,7 +403,7 @@ test('prepareDelegateAuthorityData should fail if type is invalid', async () => 
   })).rejects.toThrowError('Type options are mint and melt for delegate authority method.');
 });
 
-test('prepareDelegateAuthorityData should respect createAnother option and validate pin', async () => {
+test('prepareDelegateAuthorityData should validate options', async () => {
   const addresses = [
     'WdSD7aytFEZ5Hp8quhqu3wUCsyyGqcneMu',
     'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
@@ -468,9 +468,15 @@ test('prepareDelegateAuthorityData should respect createAnother option and valid
   expect(delegate2.outputs).toHaveLength(1);
 
   expect(wallet.prepareDelegateAuthorityData('00', 'mint', addresses[1], {
+    anotherAuthorityAddress: 'invalid-address',
+    createAnother: true,
+    pinCode: '123456',
+  })).rejects.toThrowError('Address invalid-address is not valid.');
+
+  expect(wallet.prepareDelegateAuthorityData('00', 'mint', addresses[1], {
     anotherAuthorityAddress: addresses[2],
     createAnother: false,
-    pinCode: '123456',
+    pinCode: null,
   })).rejects.toThrowError('PIN not specified in prepareDelegateAuthorityData options');
 });
 

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -380,7 +380,30 @@ test('getTxById', async () => {
   await expect(invalidCall).rejects.toThrowError('Error getting transaction by its id.');
 });
 
-test('prepareDelegateAuthorityData should respect createAnother option', async () => {
+test('prepareDelegateAuthorityData should fail if type is invalid', async () => {
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  wallet.setState('Ready');
+
+  // createAnother option should create another authority utxo to the given address
+  expect(wallet.prepareDelegateAuthorityData('00', 'explode', 'addr1', {
+    anotherAuthorityAddress: 'addr2',
+    createAnother: true,
+    pinCode: '123456',
+  })).rejects.toThrowError('Type options are mint and melt for delegate authority method.');
+});
+
+test('prepareDelegateAuthorityData should respect createAnother option and validate pin', async () => {
   const addresses = [
     'WdSD7aytFEZ5Hp8quhqu3wUCsyyGqcneMu',
     'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
@@ -443,6 +466,12 @@ test('prepareDelegateAuthorityData should respect createAnother option', async (
   });
 
   expect(delegate2.outputs).toHaveLength(1);
+
+  expect(wallet.prepareDelegateAuthorityData('00', 'mint', addresses[1], {
+    anotherAuthorityAddress: addresses[2],
+    createAnother: false,
+    pinCode: '123456',
+  })).rejects.toThrowError('PIN not specified in prepareDelegateAuthorityData options');
 });
 
 test('destroyAuthority should throw if wallet is not ready', async () => {

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -380,30 +380,7 @@ test('getTxById', async () => {
   await expect(invalidCall).rejects.toThrowError('Error getting transaction by its id.');
 });
 
-test('prepareDelegateAuthorityData should fail if type is invalid', async () => {
-  const requestPassword = jest.fn();
-  const network = new Network('testnet');
-  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
-  const wallet = new HathorWalletServiceWallet({
-    requestPassword,
-    seed,
-    network,
-    passphrase: '',
-    xpriv: null,
-    xpub: null,
-  });
-
-  wallet.setState('Ready');
-
-  // createAnother option should create another authority utxo to the given address
-  expect(wallet.prepareDelegateAuthorityData('00', 'explode', 'addr1', {
-    anotherAuthorityAddress: 'addr2',
-    createAnother: true,
-    pinCode: '123456',
-  })).rejects.toThrowError('Type options are mint and melt for delegate authority method.');
-});
-
-test('prepareDelegateAuthorityData should validate options', async () => {
+test('prepareDelegateAuthorityData', async () => {
   const addresses = [
     'WdSD7aytFEZ5Hp8quhqu3wUCsyyGqcneMu',
     'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
@@ -480,7 +457,7 @@ test('prepareDelegateAuthorityData should validate options', async () => {
   })).rejects.toThrowError('PIN not specified in prepareDelegateAuthorityData options');
 });
 
-test('destroyAuthority should throw if wallet is not ready', async () => {
+test('prepareDelegateAuthorityData should fail if type is invalid', async () => {
   const requestPassword = jest.fn();
   const network = new Network('testnet');
   const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
@@ -493,9 +470,14 @@ test('destroyAuthority should throw if wallet is not ready', async () => {
     xpub: null,
   });
 
-  expect(wallet.destroyAuthority('00', 'mint', 1, {
+  wallet.setState('Ready');
+
+  // createAnother option should create another authority utxo to the given address
+  expect(wallet.prepareDelegateAuthorityData('00', 'explode', 'addr1', {
+    anotherAuthorityAddress: 'addr2',
+    createAnother: true,
     pinCode: '123456',
-  })).rejects.toThrowError('Wallet not ready');
+  })).rejects.toThrowError('Type options are mint and melt for delegate authority method.');
 });
 
 test('delegateAuthority should throw if wallet is not ready', async () => {
@@ -572,4 +554,22 @@ test('prepareDestroyAuthority', async () => {
   expect(delegate1.outputs).toHaveLength(0);
   expect(delegate1.inputs).toHaveLength(1);
   expect(delegate1.inputs[0].hash).toStrictEqual('002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f');
+});
+
+test('destroyAuthority should throw if wallet is not ready', async () => {
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  expect(wallet.destroyAuthority('00', 'mint', 1, {
+    pinCode: '123456',
+  })).rejects.toThrowError('Wallet not ready');
 });

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -444,3 +444,41 @@ test('prepareDelegateAuthorityData should respect createAnother option', async (
 
   expect(delegate2.outputs).toHaveLength(1);
 });
+
+test('destroyAuthority should throw if wallet is not ready', async () => {
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  expect(wallet.destroyAuthority('00', 'mint', 1, {
+    pinCode: '123456',
+  })).rejects.toThrowError('Wallet not ready');
+});
+
+test('delegateAuthority should throw if wallet is not ready', async () => {
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  expect(wallet.delegateAuthority('00', 'mint', 'address1', {
+    createAnother: false,
+    anotherAuthorityAddress: null,
+    pinCode: '123456',
+  })).rejects.toThrowError('Wallet not ready');
+});

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -20,6 +20,8 @@ import config from '../../src/config';
 import MockAdapter from 'axios-mock-adapter';
 import axiosInstance from '../../src/wallet/api/walletServiceAxios';
 import { buildSuccessTxByIdTokenDataResponse, buildWalletToAuthenticateApiCall, defaultWalletSeed } from '../__fixtures__/wallet.fixtures';
+import Mnemonic from 'bitcore-mnemonic';
+import gWallet from '../../src/wallet';
 
 const MOCK_TX = {
   tx_id: '0009bc9bf8eab19c41a2aa9b9369d3b6a90ff12072729976634890d35788d5d7',
@@ -376,4 +378,69 @@ test('getTxById', async () => {
   const invalidCall = wallet.getTxById('123');
 
   await expect(invalidCall).rejects.toThrowError('Error getting transaction by its id.');
+});
+
+test('prepareDelegateAuthorityData should respect createAnother option', async () => {
+  const addresses = [
+    'WdSD7aytFEZ5Hp8quhqu3wUCsyyGqcneMu',
+    'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
+    'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX',
+  ]
+
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  const code = new Mnemonic(seed);
+  const xpriv = code.toHDPrivateKey('', network.getNetwork());
+
+  wallet.setState('Ready');
+
+  const getUtxosMock = async () => ({
+    utxos: [{
+      txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+      index: 0,
+      tokenId: '00',
+      address: addresses[0],
+      value: 1,
+      authorities: 1,
+      timelock: null,
+      heightlock: null,
+      locked: false,
+      addressPath: 'm/280\'/280\'/0/1/0',
+    }],
+    changeAmount: 4,
+  });
+  const getXprivKeyMock = () => xpriv;
+  const getInputDataMock = () => '';
+
+  jest.spyOn(wallet, 'getUtxos').mockImplementation(getUtxosMock);
+  jest.spyOn(gWallet, 'getXprivKey').mockImplementation(getXprivKeyMock);
+  jest.spyOn(wallet, 'getInputData').mockImplementation(getInputDataMock);
+
+  // createAnother option should create another authority utxo to the given address
+  const delegate1 = await wallet.prepareDelegateAuthorityData('00', 'mint', addresses[1], {
+    anotherAuthorityAddress: addresses[2],
+    createAnother: true,
+    pinCode: '123456',
+  });
+
+  expect(delegate1.outputs).toHaveLength(2);
+
+  // if we don't pass createAnother, we should not create another authority utxo
+  const delegate2 = await wallet.prepareDelegateAuthorityData('00', 'mint', addresses[1], {
+    anotherAuthorityAddress: addresses[2],
+    createAnother: false,
+    pinCode: '123456',
+  });
+
+  expect(delegate2.outputs).toHaveLength(1);
 });

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1135,6 +1135,18 @@ class HathorWallet extends EventEmitter {
     return history;
   }
 
+  /**
+   * Get a formatted TokenHistory object
+   *
+   * @param {Object} tx Full tx object
+   * @param {String} tokenUid The token uid
+   * @param {Object} tokenTxBalance The token balance on this tx
+   *
+   * @return {Object} A formatted TokenHistory object { txId, timestamp, tokenUid, balance, voided, version }
+   *
+   * @memberof HathorWallet
+   * @inner
+   **/
   static getTokenHistoryObject(tx, tokenUid, tokenTxBalance) {
     return {
       txId: tx.tx_id,

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1135,6 +1135,17 @@ class HathorWallet extends EventEmitter {
     return history;
   }
 
+  static getTokenHistoryObject(tx, tokenUid, tokenTxBalance) {
+    return {
+      txId: tx.tx_id,
+      timestamp: tx.timestamp,
+      tokenUid,
+      balance: tokenTxBalance,
+      voided: tx.is_voided,
+      version: tx.version,
+    };
+  }
+
   /**
    * Process the transactions on the websocket transaction queue as if they just arrived.
    *
@@ -1180,14 +1191,7 @@ class HathorWallet extends EventEmitter {
           tokensHistory[tokenUid] = tokenHistory;
         }
         // add this tx to the history of the corresponding token
-        tokenHistory.push({
-          txId: tx.tx_id,
-          timestamp: tx.timestamp,
-          tokenUid,
-          balance: tokenTxBalance,
-          voided: tx.is_voided,
-          version: tx.version,
-        });
+        tokenHistory.push(HathorWallet.getTokenHistoryObject(tx, tokenUid, tokenTxBalance));
       }
 
       const tokensSeen = [];
@@ -1251,14 +1255,7 @@ class HathorWallet extends EventEmitter {
         }
 
         // add this tx to the history of the corresponding token
-        tokenHistory.push({
-          txId: tx.tx_id,
-          timestamp: tx.timestamp,
-          tokenUid,
-          balance: tokenTxBalance,
-          voided: tx.is_voided,
-          version: tx.version,
-        });
+        tokenHistory.push(HathorWallet.getTokenHistoryObject(tx, tokenUid, tokenTxBalance));
 
         // in the end, sort (in place) all tx lists in descending order by timestamp
         tokenHistory.sort((elem1, elem2) => elem2.timestamp - elem1.timestamp);
@@ -1267,14 +1264,7 @@ class HathorWallet extends EventEmitter {
         const txIndex = currentHistory.findIndex((el) => el.tx_id === tx.tx_id);
 
         const newHistory = [...currentHistory];
-        newHistory[txIndex] = {
-          txId: tx.tx_id,
-          timestamp: tx.timestamp,
-          tokenUid,
-          balance: tokenTxBalance,
-          voided: tx.is_voided,
-          version: tx.version,
-        };
+        newHistory[txIndex] = HathorWallet.getTokenHistoryObject(tx, tokenUid, tokenTxBalance);
         tokensHistory[tokenUid] = newHistory;
       }
 

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1186,6 +1186,7 @@ class HathorWallet extends EventEmitter {
           tokenUid,
           balance: tokenTxBalance,
           voided: tx.is_voided,
+          version: tx.version,
         });
       }
 
@@ -1256,6 +1257,7 @@ class HathorWallet extends EventEmitter {
           tokenUid,
           balance: tokenTxBalance,
           voided: tx.is_voided,
+          version: tx.version,
         });
 
         // in the end, sort (in place) all tx lists in descending order by timestamp
@@ -1271,6 +1273,7 @@ class HathorWallet extends EventEmitter {
           tokenUid,
           balance: tokenTxBalance,
           voided: tx.is_voided,
+          version: tx.version,
         };
         tokensHistory[tokenUid] = newHistory;
       }

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -262,7 +262,7 @@ export interface IStopWalletParams {
 
 export interface DelegateAuthorityOptions {
   anotherAuthorityAddress: string | null;
-  createAnother: boolean | null;
+  createAnother: boolean;
   pinCode: string | null;
 };
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -260,6 +260,16 @@ export interface IStopWalletParams {
   cleanStorage?: boolean;
 };
 
+export interface DelegateAuthorityOptions {
+  anotherAuthorityAddress: string | null;
+  createAnother: boolean | null;
+  pinCode: string | null;
+};
+
+export interface DestroyAuthorityOptions {
+  pinCode: string | null;
+}
+
 export interface IHathorWallet {
   start(options: { pinCode: string, password: string }): Promise<void>;
   getAllAddresses(): AsyncGenerator<GetAddressesObject>;
@@ -279,10 +289,30 @@ export interface IHathorWallet {
   mintTokens(token: string, amount: number, options): Promise<Transaction>;
   prepareMeltTokensData(token: string, amount: number, options): Promise<Transaction>;
   meltTokens(token: string, amount: number, options): Promise<Transaction>;
-  prepareDelegateAuthorityData(token: string, type: string, address: string, options): Promise<Transaction>;
-  delegateAuthority(token: string, type: string, address: string, options): Promise<Transaction>;
-  prepareDestroyAuthorityData(token: string, type: string, count: number): Promise<Transaction>;
-  destroyAuthority(token: string, type: string, count: number): Promise<Transaction>;
+  prepareDelegateAuthorityData(
+    token: string,
+    type: string,
+    address: string,
+    options: DelegateAuthorityOptions,
+  ): Promise<Transaction>;
+  delegateAuthority(
+    token: string,
+    type: string,
+    address: string,
+    options: DelegateAuthorityOptions,
+  ): Promise<Transaction>;
+  prepareDestroyAuthorityData(
+    token: string,
+    type: string,
+    count: number,
+    options: DestroyAuthorityOptions,
+  ): Promise<Transaction>;
+  destroyAuthority(
+    token: string, 
+    type: string,
+    count: number,
+    options: DestroyAuthorityOptions,
+  ): Promise<Transaction>;
   getFullHistory(): TransactionFullObject[];
   getTxBalance(tx: WsTransaction, optionsParams): Promise<{[tokenId: string]: number}>;
   onConnectionChangedState(newState: ConnectionState): void;

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -52,6 +52,7 @@ export interface GetHistoryObject {
   balance: number; // Balance of this tx in this wallet (can be negative)
   timestamp: number; // Transaction timestamp
   voided: boolean; // If transaction is voided
+  version: number; // Transaction version
 }
 
 export interface AddressInfoObject {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -60,6 +60,8 @@ import {
   FullNodeVersionData,
   WalletAddressMap,
   TxByIdTokensResponseData,
+  DelegateAuthorityOptions,
+  DestroyAuthorityOptions,
 } from './types';
 import { SendTxError, UtxoError, WalletRequestError, WalletError } from '../errors';
 import { ErrorMessages } from '../errorMessages';
@@ -1515,20 +1517,20 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async prepareDelegateAuthorityData(token: string, type: string, address: string, options = {}): Promise<Transaction> {
+  async prepareDelegateAuthorityData(
+    token: string,
+    type: string,
+    address: string,
+    {
+      anotherAuthorityAddress = null,
+      createAnother = true,
+      pinCode = null,
+    } : DelegateAuthorityOptions,
+  ): Promise<Transaction> {
     this.failIfWalletNotReady();
-    type optionsType = {
-      anotherAuthorityAddress: string | null,
-      createAnother: boolean,
-      pinCode: string | null,
-    };
-    const newOptions: optionsType = Object.assign({
-      anotherAuthorityAddress: null,
-      createAnother: true,
-      pinCode: null,
-    }, options);
 
-    let authority, mask;
+    let authority: number;
+    let mask: number;
     if (type === 'mint') {
       authority = 1;
       mask = TOKEN_MINT_MASK;
@@ -1562,25 +1564,28 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const p2pkhScript = p2pkh.createScript()
     outputsObj.push(new Output(mask, p2pkhScript, {tokenData: AUTHORITY_TOKEN_DATA}));
 
-    if (newOptions.createAnother) {
-      const anotherAddressStr = newOptions.anotherAuthorityAddress || this.getCurrentAddress({ markAsUsed: true }).address;
+    if (createAnother) {
+      const anotherAddressStr = anotherAuthorityAddress
+        || this.getCurrentAddress({ markAsUsed: true }).address;
       const anotherAddress = new Address(anotherAddressStr, {network: this.network});
       if (!anotherAddress.isValid()) {
-        throw new SendTxError(`Address ${newOptions.anotherAuthorityAddress} is not valid.`);
+        throw new SendTxError(`Address ${anotherAuthorityAddress} is not valid.`);
       }
       const p2pkhAnotherAddress = new P2PKH(anotherAddress);
       const p2pkhAnotherAddressScript = p2pkhAnotherAddress.createScript()
-      outputsObj.push(new Output(mask, p2pkhAnotherAddressScript, {tokenData: AUTHORITY_TOKEN_DATA}));
+      outputsObj.push(new Output(mask, p2pkhAnotherAddressScript, {
+        tokenData: AUTHORITY_TOKEN_DATA,
+      }));
     }
 
     const tx = new Transaction(inputsObj, outputsObj);
     tx.tokens = [token];
 
-    if (!newOptions.pinCode) {
+    if (!pinCode) {
       throw new Error('PIN not specified in prepareDelegateAuthorityData options');
     }
 
-    const xprivkey = wallet.getXprivKey(newOptions.pinCode);
+    const xprivkey = wallet.getXprivKey(pinCode);
 
     // Set input data
     const dataToSignHash = tx.getDataToSignHash();
@@ -1592,6 +1597,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     inputsObj[0].setData(inputData);
 
     tx.prepareToSend();
+
     return tx;
   }
 
@@ -1601,7 +1607,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async delegateAuthority(token: string, type: string, address: string, options = {}): Promise<Transaction> {
+  async delegateAuthority(
+    token: string,
+    type: string,
+    address: string,
+    options: DelegateAuthorityOptions,
+  ): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareDelegateAuthorityData(token, type, address, options);
     return this.handleSendPreparedTransaction(tx);
@@ -1613,18 +1624,16 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async prepareDestroyAuthorityData(token: string, type: string, count: number, options = {}): Promise<Transaction> {
+  async prepareDestroyAuthorityData(
+    token: string,
+    type: string,
+    count: number,
+    { pinCode = null }: DestroyAuthorityOptions,
+  ): Promise<Transaction> {
     this.failIfWalletNotReady();
 
-    type optionsType = {
-      pinCode: string | null,
-    };
-
-    const newOptions: optionsType = Object.assign({
-      pinCode: null,
-    }, options);
-
-    let authority, mask;
+    let authority: number;
+    let mask: number;
     if (type === 'mint') {
       authority = 1;
       mask = TOKEN_MINT_MASK;
@@ -1655,11 +1664,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     // Set input data
     const dataToSignHash = tx.getDataToSignHash();
 
-    if (!newOptions.pinCode) {
+    if (!pinCode) {
       throw new Error('PIN not specified in prepareDestroyAuthorityData options');
     }
 
-    const xprivkey = wallet.getXprivKey(newOptions.pinCode);
+    const xprivkey = wallet.getXprivKey(pinCode);
 
     for (const [idx, inputObj] of tx.inputs.entries()) {
       const inputData = this.getInputData(
@@ -1680,7 +1689,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async destroyAuthority(token: string, type: string, count: number, options = {}): Promise<Transaction> {
+  async destroyAuthority(
+    token: string,
+    type: string,
+    count: number,
+    options: DestroyAuthorityOptions,
+  ): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareDestroyAuthorityData(token, type, count, options);
     return this.handleSendPreparedTransaction(tx);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1519,12 +1519,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.failIfWalletNotReady();
     type optionsType = {
       anotherAuthorityAddress: string | null,
-      createAnotherAuthority: boolean,
+      createAnother: boolean,
       pinCode: string | null,
     };
     const newOptions: optionsType = Object.assign({
       anotherAuthorityAddress: null,
-      createAnotherAuthority: true,
+      createAnother: true,
       pinCode: null,
     }, options);
 
@@ -1562,7 +1562,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const p2pkhScript = p2pkh.createScript()
     outputsObj.push(new Output(mask, p2pkhScript, {tokenData: AUTHORITY_TOKEN_DATA}));
 
-    if (newOptions.createAnotherAuthority) {
+    if (newOptions.createAnother) {
       const anotherAddressStr = newOptions.anotherAuthorityAddress || this.getCurrentAddress({ markAsUsed: true }).address;
       const anotherAddress = new Address(anotherAddressStr, {network: this.network});
       if (!anotherAddress.isValid()) {


### PR DESCRIPTION
### Acceptance Criteria
- We should return the `version` attribute on transactions history
- `prepareDelegateAuthority` on the wallet-service facade should expect `createAnother` instead of `createAnotherAuthority` param

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
