### PR TITLE
fix: avoiding a race condition on onOpen and better cleanup of event …

### DIFF
--- a/__tests__/websocket.test.js
+++ b/__tests__/websocket.test.js
@@ -47,3 +47,38 @@ test('Error on ws should emit connection_error event', () => {
 
   WebSocketHandler.ws.onError(new Error('expect-me'));
 })
+
+test('websocket started flag should be set after setup()', () => {
+  const ws = new WS({ wsURL: helpers.getWSServerURL() });
+  ws.WebSocket = WebSocket; // Mocked websocket
+
+  expect(ws.started).toBe(false);
+  ws.setup();
+  expect(ws.started).toBe(true);
+});
+
+test('onOpen event should be ignored if started is false', () => {
+  const ws = new WS({ wsURL: helpers.getWSServerURL() });
+
+  expect(ws.connected).toBe(false);
+  expect(ws.started).toBe(false);
+
+  ws.onOpen();
+
+  expect(ws.connected).toBe(false);
+  expect(ws.started).toBe(false);
+  expect(ws.connectedDate).toBe(null);
+
+  ws.setup();
+
+  expect(ws.connected).toBe(false);
+  expect(ws.started).toBe(true);
+
+  ws.onOpen();
+
+  expect(ws.connected).toBe(true);
+  expect(ws.started).toBe(true);
+  expect(ws.connectedDate).not.toBe(null);
+
+  clearInterval(ws.heartbeat);
+});

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -8,7 +8,6 @@
 import { EventEmitter } from 'events';
 import _WebSocket from 'isomorphic-ws';
 
-const WS_READYSTATE_READY = 1;
 export const DEFAULT_WS_OPTIONS = {
   wsURL: 'wss://node1.mainnet.hathor.network/v1a/',
   heartbeatInterval: 3000,
@@ -272,7 +271,7 @@ abstract class BaseWebSocket extends EventEmitter {
       return;
     }
 
-    if (this.ws.readyState === WS_READYSTATE_READY) {
+    if (this.ws.readyState === _WebSocket.OPEN) {
       this.ws.send(msg);
     } else {
       // If it is still connecting, we wait a little and try again

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -40,9 +40,12 @@ abstract class BaseWebSocket extends EventEmitter {
   private ws: _WebSocket;
   // This is the URL of the websocket.
   private wsURL: string | Function;
-  // Boolean to show when there is a websocket started with the server
+  // Boolean that indicates that the websocket was instantiated. It's important to
+  // notice that it does not indicate that the connection has been established with
+  // the server, which is what the `connected` flag indicates
   private started: boolean;
-  // Boolean to show when the websocket connection is working
+  // Boolean to show when the websocket connection was established with the 
+  // server. This gets set to true on the onOpen event listener.
   private connected: boolean | null;
   // Boolean to show when the websocket is online
   private isOnline: boolean;
@@ -261,6 +264,9 @@ abstract class BaseWebSocket extends EventEmitter {
    * Method called to send a message to the server
    */
   sendMessage(msg: string) {
+    // The started flag means that the websocket instance has been
+    // instantiated, but it does not mean that the connection was 
+    // successful yet, which is what the connected flags indicates.
     if (!this.started || !this.connected) {
       this.setIsOnline(false);
       return;

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -168,6 +168,7 @@ abstract class BaseWebSocket extends EventEmitter {
     }
 
     this.ws = null;
+    this.started = false;
   }
 
   /**

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -135,9 +135,7 @@ abstract class BaseWebSocket extends EventEmitter {
         }
       }
 
-      this.clearWsListeners();
-      this.ws.close();
-      this.ws = null;
+      this.closeWs();
     }
 
     this.ws = new this.WebSocket(wsURL);
@@ -152,17 +150,24 @@ abstract class BaseWebSocket extends EventEmitter {
   }
 
   /**
-   * Remove all event listeners from the WebSocket instance 
+   * Sets all event listeners to noops on the WebSocket instance 
+   * and close it.
    **/
-  clearWsListeners() {
+  closeWs() {
     if (!this.ws) {
       return;
     }
 
-    this.ws.onopen = null;
-    this.ws.onclose = null;
-    this.ws.onerror = null;
-    this.ws.onmessage = null;
+    this.ws.onopen = () => {};
+    this.ws.onclose = () => {};
+    this.ws.onerror = () => {};
+    this.ws.onmessage = () => {};
+
+    if (this.ws.readyState === _WebSocket.OPEN) {
+      this.ws.close();
+    }
+
+    this.ws = null;
   }
 
   /**
@@ -235,11 +240,7 @@ abstract class BaseWebSocket extends EventEmitter {
     this.connected = false;
     this.connectedDate = null;
     this.setIsOnline(false);
-    if (this.ws) {
-      this.clearWsListeners();
-      this.ws.close();
-      this.ws = null;
-    }
+    this.closeWs();
 
     this.clearSetupTimer();
     this.setupTimer = setTimeout(() => this.setup(), this.retryConnectionInterval);
@@ -312,11 +313,7 @@ abstract class BaseWebSocket extends EventEmitter {
     this.setIsOnline(false);
     this.started = false;
     this.connected = null;
-    if (this.ws) {
-      this.clearWsListeners();
-      this.ws.close();
-      this.ws = null;
-    }
+    this.closeWs();
     // @ts-ignore
     clearInterval(this.heartbeat);
   }

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -171,6 +171,7 @@ abstract class BaseWebSocket extends EventEmitter {
 
     this.ws = null;
     this.started = false;
+    this.connected = false;
   }
 
   /**


### PR DESCRIPTION
…listeners

### Acceptance Criteria
- We should only set `this.connected` after onOpen event listener is called and should check it on the `sendMessage` method, to prevent the error described in https://github.com/HathorNetwork/internal-issues/issues/144


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
