### PR TITLE
fix: buffer mandatory parameter

### DIFF
--- a/src/models/p2pkh.ts
+++ b/src/models/p2pkh.ts
@@ -84,11 +84,11 @@ class P2PKH {
    * @inner
    */
   static identify(buf: Buffer): Boolean {
-    const op_greaterthan_timestamp = OP_GREATERTHAN_TIMESTAMP.readUInt8();
-    const op_dup = OP_DUP.readUInt8();
-    const op_hash160 = OP_HASH160.readUInt8();
-    const op_equalverify = OP_EQUALVERIFY.readUInt8();
-    const op_checksig = OP_CHECKSIG.readUInt8();
+    const op_greaterthan_timestamp = OP_GREATERTHAN_TIMESTAMP.readUInt8(0);
+    const op_dup = OP_DUP.readUInt8(0);
+    const op_hash160 = OP_HASH160.readUInt8(0);
+    const op_equalverify = OP_EQUALVERIFY.readUInt8(0);
+    const op_checksig = OP_CHECKSIG.readUInt8(0);
     if (buf.length !== 31 && buf.length !== 25) {
       // this is not a P2PKH script
       return false;

--- a/src/models/p2sh.ts
+++ b/src/models/p2sh.ts
@@ -80,9 +80,9 @@ class P2SH {
    * @inner
    */
   static identify(buf: Buffer): Boolean {
-    const op_greaterthan_timestamp = OP_GREATERTHAN_TIMESTAMP.readUInt8();
-    const op_hash160 = OP_HASH160.readUInt8();
-    const op_equal = OP_EQUAL.readUInt8();
+    const op_greaterthan_timestamp = OP_GREATERTHAN_TIMESTAMP.readUInt8(0);
+    const op_hash160 = OP_HASH160.readUInt8(0);
+    const op_equal = OP_EQUAL.readUInt8(0);
     if (buf.length !== 29 && buf.length !== 23) {
       // this is not a P2PKH script
       return false;

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -61,21 +61,21 @@ export const unpackToInt = (n: number, signed: boolean, buff: Buffer): [number, 
   const slicedBuff = buff.slice(0, n);
   if (n === 1) {
     if (signed) {
-      retInt = slicedBuff.readInt8();
+      retInt = slicedBuff.readInt8(0);
     } else {
-      retInt = slicedBuff.readUInt8();
+      retInt = slicedBuff.readUInt8(0);
     }
   } else if (n === 2) {
     if (signed) {
-      retInt = slicedBuff.readInt16BE();
+      retInt = slicedBuff.readInt16BE(0);
     } else {
-      retInt = slicedBuff.readUInt16BE();
+      retInt = slicedBuff.readUInt16BE(0);
     }
   } else if (n === 4) {
     if (signed) {
-      retInt = slicedBuff.readInt32BE();
+      retInt = slicedBuff.readInt32BE(0);
     } else {
-      retInt = slicedBuff.readUInt32BE();
+      retInt = slicedBuff.readUInt32BE(0);
     }
   } else if (n === 8) {
     // We have only signed ints here
@@ -107,7 +107,7 @@ export const unpackToFloat = (buff: Buffer): [number, Buffer] => {
   const n = 8;
   validateLenToUnpack(n, buff);
 
-  const retFloat = buff.slice(0, n).readDoubleBE();
+  const retFloat = buff.slice(0, n).readDoubleBE(0);
   return [
     retFloat,
     buff.slice(n)

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -399,7 +399,7 @@ const wallet = {
    */
   getP2SHInputData(signatures: Buffer[], redeemScript: Buffer): Buffer {
     // numSignatures is the first opcode
-    const numSignatures = redeemScript.readUInt8() - OP_0.readUInt8();
+    const numSignatures = redeemScript.readUInt8(0) - OP_0.readUInt8(0);
     if (signatures.length !== numSignatures) {
       throw new Error('Signatures are incompatible with redeemScript');
     }


### PR DESCRIPTION
The `offset` parameter is mandatory on the Electron environment for the `readInt__`/`readDouble__` methods on certain conditions.

These conditions happen to us because we have an issue of passing the wrong type of parameter to `unpackToInt` and `unpackToFloat`: instead of Buffers, we're passing them `UInt8Arrays`.

For now, we will just ensure the calls with these parameters don't crash on Electron and keep working as expected, for example, when deserializing an instance of a `PartialTx`.

### Acceptance Criteria
- Every `readInt__` and `readDouble__` method called on the lib should have an `offset` parameter


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
