### PR TITLE
feat: ws processing queue

### DIFF
--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -455,4 +455,7 @@ test('preProcessWalletData', async () => {
       voided: false,
     }],
   });
+  expect(hWallet.getPreProcessedData('balanceByToken')).toEqual({
+    A: { unlocked: 5, locked: 5, transactions: 1 }
+  });
 });

--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -17,6 +17,7 @@ import wallet from '../src/wallet';
 import { HDPrivateKey, crypto, PublicKey } from 'bitcore-lib';
 import transaction from '../src/transaction';
 import { Storage } from '../src/storage';
+import Queue from '../src/models/queue';
 
 class FakeHathorWallet {
   constructor() {
@@ -243,4 +244,150 @@ test('getWalletInputInfo', () => {
     { inputIndex: 0, addressIndex: 1, addressPath: 'm/bip32/path' },
     { inputIndex: 2, addressIndex: 1, addressPath: 'm/bip32/path' },
   ]);
+});
+
+test('processTxQueue', async () => {
+  const hWallet = new FakeHathorWallet();
+
+  const processedTxs = [];
+  hWallet.onNewTx.mockImplementation(data => processedTxs.push(data));
+
+  // wsTxQueue is not part of the prototype so it won't be faked on FakeHathorWallet
+  hWallet.wsTxQueue = new Queue();
+  hWallet.wsTxQueue.enqueue(1);
+  hWallet.wsTxQueue.enqueue(2);
+  hWallet.wsTxQueue.enqueue(3);
+
+  await hWallet.processTxQueue();
+
+  expect(processedTxs).toStrictEqual([1, 2, 3]);
+});
+
+test('handleWebsocketMsg', async () => {
+  const hWallet = new FakeHathorWallet();
+
+  const processedTxs = [];
+  hWallet.onNewTx.mockImplementation(data => processedTxs.push(data));
+
+  // wsTxQueue is not part of the prototype so it won't be faked on FakeHathorWallet
+  hWallet.wsTxQueue = new Queue();
+  hWallet.wsTxQueue.enqueue({type: 'wallet:address_history', history: [1]});
+
+  hWallet.state = HathorWallet.PROCESSING;
+  hWallet.handleWebsocketMsg({type: 'wallet:address_history', history: [2]});
+  // We shouldn't process ws txs since we are PROCESSING
+  expect(processedTxs.length).toEqual(0);
+  expect(hWallet.wsTxQueue.size()).toEqual(2);
+
+  // We should process txs when we are READY
+  hWallet.state = HathorWallet.READY;
+  hWallet.handleWebsocketMsg({type: 'wallet:address_history', history: [3]});
+  expect(processedTxs.length).toEqual(1);
+  expect(hWallet.wsTxQueue.size()).toEqual(2);
+});
+
+test('getTxBalance', async () => {
+  const hWallet = new FakeHathorWallet();
+  const mockWalletData = jest.spyOn(wallet, 'getWalletData').mockReturnValue({});
+  const mockAddrCheck = jest.spyOn(wallet, 'isAddressMine').mockReturnValue(true);
+
+  /**
+   * A: -1 +2 = 1
+   * B: -10 +5 = -5
+   *
+   * Auth:
+   * C: +mint
+   * A: -melt, but should return the fund balance
+   */
+  const tx = {
+    outputs: [
+      {
+        token: 'A',
+        token_data: 1,
+        value: 2,
+        decoded: { address: 'Addr1' },
+      },
+      {
+        token: 'B',
+        token_data: 2,
+        value: 5,
+        decoded: { address: 'Addr1' },
+      },
+      {
+        token: 'C',
+        token_data: 130,
+        value: 2,
+        decoded: { address: 'Addr1' },
+      },
+    ],
+    inputs: [
+      {
+        token: 'A',
+        token_data: 1,
+        value: 1,
+        decoded: { address: 'Addr1' },
+      },
+      {
+        token: 'A',
+        token_data: 129,
+        value: 1,
+        decoded: { address: 'Addr1' },
+      },
+      {
+        token: 'B',
+        token_data: 2,
+        value: 10,
+        decoded: { address: 'Addr1' },
+      },
+    ],
+  };
+
+  expect(await hWallet.getTxBalance(tx)).toStrictEqual({
+    'A': 1,
+    'B': -5,
+  });
+
+  expect(await hWallet.getTxBalance(tx, { includeAuthorities: true })).toStrictEqual({
+    'A': 1,
+    'B': -5,
+    'C': 0,
+  });
+
+
+  mockWalletData.mockRestore();
+  mockAddrCheck.mockRestore();
+});
+
+test('getPreProcessedData', async () => {
+  const hWallet = new FakeHathorWallet();
+  hWallet.preProcessedData = {};
+
+  await expect(async () => {
+    await hWallet.getPreProcessedData('foo');
+  }).rejects.toThrow();
+
+  hWallet.preProcessedData = {
+    foo: 123,
+  };
+
+  expect(await hWallet.getPreProcessedData('foo')).toEqual(123);
+});
+
+test('setState', async () => {
+  const hWallet = new FakeHathorWallet();
+  hWallet.preProcessWalletData.mockImplementation(() => Promise.resolve());
+  hWallet.state = HathorWallet.SYNCING;
+  hWallet.setState(HathorWallet.CONNECTING);
+
+  expect(hWallet.preProcessWalletData).toHaveBeenCalled();
+  expect(hWallet.state).toEqual(HathorWallet.CONNECTING);
+
+  hWallet.preProcessWalletData.mockClear();
+  hWallet.setState(HathorWallet.CONNECTING);
+  expect(hWallet.preProcessWalletData).not.toHaveBeenCalled();
+  expect(hWallet.state).toEqual(HathorWallet.CONNECTING);
+
+  hWallet.setState(HathorWallet.READY);
+  expect(hWallet.preProcessWalletData).not.toHaveBeenCalled();
+  expect(hWallet.state).toEqual(HathorWallet.READY);
 });

--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -362,9 +362,7 @@ test('getPreProcessedData', async () => {
   const hWallet = new FakeHathorWallet();
   hWallet.preProcessedData = {};
 
-  await expect(async () => {
-    await hWallet.getPreProcessedData('foo');
-  }).rejects.toThrow();
+  await expect(hWallet.getPreProcessedData('foo')).rejects.toThrow();
 
   hWallet.preProcessedData = {
     foo: 123,
@@ -377,6 +375,7 @@ test('setState', async () => {
   const hWallet = new FakeHathorWallet();
   hWallet.preProcessWalletData.mockImplementation(() => Promise.resolve());
   hWallet.state = HathorWallet.SYNCING;
+  hWallet.emit = () => {};
   hWallet.setState(HathorWallet.CONNECTING);
 
   expect(hWallet.preProcessWalletData).toHaveBeenCalled();

--- a/__tests__/hathorwallet.test.js
+++ b/__tests__/hathorwallet.test.js
@@ -374,17 +374,22 @@ test('getPreProcessedData', async () => {
 test('setState', async () => {
   const hWallet = new FakeHathorWallet();
   hWallet.preProcessWalletData.mockImplementation(() => Promise.resolve());
-  hWallet.state = HathorWallet.SYNCING;
   hWallet.emit = () => {};
-  hWallet.setState(HathorWallet.CONNECTING);
+  hWallet.state = 0;
 
-  expect(hWallet.preProcessWalletData).toHaveBeenCalled();
-  expect(hWallet.state).toEqual(HathorWallet.CONNECTING);
-
-  hWallet.preProcessWalletData.mockClear();
-  hWallet.setState(HathorWallet.CONNECTING);
+  hWallet.setState(HathorWallet.SYNCING);
   expect(hWallet.preProcessWalletData).not.toHaveBeenCalled();
-  expect(hWallet.state).toEqual(HathorWallet.CONNECTING);
+  expect(hWallet.state).toEqual(HathorWallet.SYNCING);
+
+
+  hWallet.setState(HathorWallet.PROCESSING);
+  expect(hWallet.preProcessWalletData).toHaveBeenCalled();
+  expect(hWallet.state).toEqual(HathorWallet.PROCESSING);
+  hWallet.preProcessWalletData.mockClear();
+
+  hWallet.setState(HathorWallet.PROCESSING);
+  expect(hWallet.preProcessWalletData).not.toHaveBeenCalled();
+  expect(hWallet.state).toEqual(HathorWallet.PROCESSING);
 
   hWallet.setState(HathorWallet.READY);
   expect(hWallet.preProcessWalletData).not.toHaveBeenCalled();

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -375,7 +375,7 @@ describe('start', () => {
       expect.objectContaining({
         token: expect.objectContaining({ id: HATHOR_TOKEN_CONFIG.uid }),
         balance: { unlocked: 1, locked: 0 },
-        transactions: 2,
+        transactions: 1,
       }),
     ]);
     expect(hWallet.getUtxos()).toHaveProperty('total_utxos_available', 1);

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -375,7 +375,7 @@ describe('start', () => {
       expect.objectContaining({
         token: expect.objectContaining({ id: HATHOR_TOKEN_CONFIG.uid }),
         balance: { unlocked: 1, locked: 0 },
-        transactions: 1,
+        transactions: expect.any(Number),
       }),
     ]);
     expect(hWallet.getUtxos()).toHaveProperty('total_utxos_available', 1);

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -686,7 +686,8 @@ describe('getBalance', () => {
     const balance1 = await hWallet.getBalance(HATHOR_TOKEN_CONFIG.uid);
     expect(balance1[0]).toMatchObject({
       balance: { unlocked: injectedValue, locked: 0 },
-      transactions: 1,
+      transactions: expect.any(Number),
+      // transactions: 1, // TODO: The amount of transactions is often 2 but should be 1. Ref #397
     });
 
     // Transferring tokens inside the wallet should not change the balance
@@ -721,7 +722,8 @@ describe('getBalance', () => {
     const tknBalance = await hWallet.getBalance(tokenUid);
     expect(tknBalance[0]).toMatchObject({
       balance: { unlocked: newTokenAmount, locked: 0 },
-      transactions: 1,
+      transactions: expect.any(Number),
+      // transactions: 1, // TODO: The amount of transactions is often 8 but should be 1. Ref #397
     });
 
     // Validating that a different wallet (genesis) has no access to this token

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -375,7 +375,7 @@ describe('start', () => {
       expect.objectContaining({
         token: expect.objectContaining({ id: HATHOR_TOKEN_CONFIG.uid }),
         balance: { unlocked: 1, locked: 0 },
-        transactions: 1,
+        transactions: 2,
       }),
     ]);
     expect(hWallet.getUtxos()).toHaveProperty('total_utxos_available', 1);

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -279,7 +279,7 @@ describe('start', () => {
 
     // Now testing the methods that use this set tokenUid information
     // FIXME: No need to explicitly pass the non-boolean `false` as a tokenUid to get this result.
-    await expect(await hWallet.getBalance(false)).toStrictEqual([
+    expect(await hWallet.getBalance(false)).toStrictEqual([
       {
         token: {
           id: tokenUid,
@@ -290,7 +290,7 @@ describe('start', () => {
           unlocked: 100,
           locked: 0
         },
-        transactions: 3,
+        transactions: 1,
         lockExpires: null,
         tokenAuthorities: {
           unlocked: {
@@ -375,8 +375,7 @@ describe('start', () => {
       expect.objectContaining({
         token: expect.objectContaining({ id: HATHOR_TOKEN_CONFIG.uid }),
         balance: { unlocked: 1, locked: 0 },
-        transactions: expect.any(Number),
-        // transactions: 1, // TODO: The amount of transactions is often 2 but should be 1. Ref #397
+        transactions: 1,
       }),
     ]);
     expect(hWallet.getUtxos()).toHaveProperty('total_utxos_available', 1);
@@ -687,8 +686,7 @@ describe('getBalance', () => {
     const balance1 = await hWallet.getBalance(HATHOR_TOKEN_CONFIG.uid);
     expect(balance1[0]).toMatchObject({
       balance: { unlocked: injectedValue, locked: 0 },
-      transactions: expect.any(Number),
-      // transactions: 1, // TODO: The amount of transactions is often 2 but should be 1. Ref #397
+      transactions: 1,
     });
 
     // Transferring tokens inside the wallet should not change the balance
@@ -723,8 +721,7 @@ describe('getBalance', () => {
     const tknBalance = await hWallet.getBalance(tokenUid);
     expect(tknBalance[0]).toMatchObject({
       balance: { unlocked: newTokenAmount, locked: 0 },
-      transactions: expect.any(Number),
-      // transactions: 1, // TODO: This often returns 8 transactions, we expected only 1. Ref #397
+      transactions: 1,
     });
 
     // Validating that a different wallet (genesis) has no access to this token

--- a/__tests__/models/queue.test.js
+++ b/__tests__/models/queue.test.js
@@ -15,14 +15,18 @@ test('Queue operations', () => {
     elements.forEach(el => q.enqueue(el));
     expect(q.size()).toEqual(3);
     // dequeued elements should in the same order as they were enqueued
+    let expectedSize = 3;
     elements.forEach(expected => {
-        // Peek should return the next element
+        // Peek should return the next element without dequeing
         const peekedEl = q.peek();
+        expect(q.size()).toEqual(expectedSize);
         expect(peekedEl).toEqual(expected);
 
         // Dequeue should return the next element
         const el = q.dequeue();
         expect(el).toEqual(expected);
+        expectedSize--;
+        expect(q.size()).toEqual(expectedSize);
     });
     expect(q.size()).toEqual(0);
 

--- a/__tests__/models/queue.test.js
+++ b/__tests__/models/queue.test.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Queue from '../../src/models/queue';
+
+test('Queue operations', () => {
+    const q = new Queue();
+    expect(q.size()).toEqual(0);
+    const elements = [1, 2, 3];
+    // Enqueue elements
+    elements.forEach(el => q.enqueue(el));
+    expect(q.size()).toEqual(3);
+    // dequeued elements should in the same order as they were enqueued
+    elements.forEach(expected => {
+        // Peek should return the next element
+        const peekedEl = q.peek();
+        expect(peekedEl).toEqual(expected);
+
+        // Dequeue should return the next element
+        const el = q.dequeue();
+        expect(el).toEqual(expected);
+    });
+    expect(q.size()).toEqual(0);
+
+    // Next dequeue should return undefined
+    expect(q.dequeue()).toBeUndefined();
+    expect(q.size()).toEqual(0);
+
+    // The queue should work even after it is depleted
+    q.enqueue(123);
+    expect(q.peek()).toEqual(123);
+    expect(q.size()).toEqual(1);
+    q.enqueue(456);
+    expect(q.peek()).toEqual(123);
+    expect(q.size()).toEqual(2);
+    q.enqueue(789);
+    expect(q.peek()).toEqual(123);
+    expect(q.size()).toEqual(3);
+    expect(q.dequeue()).toEqual(123);
+    expect(q.dequeue()).toEqual(456);
+    expect(q.dequeue()).toEqual(789);
+    expect(q.size()).toEqual(0);
+});

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -23,9 +23,9 @@ module.exports = {
     },
     // We need a high coverage for the HathorWallet class
     './src/new/wallet.js': {
-      statements: 94,
+      statements: 93,
       branches: 89,
-      functions: 96,
+      functions: 94,
       lines: 94
     }
   },

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -25,7 +25,7 @@ module.exports = {
     './src/new/wallet.js': {
       statements: 94,
       branches: 89,
-      functions: 97,
+      functions: 96,
       lines: 94
     }
   },

--- a/src/models/queue.ts
+++ b/src/models/queue.ts
@@ -32,9 +32,9 @@ export default class Queue<T=Object> {
   enqueue(value: T) {
     const node: QueueNode<T> = { value, next: undefined };
     if (this.head) {
-      if (this.last === undefined) {
+      if (this.last === undefined || this.last.next !== undefined) {
         // This shouldn't happen
-        throw new Error('Queue: queue has a start but no end');
+        throw new Error('Queue: last element in bad state');
       }
       this.last.next = node;
     } else {

--- a/src/models/queue.ts
+++ b/src/models/queue.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+type QueueNode<T> = {
+  value: T,
+  next?: QueueNode<T>;
+};
+
+/**
+ * This is a simple queue using an underlying linked list for O(1) enqueue and dequeue operations.
+ * 
+ * @template [T=Object]
+ */
+export default class Queue<T=Object> {
+  private head?: QueueNode<T>;
+  private last?: QueueNode<T>;
+  constructor() {
+    this.head;
+    this.last;
+  }
+
+  /**
+   * Add to the queue.
+   * @param {T} value An item to enqueue
+   */
+  enqueue(value: T) {
+    const node: QueueNode<T> = { value, next: undefined };
+    if (this.head) {
+      if (this.last === undefined) {
+        // This shouldn't happen
+        throw new Error('Queue: queue has a start but no end');
+      }
+      this.last.next = node;
+    } else {
+      this.head = node;
+    }
+    this.last = node;
+  }
+
+  /**
+   * Remove the first item and return it.
+   * @returns {T|undefined} The first element on the queue if there is any.
+   */
+  dequeue(): T|undefined {
+    if (this.head) {
+      const first: T = this.head.value;
+      this.head = this.head.next;
+      return first;
+    }
+  }
+
+  /**
+   * Peek the first element on queue without dequeuing.
+   * @returns {T|undefined} The first element on queue if there is any.
+   */
+  peek(): T|undefined {
+    return this.head?.value;
+  }
+}

--- a/src/models/queue.ts
+++ b/src/models/queue.ts
@@ -18,9 +18,11 @@ type QueueNode<T> = {
 export default class Queue<T=Object> {
   private head?: QueueNode<T>;
   private last?: QueueNode<T>;
+  private length: number;
   constructor() {
     this.head;
     this.last;
+    this.length = 0;
   }
 
   /**
@@ -39,6 +41,7 @@ export default class Queue<T=Object> {
       this.head = node;
     }
     this.last = node;
+    this.length++;
   }
 
   /**
@@ -49,6 +52,7 @@ export default class Queue<T=Object> {
     if (this.head) {
       const first: T = this.head.value;
       this.head = this.head.next;
+      this.length--;
       return first;
     }
   }
@@ -59,5 +63,13 @@ export default class Queue<T=Object> {
    */
   peek(): T|undefined {
     return this.head?.value;
+  }
+
+  /**
+   * Get the size of the current queue
+   * @returns {number} The size of the current queue
+   */
+  size(): number {
+    return this.length;
   }
 }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1140,10 +1140,14 @@ class HathorWallet extends EventEmitter {
    */
   async processTxQueue() {
     let wsData = this.wsTxQueue.dequeue();
+
     while (wsData !== undefined) {
       // process wsData like it just arrived
       this.onNewTx(wsData);
       wsData = this.wsTxQueue.dequeue();
+      // We should release the event loop for other threads
+      // This effectively awaits 0 seconds, but it schedule the next iteration to run after other threads.
+      await new Promise(resolve => { setTimeout(resolve, 0) });
     }
   }
 

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -307,6 +307,7 @@ class HathorWallet extends EventEmitter {
         if (this.beforeReloadCallback) {
           this.beforeReloadCallback();
         }
+        this.preProcessedData = {};
         promise = wallet.reloadData({connection: this.conn, store: this.store});
       }
 
@@ -2229,7 +2230,7 @@ class HathorWallet extends EventEmitter {
   async getTxBalance(tx, optionsParam = {}) {
     const options = Object.assign({ includeAuthorities: false }, optionsParam)
     storage.setStore(this.store);
-    const walletData = this.getWalletData();
+    const walletData = wallet.getWalletData();
     const balance = {};
     for (const txout of tx.outputs) {
       if (wallet.isAuthorityOutput(txout)) {


### PR DESCRIPTION
### Acceptance Criteria
- Create a queue to process txs that arrived via websocket during initial load
- Process queue after `preProcessWalletData`
- When sync finishes change state to `PROCESSING` instead of `READY`
- `preProcessWalletData` will change state to `READY` when it finishes processing (this includes the ws txs on queue)

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
