### PR TITLE
feat: swap service `update`

### DIFF
--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -266,7 +266,9 @@ describe('update api', () => {
 
   it('should throw missing parameter errors', async () => {
     // @ts-ignore
-    await expect(update()).rejects.toThrowError('proposalId');
+    await expect(update()).rejects.toThrowError('Missing mandatory parameters');
+    // @ts-ignore
+    await expect(update({})).rejects.toThrowError('proposalId');
     // @ts-ignore
     await expect(update({
       proposalId: 'abc',

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -185,9 +185,10 @@ interface SwapUpdateParams {
 /**
  * Updates the proposal on the Atomic Swap Service with the parameters informed
  */
-export const update = async ({proposalId, password, partialTx, version, signatures}: SwapUpdateParams):
+export const update = async (params: SwapUpdateParams):
   Promise<{ success: boolean }> => {
   validateParameters();
+  const { proposalId, password, partialTx, version, signatures } = params;
 
   const swapAxios = await axiosInstance();
   const options = {
@@ -209,6 +210,11 @@ export const update = async ({proposalId, password, partialTx, version, signatur
    * @throws {Error} if any version parameter is invalid
    */
   function validateParameters() {
+    if (!params) {
+      throw new Error(`Missing mandatory parameters.`);
+    }
+
+    const { proposalId, password, partialTx, version } = params;
     // Checking for missing parameters
     const missingParameters: String[] = [];
     if (!proposalId) {
@@ -224,7 +230,7 @@ export const update = async ({proposalId, password, partialTx, version, signatur
       missingParameters.push('version');
     }
     if (missingParameters.length > 0) {
-      throw new Error(`Missing mandatory parameters: ${missingParameters.join(', ')}`)
+      throw new Error(`Missing mandatory parameters: ${missingParameters.join(', ')}`);
     }
 
     // Checking for invalid parameters

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -187,7 +187,9 @@ interface SwapUpdateParams {
  */
 export const update = async (params: SwapUpdateParams):
   Promise<{ success: boolean }> => {
+  // Validates the input parameters and throws in case of errors
   validateParameters();
+
   const { proposalId, password, partialTx, version, signatures } = params;
 
   const swapAxios = await axiosInstance();

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -172,3 +172,37 @@ export const get = async (proposalId: string, password: string): Promise<AtomicS
     throw err;
   }
 };
+
+interface SwapUpdateParams {
+  proposalId: string;
+  password: string;
+  partialTx: string;
+  version: number;
+  signatures?: string;
+}
+
+/**
+ * Updates the proposal on the Atomic Swap Service with the parameters informed
+ * @param proposalId
+ * @param password
+ * @param partialTx
+ * @param version
+ * @param [signatures]
+ */
+export const update = async ({proposalId, password, partialTx, version, signatures}: SwapUpdateParams):
+  Promise<{ success: boolean }> => {
+  const swapAxios = await axiosInstance();
+  const options = {
+    headers: { 'X-Auth-Password': hashPassword(password) }
+  } as AxiosRequestConfig;
+
+  const payload = {
+    partialTx,
+    version,
+    signatures,
+  };
+
+  const { data } = await swapAxios.put<{ success: boolean }>(`/${proposalId}`, payload, options);
+  return { success: data?.success };
+};
+


### PR DESCRIPTION
Continuation of the Atomic Swap Service integration started on #464 and #468 

### Acceptance Criteria
- The lib should interact with the `update` endpoint on the Atomic Swap Service
- All original data should be correctly encrypted on sending the data to the backend

### Note
No integration tests will be added at this stage, as there is no readily available image of the Atomic Swap Service to be added to the `docker-compose.yml` structure necessary for them.
A partial implementation of these tests, however, is available on branch [`feat/swap-service-integration`](https://github.com/HathorNetwork/hathor-wallet-lib/tree/feat/swap-service-integration) ( [diff with `dev`](https://github.com/HathorNetwork/hathor-wallet-lib/compare/dev...feat/swap-service-integration?expand=1) ) and can be executed on a local environment by running the Atomic Swap Service directly from the source code.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
