### PR TITLE
feat: create endpoint to the atomic swap service

### DIFF
--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -1,0 +1,55 @@
+
+import { decryptString, encryptString, hashPassword, create } from '../../../src/wallet/api/swapService'
+import config from '../../../src/config';
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+
+const mockAxiosAdapter = new MockAdapter(axios);
+
+describe('hashing and encrypting', () => {
+  it('should correctly hash a password', () => {
+    const password = '123';
+    const hashedPassword = hashPassword(password);
+
+    expect(hashedPassword).toHaveLength(64);
+  })
+
+  it('should correctly encrypt and decrypt a string', () => {
+    const originalString = 'PartialTx|123123||';
+    const password = 'strongPassword';
+
+    const encryptedString = encryptString(originalString, password);
+    expect(encryptedString.length !== originalString.length).toBe(true);
+
+    const decryptedString = decryptString(encryptedString, password);
+    expect(decryptedString).toStrictEqual(originalString);
+  })
+})
+
+describe('create api', () => {
+
+  it('should throw an error if the backend base URL was not configured', async () => {
+    await expect(create('PartialTx||', 'abc'))
+      .rejects.toThrowError('Swap service base URL not set.');
+  })
+
+  it('should handle backend errors', async () => {
+    config.setSwapServiceBaseUrl('http://mock-swap-url/')
+
+    mockAxiosAdapter.onPost('/').reply(503)
+    await expect(create('PartialTx||', 'abc'))
+      .rejects.toThrowError('Request failed with status code 503');
+  })
+
+  it('should return the backend results on a successful post', async () => {
+    config.setSwapServiceBaseUrl('http://mock-swap-url/')
+
+    const responseData = {
+      success: true,
+      id: 'proposal-id-123'
+    };
+    mockAxiosAdapter.onPost('/').reply(200, responseData)
+    await expect(create('PartialTx||', 'abc'))
+      .resolves.toStrictEqual(responseData)
+  })
+})

--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -26,12 +26,36 @@ describe('hashing and encrypting', () => {
   })
 })
 
-describe('create api', () => {
-
-  it('should throw an error if the backend base URL was not configured', async () => {
-    await expect(create('PartialTx||', 'abc'))
-      .rejects.toThrowError('Swap service base URL not set.');
+describe('base url configuration', () => {
+  it('should throw when no url parameter was offered', () => {
+      expect(() => config.getSwapServiceBaseUrl())
+        .toThrowError('You should either provide a network or call setSwapServiceBaseUrl before calling this.');
   })
+
+  it('should return mainnet address when requested', () => {
+      expect(config.getSwapServiceBaseUrl('mainnet'))
+        .toStrictEqual('https://atomic-swap-service.hathor.network/')
+  })
+
+  it('should return testnet address when requested', () => {
+      expect(config.getSwapServiceBaseUrl('testnet'))
+        .toContain('testnet')
+  })
+
+  it('should throw when an invalid network is requested', () => {
+    // @ts-ignore
+    expect(() => config.getSwapServiceBaseUrl('invalid'))
+      .toThrowError('You should set it explicitly.');
+  })
+
+  it('should return the specified baseURL when it was set', () => {
+    config.setSwapServiceBaseUrl('http://swap-base-url')
+      expect(config.getSwapServiceBaseUrl())
+        .toStrictEqual('http://swap-base-url')
+  })
+})
+
+describe('create api', () => {
 
   it('should handle backend errors', async () => {
     config.setSwapServiceBaseUrl('http://mock-swap-url/')

--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -39,13 +39,13 @@ describe('base url configuration', () => {
 
   it('should return testnet address when requested', () => {
       expect(config.getSwapServiceBaseUrl('testnet'))
-        .toContain('testnet')
+        .toStrictEqual('https://atomic-swap-service.testnet.hathor.network/')
   })
 
   it('should throw when an invalid network is requested', () => {
     // @ts-ignore
     expect(() => config.getSwapServiceBaseUrl('invalid'))
-      .toThrowError('You should set it explicitly.');
+      .toThrowError(`Network invalid doesn't have a correspondent Atomic Swap Service url. You should set it explicitly by calling setSwapServiceBaseUrl.`);
   })
 
   it('should return the specified baseURL when it was set', () => {
@@ -57,11 +57,18 @@ describe('base url configuration', () => {
 
 describe('create api', () => {
 
+  it('should throw missing parameter errors', async () => {
+    // @ts-ignore
+    await expect(create()).rejects.toThrowError('Missing serializedPartialTx');
+    // @ts-ignore
+    await expect(create('PartialTx|0001000000000000000000000063f78c0e0000000000||')).rejects.toThrowError('Missing password');
+  })
+
   it('should handle backend errors', async () => {
     config.setSwapServiceBaseUrl('http://mock-swap-url/')
 
     mockAxiosAdapter.onPost('/').reply(503)
-    await expect(create('PartialTx||', 'abc'))
+    await expect(create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'abc'))
       .rejects.toThrowError('Request failed with status code 503');
   })
 
@@ -73,7 +80,7 @@ describe('create api', () => {
       id: 'proposal-id-123'
     };
     mockAxiosAdapter.onPost('/').reply(200, responseData)
-    await expect(create('PartialTx||', 'abc'))
+    await expect(create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'abc'))
       .resolves.toStrictEqual(responseData)
   })
 })

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ const PushNotification = require('./lib/pushNotification');
 
 const {PartialTx, PartialTxInputData} = require('./lib/models/partial_tx');
 const PartialTxProposal = require('./lib/wallet/partialTxProposal');
+const swapService = require('./lib/wallet/api/swapService');
 
 module.exports = {
   PartialTx,
@@ -96,4 +97,5 @@ module.exports = {
   SendTransactionWalletService: SendTransactionWalletService.default,
   config: config.default,
   PushNotification,
+  swapService: swapService,
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ const TX_MINING_TESTNET_URL = 'https://txmining.testnet.hathor.network/';
 const EXPLORER_SERVICE_MAINNET_BASE_URL  = 'https://explorer-service.hathor.network/';
 const EXPLORER_SERVICE_TESTNET_BASE_URL  = 'https://explorer-service.testnet.hathor.network/';
 
-// Explorer service URL
+// Atomic Swap Service URL
 const SWAP_SERVICE_MAINNET_BASE_URL  = 'https://atomic-swap-service.hathor.network/';
 const SWAP_SERVICE_TESTNET_BASE_URL  = 'https://atomic-swap-service.testnet.hathor.network/';
 
@@ -112,6 +112,8 @@ class Config {
    * If the url was not set in the config, and no network is provided, we throw an Error.
    *
    * @param network - The name of the network to be used to select the url.
+   * @throws {Error} When `network` is not 'mainnet' or 'testnet'
+   * @throws {Error} When `network` is not provided neither by `setSwapServiceBaseUrl` nor parameter
    * @return The Atomic Swap Service url
    */
   getSwapServiceBaseUrl(network?: 'mainnet'|'testnet'): string {
@@ -129,7 +131,7 @@ class Config {
     } else if (network == 'testnet'){
       return SWAP_SERVICE_TESTNET_BASE_URL;
     } else {
-      throw new Error(`Network ${network} doesn't have a correspondent Atomic Swap Service url. You should set it explicitly.`);
+      throw new Error(`Network ${network} doesn't have a correspondent Atomic Swap Service url. You should set it explicitly by calling setSwapServiceBaseUrl.`);
     }
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,17 +105,32 @@ class Config {
   }
 
   /**
-   * Returns the base url for swap service
-   * Throws an error if it is not yet set.
+   * Returns the correct base url constant for the Atomic Swap Service.
+   * If the url was explicitly set using the config object, it is always returned.
+   * Otherwise, we return it based on the provided network parameter.
    *
-   * @return The swap service url
+   * If the url was not set in the config, and no network is provided, we throw an Error.
+   *
+   * @param network - The name of the network to be used to select the url.
+   * @return The Atomic Swap Service url
    */
-  getSwapServiceBaseUrl(): string {
-    if (!this.SWAP_SERVICE_BASE_URL) {
-      throw new GetWalletServiceUrlError('Swap service base URL not set.');
+  getSwapServiceBaseUrl(network?: 'mainnet'|'testnet'): string {
+    if (this.SWAP_SERVICE_BASE_URL) {
+      return this.SWAP_SERVICE_BASE_URL;
     }
 
-    return this.SWAP_SERVICE_BASE_URL;
+    if (!network) {
+      throw new Error('You should either provide a network or call setSwapServiceBaseUrl before calling this.');
+    }
+
+    // Keeps the old behavior for cases that don't explicitly set a SWAP_SERVICE_BASE_URL
+    if (network == 'mainnet') {
+      return SWAP_SERVICE_MAINNET_BASE_URL;
+    } else if (network == 'testnet'){
+      return SWAP_SERVICE_TESTNET_BASE_URL;
+    } else {
+      throw new Error(`Network ${network} doesn't have a correspondent Atomic Swap Service url. You should set it explicitly.`);
+    }
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,9 +16,14 @@ const TX_MINING_TESTNET_URL = 'https://txmining.testnet.hathor.network/';
 const EXPLORER_SERVICE_MAINNET_BASE_URL  = 'https://explorer-service.hathor.network/';
 const EXPLORER_SERVICE_TESTNET_BASE_URL  = 'https://explorer-service.testnet.hathor.network/';
 
+// Explorer service URL
+const SWAP_SERVICE_MAINNET_BASE_URL  = 'https://atomic-swap-service.hathor.network/';
+const SWAP_SERVICE_TESTNET_BASE_URL  = 'https://atomic-swap-service.testnet.hathor.network/';
+
 class Config {
   TX_MINING_URL?: string;
   TX_MINING_API_KEY?: string;
+  SWAP_SERVICE_BASE_URL?: string;
   WALLET_SERVICE_BASE_URL?: string;
   WALLET_SERVICE_BASE_WS_URL?: string;
   EXPLORER_SERVICE_BASE_URL?: string;
@@ -68,7 +73,7 @@ class Config {
 
   /**
    * Gets the configured api key for tx-mining-service
-   * 
+   *
    * @returns The api key
    */
   getTxMiningApiKey(): string | undefined {
@@ -97,6 +102,29 @@ class Config {
     }
 
     return this.WALLET_SERVICE_BASE_URL;
+  }
+
+  /**
+   * Returns the base url for swap service
+   * Throws an error if it is not yet set.
+   *
+   * @return The swap service url
+   */
+  getSwapServiceBaseUrl(): string {
+    if (!this.SWAP_SERVICE_BASE_URL) {
+      throw new GetWalletServiceUrlError('Swap service base URL not set.');
+    }
+
+    return this.SWAP_SERVICE_BASE_URL;
+  }
+
+  /**
+   * Sets the swap service url that will be returned by the config object.
+   *
+   * @param url - The url to be set
+   */
+  setSwapServiceBaseUrl(url: string): void {
+    this.SWAP_SERVICE_BASE_URL = url;
   }
 
   /**

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -67,6 +67,7 @@ const axiosInstance = async (timeout: number = TIMEOUT, network?: 'mainnet'|'tes
  * @param serializedPartialTx
  * @param password
  * @return Promise<{ success: boolean, id: string }>
+ * @throws {Error} When the swap service network is not configured
  * @example
  * const results = await create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'pass123')
  */

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -47,9 +47,10 @@ export function hashPassword(password): string {
 /**
  * Returns an axios instance pre-configured for interacting with the Atomic Swap Service
  * @param [timeout] Optional timeout, defaults to the lib's timeout constant
+ * @param [network] Optional network. If not present, defaults connection to the lib's configured baseUrl
  */
-const axiosInstance = async (timeout: number = TIMEOUT) => {
-  const swapServiceBaseUrl = config.getSwapServiceBaseUrl();
+const axiosInstance = async (timeout: number = TIMEOUT, network?: 'mainnet'|'testnet') => {
+  const swapServiceBaseUrl = config.getSwapServiceBaseUrl(network);
   const defaultOptions = {
     baseURL: swapServiceBaseUrl,
     timeout: timeout,

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import config from "../../config";
+import axios from "axios";
+import { TIMEOUT, } from '../../constants';
+import sha256 from 'crypto-js/sha256';
+import AES from 'crypto-js/aes';
+import CryptoJS from 'crypto-js';
+
+/**
+ * Encrypts a string ( PartialTx or Signatures ) before sending it to the backend
+ * @param serialized
+ * @param password
+ */
+export function encryptString(serialized: string, password: string): string {
+  const aesEncryptedObject = AES.encrypt(serialized, password);
+
+  // Serializing the cipher output in Base64 to avoid loss of encryption parameter data
+  const baseEncryptedObj = CryptoJS.enc.Base64.parse(aesEncryptedObject.toString());
+  return CryptoJS.enc.Base64.stringify(baseEncryptedObj);
+}
+
+/**
+ * Decrypts a string ( PartialTx or Signatures ) from the backend
+ * @param serialized
+ * @param password
+ */
+export function decryptString(serialized: string, password: string): string {
+  const aesDecryptedObject = AES.decrypt(serialized, password);
+  return aesDecryptedObject.toString(CryptoJS.enc.Utf8);
+}
+
+/**
+ * Hashes the password to use it as an authentication on the backend
+ * @param {string} password
+ * @returns {string} hashed password
+ */
+export function hashPassword(password): string {
+  return sha256(password).toString();
+}
+
+/**
+ * Returns an axios instance pre-configured for interacting with the Atomic Swap Service
+ * @param [timeout] Optional timeout, defaults to the lib's timeout constant
+ */
+const axiosInstance = async (timeout: number = TIMEOUT) => {
+  const swapServiceBaseUrl = config.getSwapServiceBaseUrl();
+  const defaultOptions = {
+    baseURL: swapServiceBaseUrl,
+    timeout: timeout,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  };
+
+  return axios.create(defaultOptions);
+};
+
+/**
+ * Calls the Atomic Swap Service requesting the creation of a new proposal identifier for the informed partialTx.
+ * @param serializedPartialTx
+ * @param password
+ */
+export const create = async (serializedPartialTx: string, password: string) => {
+  const swapAxios = await axiosInstance();
+  const payload = {
+    partialTx: encryptString(serializedPartialTx, password),
+    authPassword: hashPassword(password),
+  };
+
+  const { data } = await swapAxios.post<{ success: boolean, id: string }>('/', payload);
+  return data;
+};

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -66,8 +66,18 @@ const axiosInstance = async (timeout: number = TIMEOUT, network?: 'mainnet'|'tes
  * Calls the Atomic Swap Service requesting the creation of a new proposal identifier for the informed partialTx.
  * @param serializedPartialTx
  * @param password
+ * @return Promise<{ success: boolean, id: string }>
+ * @example
+ * const results = await create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'pass123')
  */
 export const create = async (serializedPartialTx: string, password: string) => {
+  if (!serializedPartialTx) {
+    throw new Error('Missing serializedPartialTx')
+  }
+  if (!password) {
+    throw new Error('Missing password')
+  }
+
   const swapAxios = await axiosInstance();
   const payload = {
     partialTx: encryptString(serializedPartialTx, password),


### PR DESCRIPTION
Implements the initial code for communication with the Atomic Swap Service.

### Acceptance Criteria
- Hashing and encrypting all data before sending it over to the Atomic Swap Service
- Only the `create` endpoint will be interacted with

### Note
No integration tests will be implemented at this stage, as there is no readily available image of the Atomic Swap Service to be added to the `docker-compose.yml` structure necessary for them.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
