### PR TITLE
chore: bump 0.46.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Library used by Hathor Wallet",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Acceptance Criteria
- Bump to v0.46.1
- Integration with the Atomic Swap Service backend: `get` endpoint
- Exports Atomic Swap Service default urls for mainnet and testnet


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
