### PR TITLE
chore: pin 3rd party actions to full commit sha

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Collect docker logs on failure
         if: failure()
-        uses: jwalton/gh-docker-logs@v2
+        # pinned jwalton/gh-docker-logs@v2.2.1 to its commit sha
+        # https://github.com/jwalton/gh-docker-logs/releases/tag/v2.2.1
+        uses: jwalton/gh-docker-logs@59c9656cd3cb7542525f3dce7ae2f44c0ff85d66
         with:
           dest: './docker-logs'
       - name: Tar logs

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -18,10 +18,12 @@ jobs:
         node-version: [14.x, 16.x]
 
     steps:
-      - uses: actions/checkout@v3
+        # https://github.com/actions/checkout/releases/tag/v3.5.0
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        # https://github.com/actions/setup-node/releases/tag/v3.6.0
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -33,14 +35,14 @@ jobs:
 
       - name: Upload debug transaction logs
         if: always()
-        uses: actions/upload-artifact@v3
+        # https://github.com/actions/upload-artifact/releases/tag/v3.1.2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: test-transacion-logs
           path: tmp
 
       - name: Collect docker logs on failure
         if: failure()
-        # pinned jwalton/gh-docker-logs@v2.2.1 to its commit sha
         # https://github.com/jwalton/gh-docker-logs/releases/tag/v2.2.1
         uses: jwalton/gh-docker-logs@59c9656cd3cb7542525f3dce7ae2f44c0ff85d66
         with:
@@ -50,7 +52,8 @@ jobs:
         run: tar cvzf ./docker-logs.tgz ./docker-logs
       - name: Upload logs to GitHub
         if: failure()
-        uses: actions/upload-artifact@v2
+        # https://github.com/actions/upload-artifact/releases/tag/v3.1.2
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: logs.tgz
           path: ./docker-logs.tgz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,11 @@ jobs:
       matrix:
         node-version: [12.x, 14.x]
     steps:
-    - uses: actions/checkout@v2
+      # https://github.com/actions/checkout/releases/tag/v3.5.0
+    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      # https://github.com/actions/setup-node/releases/tag/v3.6.0
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
@@ -30,7 +32,8 @@ jobs:
     - name: Test
       run: npm run test
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      # https://github.com/codecov/codecov-action/releases/tag/v3.1.1
+      uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
       if: ${{ matrix.node-version }} == 14.x
       with:
         verbose: true


### PR DESCRIPTION
### Acceptance Criteria
- Pin github actions version to the commit sha as suggested by github security docs


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
