### PR TITLE
chore: deprecate node12 ci actions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,10 +18,10 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -33,14 +33,14 @@ jobs:
 
       - name: Upload debug transaction logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-transacion-logs
           path: tmp
 
       - name: Collect docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v1
+        uses: jwalton/gh-docker-logs@v2
         with:
           dest: './docker-logs'
       - name: Tar logs


### PR DESCRIPTION
### Motivation

Github is deprecating the CI actions versions that use node12 and showing warnings since node12 reached its EOL on april 2022.

- [github changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- [ref to EOL in MS updates](https://azure.microsoft.com/en-us/updates/node12/#:~:text=On%2030%20April%202022%2C%20extended,workloads%20will%20not%20be%20impacted.)

### Acceptance Criteria
- Upgrade the actions to the most recent version (which uses node16)

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
