### PR TITLE
feat: add new parameter to set mint/melt authority address when minting/melting tokens

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1675,7 +1675,10 @@ describe('mintTokens', () => {
       .rejects.toThrow('must belong to your wallet');
 
     // Mint tokens with external address but allowing it
-    const mintResponse4 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress, allowExternalMintAuthorityAddress: true });
+    const mintResponse4 = await hWallet.mintTokens(tokenUid, 100, {
+      mintAuthorityAddress: externalAddress,
+      allowExternalMintAuthorityAddress: true
+    });
     expect(mintResponse4.hash).toBeDefined();
     await waitForTxReceived(hWallet, mintResponse4.hash);
 
@@ -1820,7 +1823,10 @@ describe('meltTokens', () => {
       .rejects.toThrow('must belong to your wallet');
 
     // Melt tokens with external address but allowing it
-    const meltResponse3 = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress, allowExternalMeltAuthorityAddress: true });
+    const meltResponse3 = await hWallet.meltTokens(tokenUid, 100, {
+      meltAuthorityAddress: externalAddress,
+      allowExternalMeltAuthorityAddress: true
+    });
     await waitForTxReceived(hWallet, meltResponse3.hash);
 
     // Validating a new melt authority was created by default

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1672,10 +1672,7 @@ describe('mintTokens', () => {
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
     await expect(hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress }))
-      .rejects.toStrictEqual({
-        success: false,
-        message: expect.stringContaining('must belong to your wallet'),
-      });
+      .rejects.toThrow('must belong to your wallet');
 
     // Mint tokens with external address but allowing it
     const mintResponse4 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress, allowExternalMintAuthorityAddress: true });
@@ -1820,10 +1817,7 @@ describe('meltTokens', () => {
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
     await expect(hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress }))
-      .rejects.toStrictEqual({
-        success: false,
-        message: expect.stringContaining('must belong to your wallet'),
-      });
+      .rejects.toThrow('must belong to your wallet');
 
     // Melt tokens with external address but allowing it
     const meltResponse3 = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress, allowExternalMeltAuthorityAddress: true });

--- a/__tests__/models/address.test.js
+++ b/__tests__/models/address.test.js
@@ -58,9 +58,10 @@ test('Address getType', () => {
 test('Address script', () => {
   const addr = new Address('wcFwC82mLoUudtgakZGMPyTL2aHcgSJgDZ');
   const p2sh = new P2SH(addr);
-  expect(addr.getScript()).toBe(p2sh.createScript());
+  expect(addr.getScript()).toStrictEqual(p2sh.createScript());
 
+  const mainnetNetwork = new Network('mainnet')
   const addr2 = new Address('HNBUHhzkVuSFUNW21HrajUFNUiX8JrznSb', {network: mainnetNetwork});
   const p2pkh = new P2PKH(addr2);
-  expect(addr2.getScript()).toBe(p2pkh.createScript());
+  expect(addr2.getScript()).toStrictEqual(p2pkh.createScript());
 });

--- a/__tests__/models/address.test.js
+++ b/__tests__/models/address.test.js
@@ -7,6 +7,8 @@
 
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
+import P2PKH from '../../src/models/p2pkh';
+import P2SH from '../../src/models/p2sh';
 
 
 test('Validate address', () => {
@@ -51,4 +53,14 @@ test('Address getType', () => {
   // Mainnet p2sh
   const addr4 = new Address('hXRpjKbgVVGF1ioYtscCRavnzvGbsditXn', {network: mainnetNetwork});
   expect(addr4.getType()).toBe('p2sh');
+});
+
+test('Address script', () => {
+  const addr = new Address('wcFwC82mLoUudtgakZGMPyTL2aHcgSJgDZ');
+  const p2sh = new P2SH(addr);
+  expect(addr.getScript()).toBe(p2sh.createScript());
+
+  const addr2 = new Address('HNBUHhzkVuSFUNW21HrajUFNUiX8JrznSb', {network: mainnetNetwork});
+  const p2pkh = new P2PKH(addr2);
+  expect(addr2.getScript()).toBe(p2pkh.createScript());
 });

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -17,7 +17,7 @@ import {
 import config from '../../src/config';
 import { buildSuccessTxByIdTokenDataResponse, buildWalletToAuthenticateApiCall, defaultWalletSeed } from '../__mock_helpers/wallet-service.fixtures';
 import Mnemonic from 'bitcore-mnemonic';
-import { TxNotFoundError } from '../../src/errors';
+import { TxNotFoundError, SendTxError } from '../../src/errors';
 import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
 import transaction from '../../src/utils/transaction';
 import { TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
@@ -448,7 +448,15 @@ test('prepareMintTokens', async () => {
   const spy2 = jest.spyOn(wallet.storage, 'getMainXPrivKey').mockReturnValue(Promise.resolve(xpriv.xprivkey));
   const spy3 = jest.spyOn(wallet, 'getInputData').mockImplementation(getInputDataMock);
 
-  // createAnother option should create another authority utxo to the given address
+  // error because of wrong authority output address
+  await expect(wallet.prepareMintTokensData('01', 100, {
+    address: addresses[1],
+    createAnotherMint: true,
+    mintAuthorityAddress: 'abc',
+    pinCode: '123456',
+  })).rejects.toThrowError(SendTxError);
+
+  // mint data with correct address for authority output
   const mintData = await wallet.prepareMintTokensData('01', 100, {
     address: addresses[1],
     createAnotherMint: true,
@@ -540,7 +548,15 @@ test('prepareMeltTokens', async () => {
   const spy2 = jest.spyOn(wallet.storage, 'getMainXPrivKey').mockReturnValue(Promise.resolve(xpriv.xprivkey));
   const spy3 = jest.spyOn(wallet, 'getInputData').mockImplementation(getInputDataMock);
 
-  // createAnother option should create another authority utxo to the given address
+  // error because of wrong authority output address
+  await expect(wallet.prepareMeltTokensData('01', 1, {
+    address: addresses[1],
+    createAnotherMelt: true,
+    meltAuthorityAddress: 'abc',
+    pinCode: '123456',
+  })).rejects.toThrowError(SendTxError);
+
+  // melt data with correct address for authority output
   const meltData = await wallet.prepareMeltTokensData('01', 1, {
     address: addresses[1],
     createAnotherMelt: true,

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -19,6 +19,8 @@ import { buildSuccessTxByIdTokenDataResponse, buildWalletToAuthenticateApiCall, 
 import Mnemonic from 'bitcore-mnemonic';
 import { TxNotFoundError } from '../../src/errors';
 import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
+import transaction from '../../src/utils/transaction';
+import { TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
 
 // Mock SendTransactionWalletService class so we don't try to send actual transactions
 // TODO: We should refactor the way we use classes from inside other classes. Using dependency injection would facilitate unit tests a lot and avoid mocks like this.
@@ -379,6 +381,190 @@ test('getTxById', async () => {
   const invalidCall = wallet.getTxById('123');
 
   await expect(invalidCall).rejects.toThrowError('Error getting transaction by its id.');
+});
+
+test('prepareMintTokens', async () => {
+  const addresses = [
+    'WdSD7aytFEZ5Hp8quhqu3wUCsyyGqcneMu',
+    'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
+    'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX',
+  ]
+
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  const code = new Mnemonic(seed);
+  const xpriv = code.toHDPrivateKey('', network.getNetwork());
+
+  wallet.setState('Ready');
+
+  const getUtxosMock = async (params) => {
+    if (params.tokenId === '00') {
+      return {
+        utxos: [{
+          txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5d',
+          index: 0,
+          tokenId: '00',
+          address: addresses[0],
+          value: 1,
+          authorities: 0,
+          timelock: null,
+          heightlock: null,
+          locked: false,
+          addressPath: 'm/280\'/280\'/0/1/0',
+        }],
+        changeAmount: 0,
+      };
+    } else {
+      return {
+        utxos: [{
+          txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+          index: 0,
+          tokenId: '01',
+          address: addresses[0],
+          value: 1,
+          authorities: TOKEN_MINT_MASK,
+          timelock: null,
+          heightlock: null,
+          locked: false,
+          addressPath: 'm/280\'/280\'/0/1/0',
+        }],
+        changeAmount: 0,
+      };
+    }
+  };
+  const getInputDataMock = (xp: string, dtsh: Buffer) => Buffer.alloc(0);
+
+  const spy1 = jest.spyOn(wallet, 'getUtxos').mockImplementation(getUtxosMock);
+  const spy2 = jest.spyOn(wallet.storage, 'getMainXPrivKey').mockReturnValue(Promise.resolve(xpriv.xprivkey));
+  const spy3 = jest.spyOn(wallet, 'getInputData').mockImplementation(getInputDataMock);
+
+  // createAnother option should create another authority utxo to the given address
+  const mintData = await wallet.prepareMintTokensData('01', 100, {
+    address: addresses[1],
+    createAnotherMint: true,
+    mintAuthorityAddress: addresses[2],
+    pinCode: '123456',
+  });
+
+  expect(mintData.outputs).toHaveLength(2);
+
+  const authorityOutputs = mintData.outputs.filter(
+    o => transaction.isAuthorityOutput({ token_data: o.tokenData })
+  );
+
+  expect(authorityOutputs).toHaveLength(1);
+  const authorityOutput = authorityOutputs[0];
+  expect(authorityOutput.value).toEqual(TOKEN_MINT_MASK);
+  const p2pkh = authorityOutput.parseScript(network);
+  // Validate that the authority output was sent to the correct address
+  expect(p2pkh.address.base58).toEqual(addresses[2]);
+
+  // Clear mocks
+  spy1.mockRestore();
+  spy2.mockRestore();
+  spy3.mockRestore();
+});
+
+test('prepareMeltTokens', async () => {
+  const addresses = [
+    'WdSD7aytFEZ5Hp8quhqu3wUCsyyGqcneMu',
+    'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
+    'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX',
+  ]
+
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
+  const wallet = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    xpriv: null,
+    xpub: null,
+  });
+
+  const code = new Mnemonic(seed);
+  const xpriv = code.toHDPrivateKey('', network.getNetwork());
+
+  wallet.setState('Ready');
+
+  const getUtxosMock = async (params) => {
+    if (params.authority === TOKEN_MELT_MASK) {
+      return {
+        utxos: [{
+          txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+          index: 0,
+          tokenId: '01',
+          address: addresses[0],
+          value: 1,
+          authorities: TOKEN_MELT_MASK,
+          timelock: null,
+          heightlock: null,
+          locked: false,
+          addressPath: 'm/280\'/280\'/0/1/0',
+        }],
+        changeAmount: 0,
+      };
+    } else {
+      return {
+        utxos: [{
+          txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5d',
+          index: 0,
+          tokenId: '01',
+          address: addresses[0],
+          value: 1,
+          authorities: 0,
+          timelock: null,
+          heightlock: null,
+          locked: false,
+          addressPath: 'm/280\'/280\'/0/1/0',
+        }],
+        changeAmount: 0,
+      };
+    }
+  };
+  const getInputDataMock = (xp: string, dtsh: Buffer) => Buffer.alloc(0);
+
+  const spy1 = jest.spyOn(wallet, 'getUtxos').mockImplementation(getUtxosMock);
+  const spy2 = jest.spyOn(wallet.storage, 'getMainXPrivKey').mockReturnValue(Promise.resolve(xpriv.xprivkey));
+  const spy3 = jest.spyOn(wallet, 'getInputData').mockImplementation(getInputDataMock);
+
+  // createAnother option should create another authority utxo to the given address
+  const meltData = await wallet.prepareMeltTokensData('01', 1, {
+    address: addresses[1],
+    createAnotherMelt: true,
+    meltAuthorityAddress: addresses[2],
+    pinCode: '123456',
+  });
+
+  expect(meltData.outputs).toHaveLength(1);
+
+  const authorityOutputs = meltData.outputs.filter(
+    o => transaction.isAuthorityOutput({ token_data: o.tokenData })
+  );
+
+  expect(authorityOutputs).toHaveLength(1);
+  const authorityOutput = authorityOutputs[0];
+  expect(authorityOutput.value).toEqual(TOKEN_MELT_MASK);
+  const p2pkh = authorityOutput.parseScript(network);
+  // Validate that the authority output was sent to the correct address
+  expect(p2pkh.address.base58).toEqual(addresses[2]);
+
+  // Clear mocks
+  spy1.mockRestore();
+  spy2.mockRestore();
+  spy3.mockRestore();
 });
 
 test('prepareDelegateAuthorityData', async () => {

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -390,6 +390,13 @@ test('prepareMintTokens', async () => {
     'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX',
   ]
 
+  mockAxiosAdapter.onPost('wallet/addresses/check_mine').reply(200, {
+    success: true,
+    addresses: {
+      'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX': true,
+    },
+  });
+
   const requestPassword = jest.fn();
   const network = new Network('testnet');
   const seed = 'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';
@@ -456,6 +463,15 @@ test('prepareMintTokens', async () => {
     pinCode: '123456',
   })).rejects.toThrowError(SendTxError);
 
+  // error because of wrong authority output address
+  await expect(wallet.prepareMintTokensData('01', 100, {
+    address: addresses[1],
+    createAnotherMint: true,
+    mintAuthorityAddress: 'abc',
+    allowExternalMintAuthorityAddress: true,
+    pinCode: '123456',
+  })).rejects.toThrowError(SendTxError);
+
   // mint data with correct address for authority output
   const mintData = await wallet.prepareMintTokensData('01', 100, {
     address: addresses[1],
@@ -489,6 +505,13 @@ test('prepareMeltTokens', async () => {
     'WbjNdAGBWAkCS2QVpqmacKXNy8WVXatXNM',
     'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX',
   ]
+
+  mockAxiosAdapter.onPost('wallet/addresses/check_mine').reply(200, {
+    success: true,
+    addresses: {
+      'WR1i8USJWQuaU423fwuFQbezfevmT4vFWX': true,
+    },
+  });
 
   const requestPassword = jest.fn();
   const network = new Network('testnet');
@@ -553,6 +576,15 @@ test('prepareMeltTokens', async () => {
     address: addresses[1],
     createAnotherMelt: true,
     meltAuthorityAddress: 'abc',
+    pinCode: '123456',
+  })).rejects.toThrowError(SendTxError);
+
+  // error because of wrong authority output address
+  await expect(wallet.prepareMeltTokensData('01', 1, {
+    address: addresses[1],
+    createAnotherMelt: true,
+    meltAuthorityAddress: 'abc',
+    allowExternalMeltAuthorityAddress: true,
     pinCode: '123456',
   })).rejects.toThrowError(SendTxError);
 

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -30,6 +30,8 @@ jest.mock('../../src/wallet/sendTransactionWalletService', () => {
   });
 });
 
+const addressPath = 'm/280\'/280\'/0/1/0';
+
 const MOCK_TX = {
   tx_id: '0009bc9bf8eab19c41a2aa9b9369d3b6a90ff12072729976634890d35788d5d7',
   nonce: 194,
@@ -427,7 +429,7 @@ test('prepareMintTokens', async () => {
           timelock: null,
           heightlock: null,
           locked: false,
-          addressPath: 'm/280\'/280\'/0/1/0',
+          addressPath,
         }],
         changeAmount: 0,
       };
@@ -443,7 +445,7 @@ test('prepareMintTokens', async () => {
           timelock: null,
           heightlock: null,
           locked: false,
-          addressPath: 'm/280\'/280\'/0/1/0',
+          addressPath,
         }],
         changeAmount: 0,
       };
@@ -543,7 +545,7 @@ test('prepareMeltTokens', async () => {
           timelock: null,
           heightlock: null,
           locked: false,
-          addressPath: 'm/280\'/280\'/0/1/0',
+          addressPath,
         }],
         changeAmount: 0,
       };
@@ -559,7 +561,7 @@ test('prepareMeltTokens', async () => {
           timelock: null,
           heightlock: null,
           locked: false,
-          addressPath: 'm/280\'/280\'/0/1/0',
+          addressPath,
         }],
         changeAmount: 0,
       };
@@ -650,7 +652,7 @@ test('prepareDelegateAuthorityData', async () => {
       timelock: null,
       heightlock: null,
       locked: false,
-      addressPath: 'm/280\'/280\'/0/1/0',
+      addressPath,
     }],
     changeAmount: 4,
   });
@@ -774,7 +776,7 @@ test('prepareDestroyAuthority', async () => {
       timelock: null,
       heightlock: null,
       locked: false,
-      addressPath: 'm/280\'/280\'/0/1/0',
+      addressPath,
     }],
     changeAmount: 4,
   });

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -8,6 +8,8 @@
 import { AddressError } from '../errors';
 import { encoding, util } from 'bitcore-lib';
 import Network from './network';
+import P2PKH from './p2pkh';
+import P2SH from './p2sh';
 import _ from 'lodash';
 import helpers from '../utils/helpers';
 
@@ -123,6 +125,29 @@ class Address {
       return 'p2sh';
     } else {
       throw new AddressError('Invalid address type.');
+    }
+  }
+
+  /**
+   * Get address script
+   *
+   * Will get the type of the address (p2pkh or p2sh)
+   * then create the script
+   *
+   * @throws {AddressError} Will throw an error if address is not valid
+   *
+   * @return {Buffer}
+   * @memberof Address
+   * @inner
+   */
+  getScript(): Buffer {
+    const addressType = this.getType();
+    if (addressType === 'p2pkh') {
+      const p2pkh = new P2PKH(this);
+      return p2pkh.createScript();
+    } else {
+      const p2sh = new P2SH(this);
+      return p2sh.createScript();
     }
   }
 }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1661,7 +1661,7 @@ class HathorWallet extends EventEmitter {
 
     if (newOptions.meltAuthorityAddress && !newOptions.allowExternalMeltAuthorityAddress) {
       // Validate that the melt authority address belongs to the wallet
-      const isAddressMine = this.isAddressMine(newOptions.meltAuthorityAddress);
+      const isAddressMine = await this.isAddressMine(newOptions.meltAuthorityAddress);
       if (!isAddressMine) {
         throw new Error('The melt authority address must belong to your wallet.');
       }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1530,6 +1530,7 @@ class HathorWallet extends EventEmitter {
    *   'startMiningTx': boolean to trigger start mining (default true)
    *   'createAnotherMint': boolean to create another mint authority or not for the wallet
    *   'mintAuthorityAddress': address to send the new mint authority created
+   *   'allowExternalMintAuthorityAddress': boolean allow the mint authority address to be from another wallet (default false)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
    *
@@ -1548,12 +1549,21 @@ class HathorWallet extends EventEmitter {
       changeAddress: null,
       createAnotherMint: true,
       mintAuthorityAddress: null,
+      allowExternalMintAuthorityAddress: false,
       pinCode: null,
     }, options);
 
     const pin = newOptions.pinCode || this.pinCode;
     if (!pin) {
       throw new Error(ERROR_MESSAGE_PIN_REQUIRED);
+    }
+
+    if (newOptions.mintAuthorityAddress && !newOptions.allowExternalMintAuthorityAddress) {
+      // Validate that the mint authority address belongs to the wallet
+      const isAddressMine = await this.isAddressMine(newOptions.mintAuthorityAddress);
+      if (!isAddressMine) {
+        throw new Error('The mint authority address must belong to your wallet.');
+      }
     }
 
     const mintAddress = newOptions.address || (await this.getCurrentAddress()).address;
@@ -1594,6 +1604,8 @@ class HathorWallet extends EventEmitter {
    * @param {boolean} [options.createAnotherMint] boolean to create another mint authority or not
    *                                              for the wallet
    * @param {string} [options.mintAuthorityAddress] address to send the new mint authority created
+   * @param {boolean} [options.allowExternalMintAuthorityAddress=false] allow the mint authority address
+   *                                                                    to be from another wallet
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this
    *
@@ -1619,6 +1631,7 @@ class HathorWallet extends EventEmitter {
    *   'changeAddress': address of the change output
    *   'createAnotherMelt': boolean to create another melt authority or not for the wallet
    *   'meltAuthorityAddress': address to send the new melt authority created
+   *   'allowExternalMeltAuthorityAddress': boolean allow the melt authority address to be from another wallet (default false)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
    *
@@ -1637,12 +1650,21 @@ class HathorWallet extends EventEmitter {
       changeAddress: null,
       createAnotherMelt: true,
       meltAuthorityAddress: null,
+      allowExternalMeltAuthorityAddress: false,
       pinCode: null,
     }, options);
 
     const pin = newOptions.pinCode || this.pinCode;
     if (!pin) {
       throw new Error(ERROR_MESSAGE_PIN_REQUIRED);
+    }
+
+    if (newOptions.meltAuthorityAddress && !newOptions.allowExternalMeltAuthorityAddress) {
+      // Validate that the melt authority address belongs to the wallet
+      const isAddressMine = this.isAddressMine(newOptions.meltAuthorityAddress);
+      if (!isAddressMine) {
+        throw new Error('The melt authority address must belong to your wallet.');
+      }
     }
 
     const meltInput = await this.getMeltAuthority(tokenUid, {many: false});
@@ -1678,6 +1700,8 @@ class HathorWallet extends EventEmitter {
    * @param {boolean} [options.createAnotherMelt] boolean to create another melt authority or not
    *                                              for the wallet
    * @param {string} [options.meltAuthorityAddress] address to send the new melt authority created
+   * @param {boolean} [options.allowExternalMeltAuthorityAddress=false] allow the melt authority address
+   *                                                                    to be from another wallet
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1529,6 +1529,7 @@ class HathorWallet extends EventEmitter {
    *   'changeAddress': address of the change output
    *   'startMiningTx': boolean to trigger start mining (default true)
    *   'createAnotherMint': boolean to create another mint authority or not for the wallet
+   *   'mintAuthorityAddress': address to send the new mint authority created
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
    *
@@ -1546,6 +1547,7 @@ class HathorWallet extends EventEmitter {
       address: null,
       changeAddress: null,
       createAnotherMint: true,
+      mintAuthorityAddress: null,
       pinCode: null,
     }, options);
 
@@ -1567,6 +1569,7 @@ class HathorWallet extends EventEmitter {
       mintInput: mintInput[0],
       createAnotherMint: newOptions.createAnotherMint,
       changeAddress: newOptions.changeAddress,
+      mintAuthorityAddress: newOptions.mintAuthorityAddress,
     };
     const txData = await tokenUtils.prepareMintTxData(
       mintAddress,
@@ -1590,6 +1593,7 @@ class HathorWallet extends EventEmitter {
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {boolean} [options.createAnotherMint] boolean to create another mint authority or not
    *                                              for the wallet
+   * @param {string} [options.mintAuthorityAddress] address to send the new mint authority created
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this
    *
@@ -1614,6 +1618,7 @@ class HathorWallet extends EventEmitter {
    *   'address': address of the HTR deposit back
    *   'changeAddress': address of the change output
    *   'createAnotherMelt': boolean to create another melt authority or not for the wallet
+   *   'meltAuthorityAddress': address to send the new melt authority created
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
    *
@@ -1631,6 +1636,7 @@ class HathorWallet extends EventEmitter {
       address: null,
       changeAddress: null,
       createAnotherMelt: true,
+      meltAuthorityAddress: null,
       pinCode: null,
     }, options);
 
@@ -1647,6 +1653,7 @@ class HathorWallet extends EventEmitter {
 
     const meltOptions = {
       createAnotherMelt: newOptions.createAnotherMelt,
+      meltAuthorityAddress: newOptions.meltAuthorityAddress,
       changeAddress: newOptions.changeAddress,
     };
     const txData = await tokenUtils.prepareMeltTxData(
@@ -1670,6 +1677,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.changeAddress] address of the change output
    * @param {boolean} [options.createAnotherMelt] boolean to create another melt authority or not
    *                                              for the wallet
+   * @param {string} [options.meltAuthorityAddress] address to send the new melt authority created
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -174,7 +174,7 @@ export class Storage implements IStorage {
       return changeAddress;
     }
 
-    return await this.getCurrentAddress();
+    return this.getCurrentAddress();
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -174,7 +174,7 @@ export class Storage implements IStorage {
       return changeAddress;
     }
 
-    return this.getCurrentAddress();
+    return await this.getCurrentAddress();
   }
 
   /**

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -288,13 +288,13 @@ const tokens = {
       isCreateNFT = false,
       mintAuthorityAddress = null,
     }: {
-      token?: string|null,
-      mintInput?: IDataInput|null,
+      token?: string | null,
+      mintInput?: IDataInput | null,
       createAnotherMint?: boolean,
       createMelt?: boolean,
-      changeAddress?: string|null,
+      changeAddress?: string | null,
       isCreateNFT?: boolean,
-      mintAuthorityAddress?: string|null,
+      mintAuthorityAddress?: string | null,
     } = {},
   ): Promise<IDataTx> {
     const inputs: IDataInput[] = [];
@@ -382,8 +382,8 @@ const tokens = {
    * @param {IStorage} storage The storage object
    * @param {Object} [options={}] Options to create the melt transaction
    * @param {boolean} [options.createAnotherMelt=true] If should create another melt authority
-   * @param {string|null} [options.meltAuthorityAddress=null] Address to send the new melt authority created
-   * @param {string|null} [options.changeAddress=null] Address to send the change
+   * @param {string | null} [options.meltAuthorityAddress=null] Address to send the new melt authority created
+   * @param {string | null} [options.changeAddress=null] Address to send the change
    * @returns {Promise<IDataTx>}
    */
   async prepareMeltTxData(
@@ -398,8 +398,8 @@ const tokens = {
       changeAddress = null,
     }: {
       createAnotherMelt?: boolean,
-      meltAuthorityAddress?: string|null,
-      changeAddress?: string|null,
+      meltAuthorityAddress?: string | null,
+      changeAddress?: string | null,
     } = {},
   ): Promise<IDataTx> {
     if ((authorityMeltInput.token !== token) || (authorityMeltInput.authorities !== 2)) {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -270,6 +270,7 @@ const tokens = {
    * @param {string|null} [options.token=null] Token to mint, may be null if we are creating the token
    * @param {IDataInput|null} [options.mintInput=null] Input to spend, may be null if we are creating the token
    * @param {boolean} [options.createAnotherMint=true] If a mint authority should be created on the transaction.
+   * @param {string|null} [options.mintAuthorityAddress=null] The address to send the new mint authority created
    * @param {string|null} [options.changeAddress=null] The address to send any change output.
    * @param {boolean} [options.isCreateNFT=false] If this transaction will create an NFT
    *
@@ -285,6 +286,7 @@ const tokens = {
       createAnotherMint = true,
       changeAddress = null,
       isCreateNFT = false,
+      mintAuthorityAddress = null,
     }: {
       token?: string|null,
       mintInput?: IDataInput|null,
@@ -292,6 +294,7 @@ const tokens = {
       createMelt?: boolean,
       changeAddress?: string|null,
       isCreateNFT?: boolean,
+      mintAuthorityAddress?: string|null,
     } = {},
   ): Promise<IDataTx> {
     const inputs: IDataInput[] = [];
@@ -350,7 +353,7 @@ const tokens = {
     });
 
     if (createAnotherMint) {
-      const newAddress = await storage.getCurrentAddress();
+      const newAddress = mintAuthorityAddress || await storage.getCurrentAddress();
       outputs.push({
         type: 'mint',
         address: newAddress,
@@ -379,6 +382,7 @@ const tokens = {
    * @param {IStorage} storage The storage object
    * @param {Object} [options={}] Options to create the melt transaction
    * @param {boolean} [options.createAnotherMelt=true] If should create another melt authority
+   * @param {string|null} [options.meltAuthorityAddress=null] Address to send the new melt authority created
    * @param {string|null} [options.changeAddress=null] Address to send the change
    * @returns {Promise<IDataTx>}
    */
@@ -390,9 +394,11 @@ const tokens = {
     storage: IStorage,
     {
       createAnotherMelt = true,
+      meltAuthorityAddress = null,
       changeAddress = null,
     }: {
       createAnotherMelt?: boolean,
+      meltAuthorityAddress?: string|null,
       changeAddress?: string|null,
     } = {},
   ): Promise<IDataTx> {
@@ -439,7 +445,7 @@ const tokens = {
     }
 
     if (createAnotherMelt) {
-      const newAddress = await storage.getCurrentAddress();
+      const newAddress = meltAuthorityAddress || await storage.getCurrentAddress();
       outputs.push({
         type: getAddressType(newAddress, storage.config.getNetwork()),
         address: newAddress,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1366,7 +1366,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     if (newOptions.createAnotherMint) {
       // b. Mint authority
-      const authorityAddress = newOptions.mintAuthorityAddress || this.getCurrentAddress({ markAsUsed: true }).address;
+      const authorityAddress = newOptions.mintAuthorityAddress
+        || this.getCurrentAddress({ markAsUsed: true }).address;
       const authorityAddressObj = new Address(authorityAddress, { network: this.network });
       if (!authorityAddressObj.isValid()) {
         throw new SendTxError(`Address ${newOptions.mintAuthorityAddress} is not valid.`);
@@ -1517,13 +1518,18 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     if (newOptions.createAnotherMelt) {
       // b. Melt authority
-      const authorityAddress = newOptions.meltAuthorityAddress || this.getCurrentAddress({ markAsUsed: true }).address;
+      const authorityAddress = newOptions.meltAuthorityAddress
+        || this.getCurrentAddress({ markAsUsed: true }).address;
       const authorityAddressObj = new Address(authorityAddress, { network: this.network });
       if (!authorityAddressObj.isValid()) {
         throw new SendTxError(`Address ${newOptions.meltAuthorityAddress} is not valid.`);
       }
       const p2pkhAuthorityScript = authorityAddressObj.getScript();
-      outputsObj.push(new Output(TOKEN_MELT_MASK, p2pkhAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA }));
+      outputsObj.push(
+        new Output(TOKEN_MELT_MASK, p2pkhAuthorityScript, {
+          tokenData: AUTHORITY_TOKEN_DATA
+        })
+      );
     }
 
     if (changeAmount) {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1303,12 +1303,14 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       address: string | null,
       changeAddress: string | null,
       createAnotherMint: boolean,
+      mintAuthorityAddress: string | null,
       pinCode: string | null,
     };
     const newOptions: optionsType = Object.assign({
       address: null,
       changeAddress: null,
       createAnotherMint: true,
+      mintAuthorityAddress: null,
       pinCode: null,
     }, options);
 
@@ -1354,7 +1356,14 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     if (newOptions.createAnotherMint) {
       // b. Mint authority
-      outputsObj.push(new Output(TOKEN_MINT_MASK, p2pkhScript, {tokenData: AUTHORITY_TOKEN_DATA}));
+      const authorityAddress = newOptions.mintAuthorityAddress || this.getCurrentAddress({ markAsUsed: true }).address;
+      const authorityAddressObj = new Address(authorityAddress, { network: this.network });
+      if (!authorityAddressObj.isValid()) {
+        throw new SendTxError(`Address ${newOptions.mintAuthorityAddress} is not valid.`);
+      }
+      const p2pkhAuthority = new P2PKH(authorityAddressObj);
+      const p2pkhAuthorityScript = p2pkhAuthority.createScript()
+      outputsObj.push(new Output(TOKEN_MINT_MASK, p2pkhAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA }));
     }
 
     if (changeAmount) {
@@ -1433,12 +1442,14 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       address: string | null,
       changeAddress: string | null,
       createAnotherMelt: boolean,
+      meltAuthorityAddress: string | null,
       pinCode: string | null,
     };
     const newOptions: optionsType = Object.assign({
       address: null,
       changeAddress: null,
       createAnotherMelt: true,
+      meltAuthorityAddress: null,
       pinCode: null,
     }, options);
 
@@ -1486,8 +1497,15 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     }
 
     if (newOptions.createAnotherMelt) {
-      // b. Mint authority
-      outputsObj.push(new Output(TOKEN_MELT_MASK, p2pkhScript, {tokenData: AUTHORITY_TOKEN_DATA}));
+      // b. Melt authority
+      const authorityAddress = newOptions.meltAuthorityAddress || this.getCurrentAddress({ markAsUsed: true }).address;
+      const authorityAddressObj = new Address(authorityAddress, { network: this.network });
+      if (!authorityAddressObj.isValid()) {
+        throw new SendTxError(`Address ${newOptions.meltAuthorityAddress} is not valid.`);
+      }
+      const p2pkhAuthority = new P2PKH(authorityAddressObj);
+      const p2pkhAuthorityScript = p2pkhAuthority.createScript()
+      outputsObj.push(new Output(TOKEN_MELT_MASK, p2pkhAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA }));
     }
 
     if (changeAmount) {


### PR DESCRIPTION
### Acceptance Criteria
- `mintTokens` method must have a parameter to set the address to send the new mint authority created
- `meltTokens` method must have a parameter to set the address to send the new melt authority created


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
