### PR TITLE
fix: allow providing pinCode when sending transaction with HathorWalletServiceWallet

### DIFF
--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -18,6 +18,15 @@ import config from '../../src/config';
 import { buildSuccessTxByIdTokenDataResponse, buildWalletToAuthenticateApiCall, defaultWalletSeed } from '../__mock_helpers/wallet-service.fixtures';
 import Mnemonic from 'bitcore-mnemonic';
 import { TxNotFoundError } from '../../src/errors';
+import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
+
+// Mock SendTransactionWalletService class so we don't try to send actual transactions
+// TODO: We should refactor the way we use classes from inside other classes. Using dependency injection would facilitate unit tests a lot and avoid mocks like this.
+jest.mock('../../src/wallet/sendTransactionWalletService', () => {
+  return jest.fn().mockImplementation(() => {
+    return {run: () => {}};
+  });
+});
 
 const MOCK_TX = {
   tx_id: '0009bc9bf8eab19c41a2aa9b9369d3b6a90ff12072729976634890d35788d5d7',
@@ -717,4 +726,24 @@ test('instantiate a new wallet without web socket initialization', async () => {
   expect(spyOnGetNewAddress).toBeCalledTimes(1);
   expect(spyOnSetupConnection).toBeCalledTimes(0);
   expect(wallet.isReady()).toBeTruthy();
-})
+});
+
+test('sendTransaction', async () => {
+  // Initialize wallet
+  const wallet = buildWalletToAuthenticateApiCall();
+  jest.spyOn(wallet, 'isReady').mockReturnValue(true);
+
+  // Send transaction
+  await wallet.sendTransaction('WYLW8ujPemSuLJwbeNvvH6y7nakaJ6cEwT', 10, { pinCode: "1234" });
+
+  // Assertions
+  expect(SendTransactionWalletService).toHaveBeenCalledWith(
+    expect.any(HathorWalletServiceWallet),
+    {
+      "changeAddress": null,
+      "inputs": [],
+      "outputs": [{"address": "WYLW8ujPemSuLJwbeNvvH6y7nakaJ6cEwT", "token": "00", "type": "p2pkh", "value": 10}],
+      "pin": "1234"
+    }
+  );
+});

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1165,6 +1165,7 @@ class HathorWallet extends EventEmitter {
    * @param [options] Options parameters
    * @param {string} [options.changeAddress] address of the change output
    * @param {string} [options.token] token uid
+   * @param {string} [options.pinCode] pin to decrypt the private key
    *
    * @return {Promise<Transaction>} Promise that resolves when transaction is sent
    **/
@@ -1176,9 +1177,9 @@ class HathorWallet extends EventEmitter {
       token: '00',
       changeAddress: null
     }, options);
-    const { token, changeAddress } = newOptions;
+    const { token, changeAddress, pinCode } = newOptions;
     const outputs = [{ address, value, token }];
-    return this.sendManyOutputsTransaction(outputs, { inputs: [], changeAddress });
+    return this.sendManyOutputsTransaction(outputs, { inputs: [], changeAddress, pinCode });
   }
 
   /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -111,7 +111,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   private indexToUse: number;
   // WalletService-ready connection class
   private conn: WalletServiceConnection;
-  // Flag to indicate if the wallet was already connected when the webscoket conn is established
+  // Flag to indicate if the wallet was already connected when the websocket conn is established
   private firstConnection: boolean;
   // Flag to indicate if the websocket connection is enabled
   private readonly _isWsEnabled: boolean;
@@ -885,13 +885,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async sendManyOutputsTransaction(outputs: Array<OutputRequestObj | DataScriptOutputRequestObj>, options: { inputs?: InputRequestObj[], changeAddress?: string } = {}): Promise<Transaction> {
+  async sendManyOutputsTransaction(outputs: Array<OutputRequestObj | DataScriptOutputRequestObj>, options: { inputs?: InputRequestObj[], changeAddress?: string, pinCode?: string } = {}): Promise<Transaction> {
     this.failIfWalletNotReady();
     const newOptions = Object.assign({
       inputs: [],
       changeAddress: null
     }, options);
-    const { inputs, changeAddress } = newOptions;
+    const { inputs, changeAddress, pinCode } = newOptions;
     const sendTransactionOutputs = outputs.map((output) => {
       let typedOutput = output as OutputSendTransaction;
       if (typedOutput.type === OutputType.DATA) {
@@ -903,7 +903,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
       return typedOutput;
     });
-    const sendTransaction = new SendTransactionWalletService(this, { outputs: sendTransactionOutputs, inputs, changeAddress });
+    const sendTransaction = new SendTransactionWalletService(this, { outputs: sendTransactionOutputs, inputs, changeAddress, pin: pinCode });
     return sendTransaction.run();
   }
 
@@ -913,15 +913,15 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async sendTransaction(address: string, value: number, options: { token?: string, changeAddress?: string } = {}): Promise<Transaction> {
+  async sendTransaction(address: string, value: number, options: { token?: string, changeAddress?: string, pinCode?: string } = {}): Promise<Transaction> {
     this.failIfWalletNotReady();
     const newOptions = Object.assign({
       token: '00',
       changeAddress: null
     }, options);
-    const { token, changeAddress } = newOptions;
+    const { token, changeAddress, pinCode } = newOptions;
     const outputs = [{ address, value, token }];
-    return this.sendManyOutputsTransaction(outputs, { inputs: [], changeAddress });
+    return this.sendManyOutputsTransaction(outputs, { inputs: [], changeAddress, pinCode });
   }
 
   /**


### PR DESCRIPTION
### Acceptance Criteria
- We should allow providing the pinCode in the `HathorWalletServiceWallet's sendTransaction` method. Otherwise, we would get an error of missing pinCode when trying to send a transaction with this method in a wallet that uses a pin code.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
