### PR TITLE
feat: leveldb filter locked utxos

### DIFF
--- a/__tests__/storage/leveldb/leveldb_store.test.js
+++ b/__tests__/storage/leveldb/leveldb_store.test.js
@@ -236,9 +236,8 @@ test('token methods', async () => {
 });
 
 test('utxo methods', async () => {
-  const currDate = new Date('2020-01-01T00:00:00.000Z');
-  const dateLocked = new Date('2020-03-01T00:00:00.000Z');
-  jest.useFakeTimers().setSystemTime(currDate);
+  const dateLocked = new Date('3000-03-01T12:00');
+
   const xpriv = HDPrivateKey();
   const store = new LevelDBStore(DATA_DIR, xpriv.xpubkey);
   const utxos = [
@@ -276,8 +275,9 @@ test('utxo methods', async () => {
       height: null,
     },
   ];
-  await store.saveUtxo(utxos[0]);
-  await store.saveUtxo(utxos[1]);
+  for (const u of utxos) {
+    await store.saveUtxo(u);
+  }
   let buf = [];
   for await (const u of store.utxoIter()) {
     buf.push(u);

--- a/__tests__/storage/leveldb/leveldb_store.test.js
+++ b/__tests__/storage/leveldb/leveldb_store.test.js
@@ -236,6 +236,9 @@ test('token methods', async () => {
 });
 
 test('utxo methods', async () => {
+  const currDate = new Date('2020-01-01T00:00:00.000Z');
+  const dateLocked = new Date('2020-03-01T00:00:00.000Z');
+  jest.useFakeTimers().setSystemTime(currDate);
   const xpriv = HDPrivateKey();
   const store = new LevelDBStore(DATA_DIR, xpriv.xpubkey);
   const utxos = [
@@ -261,6 +264,17 @@ test('utxo methods', async () => {
       type: 1,
       height: null,
     },
+    {
+      txId: 'tx03',
+      index: 40,
+      token: '00',
+      address: 'WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp',
+      value: 100,
+      authorities: 0,
+      timelock: Math.floor(dateLocked.getTime() / 1000),
+      type: 1,
+      height: null,
+    },
   ];
   await store.saveUtxo(utxos[0]);
   await store.saveUtxo(utxos[1]);
@@ -268,11 +282,18 @@ test('utxo methods', async () => {
   for await (const u of store.utxoIter()) {
     buf.push(u);
   }
-  expect(buf).toHaveLength(2);
+  expect(buf).toHaveLength(3);
 
   // Default values will filter for HTR token
   buf = [];
   for await (const u of store.selectUtxos({})) {
+    buf.push(u);
+  }
+  expect(buf).toHaveLength(2);
+
+  // only_available_utxos should filter locked utxos
+  buf = [];
+  for await (const u of store.selectUtxos({ only_available_utxos: true })) {
     buf.push(u);
   }
   expect(buf).toHaveLength(1);

--- a/__tests__/utils/transaction.test.js
+++ b/__tests__/utils/transaction.test.js
@@ -286,7 +286,7 @@ test('canUseUtxo', async () => {
   const isSelSpy = jest.spyOn(storage, 'isUtxoSelectedAsInput').mockReturnValue(Promise.resolve(false));
   storage.version = { reward_spend_min_blocks: 5 };
 
-  jest.useFakeTimers()
+  jest.useFakeTimers();
   jest.setSystemTime(t3);
 
   // Free tx, in both timelock, heightlock and not selected as input


### PR DESCRIPTION
### Acceptance Criteria
- filter for locked utxos only if `only_available_utxos` is true
- filter for timelocks on leveldb


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
