### PR TITLE
feat: Swap Service `get`

### DIFF
--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -157,4 +157,38 @@ describe('get api', () => {
     const resolvedData = await get('b4a5b077-c599-41e8-a791-85e08efcb1da', password);
     expect(resolvedData).toStrictEqual(responseData)
   })
+
+  it('should correctly parse the history', async () => {
+    const originalPartialTx = 'PartialTx|0001000000000000000000000063f78c0e0000000000||';
+    const password = 'abc';
+    const encryptedPartialTx = encryptString(originalPartialTx, password);
+
+    config.setSwapServiceBaseUrl('http://mock-swap-url/')
+    const rawHttpBody = {
+      id: 'b4a5b077-c599-41e8-a791-85e08efcb1da',
+      partialTx: encryptedPartialTx,
+      signatures: null,
+      timestamp: 'Wed Mar 01 2023 18:56:00 GMT-0300 (Brasilia Standard Time)',
+      version: 0,
+      history: [{
+        partialTx: encryptedPartialTx,
+        timestamp: 'Wed Fev 01 2023 18:56:00 GMT-0300 (Brasilia Standard Time)'
+      }]
+    }
+
+    const responseData = {
+      proposalId: 'b4a5b077-c599-41e8-a791-85e08efcb1da',
+      partialTx: originalPartialTx,
+      signatures: null,
+      timestamp: 'Wed Mar 01 2023 18:56:00 GMT-0300 (Brasilia Standard Time)',
+      version: 0,
+      history: [{
+        partialTx: originalPartialTx,
+        timestamp: 'Wed Fev 01 2023 18:56:00 GMT-0300 (Brasilia Standard Time)'
+      }]
+    };
+    mockAxiosAdapter.onGet('/b4a5b077-c599-41e8-a791-85e08efcb1da').reply(200, rawHttpBody)
+    const resolvedData = await get('b4a5b077-c599-41e8-a791-85e08efcb1da', password);
+    expect(resolvedData).toStrictEqual(responseData)
+  })
 })

--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -103,6 +103,34 @@ describe('get api', () => {
       .rejects.toThrowError('Request failed with status code 503');
   })
 
+  it('should throw if the password cannot decode the proposal', async () => {
+    const originalPartialTx = 'PartialTx|0001000000000000000000000063f78c0e0000000000||';
+    const password = 'abc';
+    const incorrectPassword = 'bcd';
+
+    config.setSwapServiceBaseUrl('http://mock-swap-url/')
+    const rawHttpBody = {
+      id: 'b4a5b077-c599-41e8-a791-85e08efcb1da',
+      partialTx: encryptString(originalPartialTx, password),
+      signatures: null,
+      timestamp: 'Wed Mar 01 2023 18:56:00 GMT-0300 (Brasilia Standard Time)',
+      version: 0,
+      history: []
+    }
+
+    const responseData = {
+      proposalId: 'b4a5b077-c599-41e8-a791-85e08efcb1da',
+      partialTx: originalPartialTx,
+      signatures: null,
+      timestamp: 'Wed Mar 01 2023 18:56:00 GMT-0300 (Brasilia Standard Time)',
+      version: 0,
+      history: []
+    };
+    mockAxiosAdapter.onGet('/b4a5b077-c599-41e8-a791-85e08efcb1da').reply(200, rawHttpBody)
+    await expect(get('b4a5b077-c599-41e8-a791-85e08efcb1da', incorrectPassword))
+      .rejects.toThrowError('Incorrect password: could not decode the proposal');
+  })
+
   it('should return the backend results on a successful request', async () => {
     const originalPartialTx = 'PartialTx|0001000000000000000000000063f78c0e0000000000||';
     const password = 'abc';

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -81,3 +81,15 @@ export interface Authority {
   mint: number;
   melt: number;
 }
+
+/**
+ * A backend-mediated Atomic Swap proposal, containing backend metadata such as id, version and history
+ */
+export interface AtomicSwapProposal {
+  proposalId: string,
+  partialTx: string,
+  signatures: string | null,
+  timestamp: string,
+  version: number,
+  history: { partialTx: string, timestamp: string }[]
+}

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -6,11 +6,25 @@
  */
 
 import config from "../../config";
-import axios from "axios";
+import axios, { AxiosRequestConfig } from "axios";
 import { TIMEOUT, } from '../../constants';
 import sha256 from 'crypto-js/sha256';
 import AES from 'crypto-js/aes';
 import CryptoJS from 'crypto-js';
+import { AtomicSwapProposal } from "../../models/types";
+
+/**
+ * This interface represents the type returned on the HTTP response, with its untreated and encrypted data.
+ * The results should be translated to an `AtomicSwapProposal` interface before being sent out of this service.
+ */
+interface RawBackendProposal {
+  id: string,
+  partialTx: string,
+  signatures: string | null,
+  timestamp: string,
+  version: number,
+  history: { partialTx: string, timestamp: string }[]
+}
 
 /**
  * Encrypts a string ( PartialTx or Signatures ) before sending it to the backend
@@ -31,6 +45,12 @@ export function encryptString(serialized: string, password: string): string {
  * @param password
  */
 export function decryptString(serialized: string, password: string): string {
+  if (!serialized) {
+    throw new Error('Missing encrypted string');
+  }
+  if (!password) {
+    throw new Error('Missing password');
+  }
   const aesDecryptedObject = AES.decrypt(serialized, password);
   return aesDecryptedObject.toString(CryptoJS.enc.Utf8);
 }
@@ -87,4 +107,43 @@ export const create = async (serializedPartialTx: string, password: string) => {
 
   const { data } = await swapAxios.post<{ success: boolean, id: string }>('/', payload);
   return data;
+};
+
+/**
+ * Fetches from the Atomic Swap Service the most up-to-date version of the proposal by the given id
+ * and decrypts it locally
+ * @throws {Error} When the swap service network is not configured
+ * @param proposalId
+ * @param password
+ * @example
+ * const results = await create('b4a5b077-c599-41e8-a791-85e08efcb1da', 'pass123')
+ */
+export const get = async (proposalId: string, password: string): Promise<AtomicSwapProposal> => {
+  if (!proposalId) {
+    throw new Error('Missing proposalId');
+  }
+  if (!password) {
+    throw new Error('Missing password');
+  }
+
+  const swapAxios = await axiosInstance();
+  const options = {
+    headers: { 'X-Auth-Password': hashPassword(password) }
+  } as AxiosRequestConfig;
+
+  const { data } = await swapAxios.get<RawBackendProposal>(`/${proposalId}`, options);
+  // TODO: Implement a way to idenfity if the password is incorrect
+
+  const decryptedData: AtomicSwapProposal = {
+    proposalId: data.id,
+    version: data.version,
+    timestamp: data.timestamp,
+    partialTx: decryptString(data.partialTx, password),
+    signatures: data.signatures ? decryptString(data.signatures, password) : null,
+    history: data.history.map(r => ({
+      partialTx: decryptString(r.partialTx, password),
+      timestamp: r.timestamp,
+    }))
+  };
+  return decryptedData;
 };

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -12,6 +12,7 @@ import sha256 from 'crypto-js/sha256';
 import AES from 'crypto-js/aes';
 import CryptoJS from 'crypto-js';
 import { AtomicSwapProposal } from "../../models/types";
+import { PartialTxPrefix } from '../../models/partial_tx';
 
 /**
  * This interface represents the type returned on the HTTP response, with its untreated and encrypted data.
@@ -132,7 +133,6 @@ export const get = async (proposalId: string, password: string): Promise<AtomicS
   } as AxiosRequestConfig;
 
   const { data } = await swapAxios.get<RawBackendProposal>(`/${proposalId}`, options);
-  // TODO: Implement a way to idenfity if the password is incorrect
 
   const decryptedData: AtomicSwapProposal = {
     proposalId: data.id,
@@ -145,5 +145,10 @@ export const get = async (proposalId: string, password: string): Promise<AtomicS
       timestamp: r.timestamp,
     }))
   };
+
+  // If the PartialTx does not have the correct prefix, it was not correctly decoded
+  if (!decryptedData.partialTx.startsWith(PartialTxPrefix)) {
+    throw new Error('Incorrect password: could not decode the proposal');
+  }
   return decryptedData;
 };


### PR DESCRIPTION
Continuation of the Atomic Swap Service integration started on #464 

### Acceptance Criteria
- The lib should interact with the `get` endpoint on the Atomic Swap Service
- All original data should be correctly decrypted on returning the data to the client

### Note
No integration tests will be implemented at this stage, as there is no readily available image of the Atomic Swap Service to be added to the `docker-compose.yml` structure necessary for them.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
