### PR TITLE
fix: client apps should access default swap urls

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -17,8 +17,8 @@ const EXPLORER_SERVICE_MAINNET_BASE_URL  = 'https://explorer-service.hathor.netw
 const EXPLORER_SERVICE_TESTNET_BASE_URL  = 'https://explorer-service.testnet.hathor.network/';
 
 // Atomic Swap Service URL
-const SWAP_SERVICE_MAINNET_BASE_URL  = 'https://atomic-swap-service.hathor.network/';
-const SWAP_SERVICE_TESTNET_BASE_URL  = 'https://atomic-swap-service.testnet.hathor.network/';
+export const SWAP_SERVICE_MAINNET_BASE_URL  = 'https://atomic-swap-service.hathor.network/';
+export const SWAP_SERVICE_TESTNET_BASE_URL  = 'https://atomic-swap-service.testnet.hathor.network/';
 
 class Config {
   TX_MINING_URL?: string;


### PR DESCRIPTION
The current implementation requires the client applications to duplicate the `mainnet` and `testnet` urls on their codes if one decides to use the `setSwapServiceBaseUrl` method for URL configuration.

This change makes the lib's default values available for them.

### Acceptance Criteria
- Default Atomic Swap Service URLs should be exported


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
