### PR TITLE
feat: add new parameter to set authority address when minting/melting tokens

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - dev
       - master
+      - v0.46.1_master
 
 env:
   TEST_WALLET_START_TIMEOUT: '180000' # 3 minutes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
     branches:
     - dev
     - master
+    - v0.46.1_master
 jobs:
   test:
     runs-on: 'ubuntu-latest'

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1778,6 +1778,33 @@ describe('mintTokens', () => {
     const tokenBalance = await hWallet.getBalance(tokenUid);
     const expectedAmount = 100 + mintAmount;
     expect(tokenBalance[0]).toHaveProperty('balance.unlocked', expectedAmount);
+
+    // Mint tokens with defined mint authority address
+    const address0 = await hWallet.getAddressAtIndex(0);
+
+    const mintResponse2 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: address0 });
+    expect(mintResponse2.hash).toBeDefined();
+    await waitForTxReceived(hWallet, mintResponse2.hash);
+
+    // Validating there is a correct reference to the custom token
+    expect(mintResponse2).toHaveProperty('tokens.length', 1);
+    expect(mintResponse2.tokens[0]).toEqual(tokenUid);
+
+    // Validating a new mint authority was created by default
+    const authorityOutputs2 = mintResponse2.outputs.filter(
+      o => transaction.isAuthorityOutput({token_data: o.tokenData})
+    );
+    expect(authorityOutputs2).toHaveLength(1);
+    const authorityOutput = authorityOutputs2[0];
+    expect(authorityOutput.value).toEqual(TOKEN_MINT_MASK);
+    const p2pkh = authorityOutput.parseScript(hWallet.getNetworkObject());
+    // Validate that the authority output was sent to the correct address
+    expect(p2pkh.address.base58).toEqual(address0);
+
+    // Validating custom token balance
+    const tokenBalance2 = await hWallet.getBalance(tokenUid);
+    const expectedAmount2 = expectedAmount + 100;
+    expect(tokenBalance2[0]).toHaveProperty('balance.unlocked', expectedAmount2);
   });
 
   it('should deposit correct HTR values for minting', async () => {
@@ -1854,7 +1881,7 @@ describe('meltTokens', () => {
       hWallet,
       'Token to Melt',
       'TMELT',
-      100,
+      200,
     );
 
     // Should not melt more than there is available
@@ -1871,8 +1898,29 @@ describe('meltTokens', () => {
 
     // Validating custom token balance
     const tokenBalance = await hWallet.getBalance(tokenUid);
-    const expectedAmount = 100 - meltAmount;
+    const expectedAmount = 200 - meltAmount;
     expect(tokenBalance[0]).toHaveProperty('balance.unlocked', expectedAmount);
+
+    // Melt tokens with defined melt authority address
+    const address0 = await hWallet.getAddressAtIndex(0);
+    const meltResponse = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: address0 });
+    await waitForTxReceived(hWallet, meltResponse.hash);
+
+    // Validating a new melt authority was created by default
+    const authorityOutputs = meltResponse.outputs.filter(
+      o => transaction.isAuthorityOutput({token_data: o.tokenData})
+    );
+    expect(authorityOutputs).toHaveLength(1);
+    const authorityOutput = authorityOutputs[0];
+    expect(authorityOutput.value).toEqual(TOKEN_MELT_MASK);
+    const p2pkh = authorityOutput.parseScript(hWallet.getNetworkObject());
+    // Validate that the authority output was sent to the correct address
+    expect(p2pkh.address.base58).toEqual(address0);
+
+    // Validating custom token balance
+    const tokenBalance2 = await hWallet.getBalance(tokenUid);
+    const expectedAmount2 = expectedAmount - 100;
+    expect(tokenBalance2[0]).toHaveProperty('balance.unlocked', expectedAmount2);
   });
 
   it('should recover correct amount of HTR on melting', async () => {

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1792,7 +1792,7 @@ describe('mintTokens', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs2 = mintResponse2.outputs.filter(
-      o => transaction.isAuthorityOutput({token_data: o.tokenData})
+      o => transaction.isTokenDataAuthority(o.tokenData)
     );
     expect(authorityOutputs2).toHaveLength(1);
     const authorityOutput = authorityOutputs2[0];
@@ -1908,7 +1908,7 @@ describe('meltTokens', () => {
 
     // Validating a new melt authority was created by default
     const authorityOutputs = meltResponse.outputs.filter(
-      o => transaction.isAuthorityOutput({token_data: o.tokenData})
+      o => transaction.isTokenDataAuthority(o.tokenData)
     );
     expect(authorityOutputs).toHaveLength(1);
     const authorityOutput = authorityOutputs[0];

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1805,6 +1805,38 @@ describe('mintTokens', () => {
     const tokenBalance2 = await hWallet.getBalance(tokenUid);
     const expectedAmount2 = expectedAmount + 100;
     expect(tokenBalance2[0]).toHaveProperty('balance.unlocked', expectedAmount2);
+
+    // Mint tokens with external address should return error by default
+    const hWallet2 = await generateWalletHelper();
+    const externalAddress = await hWallet2.getAddressAtIndex(0);
+
+    const mintResponse3 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress });
+    expect(mintResponse3.success).toBe(false);
+
+    // Mint tokens with external address but allowing it
+    const mintResponse4 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress, allowExternalMintAuthorityAddress: true });
+    expect(mintResponse4.hash).toBeDefined();
+    await waitForTxReceived(hWallet, mintResponse4.hash);
+
+    // Validating there is a correct reference to the custom token
+    expect(mintResponse4).toHaveProperty('tokens.length', 1);
+    expect(mintResponse4.tokens[0]).toEqual(tokenUid);
+
+    // Validating a new mint authority was created by default
+    const authorityOutputs4 = mintResponse4.outputs.filter(
+      o => transaction.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs4).toHaveLength(1);
+    const authorityOutput4 = authorityOutputs4[0];
+    expect(authorityOutput4.value).toEqual(TOKEN_MINT_MASK);
+    const p4pkh = authorityOutput4.parseScript(hWallet.getNetworkObject());
+    // Validate that the authority output was sent to the correct address
+    expect(p4pkh.address.base58).toEqual(externalAddress);
+
+    // Validating custom token balance
+    const tokenBalance4 = await hWallet.getBalance(tokenUid);
+    const expectedAmount4 = expectedAmount2 + 100;
+    expect(tokenBalance4[0]).toHaveProperty('balance.unlocked', expectedAmount4);
   });
 
   it('should deposit correct HTR values for minting', async () => {
@@ -1881,7 +1913,7 @@ describe('meltTokens', () => {
       hWallet,
       'Token to Melt',
       'TMELT',
-      200,
+      300,
     );
 
     // Should not melt more than there is available
@@ -1921,6 +1953,33 @@ describe('meltTokens', () => {
     const tokenBalance2 = await hWallet.getBalance(tokenUid);
     const expectedAmount2 = expectedAmount - 100;
     expect(tokenBalance2[0]).toHaveProperty('balance.unlocked', expectedAmount2);
+
+    // Melt tokens with external address should return error
+    const hWallet2 = await generateWalletHelper();
+    const externalAddress = await hWallet2.getAddressAtIndex(0);
+
+    const meltResponse2 = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress });
+    expect(meltResponse2.success).toBe(false);
+
+    // Melt tokens with external address but allowing it
+    const meltResponse3 = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress, allowExternalMeltAuthorityAddress: true });
+    await waitForTxReceived(hWallet, meltResponse3.hash);
+
+    // Validating a new melt authority was created by default
+    const authorityOutputs3 = meltResponse3.outputs.filter(
+      o => transaction.isTokenDataAuthority(o.tokenData)
+    );
+    expect(authorityOutputs3).toHaveLength(1);
+    const authorityOutput3 = authorityOutputs3[0];
+    expect(authorityOutput3.value).toEqual(TOKEN_MELT_MASK);
+    const p3pkh = authorityOutput3.parseScript(hWallet.getNetworkObject());
+    // Validate that the authority output was sent to the correct address
+    expect(p3pkh.address.base58).toEqual(externalAddress);
+
+    // Validating custom token balance
+    const tokenBalance3 = await hWallet.getBalance(tokenUid);
+    const expectedAmount3 = expectedAmount2 - 100;
+    expect(tokenBalance3[0]).toHaveProperty('balance.unlocked', expectedAmount3);
   });
 
   it('should recover correct amount of HTR on melting', async () => {

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1810,8 +1810,11 @@ describe('mintTokens', () => {
     const hWallet2 = await generateWalletHelper();
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
-    const mintResponse3 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress });
-    expect(mintResponse3.success).toBe(false);
+    await expect(hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress }))
+      .rejects.toStrictEqual({
+        success: false,
+        message: expect.stringContaining('must belong to your wallet'),
+      });
 
     // Mint tokens with external address but allowing it
     const mintResponse4 = await hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress, allowExternalMintAuthorityAddress: true });
@@ -1930,7 +1933,7 @@ describe('meltTokens', () => {
 
     // Validating custom token balance
     const tokenBalance = await hWallet.getBalance(tokenUid);
-    const expectedAmount = 200 - meltAmount;
+    const expectedAmount = 300 - meltAmount;
     expect(tokenBalance[0]).toHaveProperty('balance.unlocked', expectedAmount);
 
     // Melt tokens with defined melt authority address
@@ -1958,8 +1961,11 @@ describe('meltTokens', () => {
     const hWallet2 = await generateWalletHelper();
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
-    const meltResponse2 = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress });
-    expect(meltResponse2.success).toBe(false);
+    await expect(hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress }))
+      .rejects.toStrictEqual({
+        success: false,
+        message: expect.stringContaining('must belong to your wallet'),
+      });
 
     // Melt tokens with external address but allowing it
     const meltResponse3 = await hWallet.meltTokens(tokenUid, 100, { meltAuthorityAddress: externalAddress, allowExternalMeltAuthorityAddress: true });

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1845,7 +1845,7 @@ class HathorWallet extends EventEmitter {
    *                                   (if not sent we choose the next available address to use)
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {boolean} [options.createAnotherMint] boolean to create another mint authority or not
-   *                                              for the wallet
+   * @param {string} [options.mintAuthorityAddress] the address to send the new mint authority created
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this
    *
@@ -1936,6 +1936,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.changeAddress] address of the change output
    * @param {boolean} [options.createAnotherMelt] boolean to create another melt authority or not
    *                                              for the wallet
+   * @param {string} [options.meltAuthorityAddress] the address to send the new melt authority created
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1789,6 +1789,7 @@ class HathorWallet extends EventEmitter {
    *   'changeAddress': address of the change output
    *   'startMiningTx': boolean to trigger start mining (default true)
    *   'createAnotherMint': boolean to create another mint authority or not for the wallet
+   *   'mintAuthorityAddress': string The address to send the new mint authority created
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
    *
@@ -1807,6 +1808,7 @@ class HathorWallet extends EventEmitter {
       address: null,
       changeAddress: null,
       createAnotherMint: true,
+      mintAuthorityAddress: null,
       startMiningTx: true,
       pinCode: null,
     }, options);
@@ -1868,6 +1870,7 @@ class HathorWallet extends EventEmitter {
    *   'address': address of the HTR deposit back
    *   'changeAddress': address of the change output
    *   'createAnotherMelt': boolean to create another melt authority or not for the wallet
+   *   'meltAuthorityAddress': string The address to send the new melt authority created
    *   'startMiningTx': boolean to trigger start mining (default true)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
@@ -1887,6 +1890,7 @@ class HathorWallet extends EventEmitter {
       address: null,
       changeAddress: null,
       createAnotherMelt: true,
+      meltAuthorityAddress: null,
       startMiningTx: true,
       pinCode: null,
     }, options);
@@ -1903,7 +1907,18 @@ class HathorWallet extends EventEmitter {
     }
 
     // Always create another melt authority output
-    const ret = tokens.generateMeltData(meltInput[0], tokenUid, amount, pin, newOptions.createAnotherMelt, { depositAddress: newOptions.address, changeAddress: newOptions.changeAddress });
+    const ret = tokens.generateMeltData(
+      meltInput[0],
+      tokenUid,
+      amount,
+      pin,
+      newOptions.createAnotherMelt,
+      {
+        depositAddress: newOptions.address,
+        changeAddress: newOptions.changeAddress,
+        meltAuthorityAddress: newOptions.meltAuthorityAddress
+      }
+    );
     if (!ret.success) {
       return Promise.reject(ret);
     }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1820,7 +1820,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject({success: false, message: ERROR_MESSAGE_PIN_REQUIRED, error: ERROR_CODE_PIN_REQUIRED});
     }
 
-    if (newOptions.mintAuthorityAddress && !allowExternalMintAuthorityAddress) {
+    if (newOptions.mintAuthorityAddress && !newOptions.allowExternalMintAuthorityAddress) {
       // Validate that the mint authority address belongs to the wallet
       if (!this.isAddressMine(newOptions.mintAuthorityAddress)) {
         return Promise.reject({ success: false, message: 'The mint authority address must belong to your wallet.' });
@@ -1914,7 +1914,7 @@ class HathorWallet extends EventEmitter {
       return Promise.reject({success: false, message: ERROR_MESSAGE_PIN_REQUIRED, error: ERROR_CODE_PIN_REQUIRED});
     }
 
-    if (newOptions.meltAuthorityAddress && !allowExternalMeltAuthorityAddress) {
+    if (newOptions.meltAuthorityAddress && !newOptions.allowExternalMeltAuthorityAddress) {
       // Validate that the melt authority address belongs to the wallet
       if (!this.isAddressMine(newOptions.meltAuthorityAddress)) {
         return Promise.reject({ success: false, message: 'The melt authority address must belong to your wallet.' });

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1790,6 +1790,7 @@ class HathorWallet extends EventEmitter {
    *   'startMiningTx': boolean to trigger start mining (default true)
    *   'createAnotherMint': boolean to create another mint authority or not for the wallet
    *   'mintAuthorityAddress': string The address to send the new mint authority created
+   *   'allowExternalMintAuthorityAddress': boolean allow the mint authority address to be from another wallet (default false)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
    *
@@ -1809,6 +1810,7 @@ class HathorWallet extends EventEmitter {
       changeAddress: null,
       createAnotherMint: true,
       mintAuthorityAddress: null,
+      allowExternalMintAuthorityAddress: false,
       startMiningTx: true,
       pinCode: null,
     }, options);
@@ -1816,6 +1818,13 @@ class HathorWallet extends EventEmitter {
     const pin = newOptions.pinCode || this.pinCode;
     if (!pin) {
       return Promise.reject({success: false, message: ERROR_MESSAGE_PIN_REQUIRED, error: ERROR_CODE_PIN_REQUIRED});
+    }
+
+    if (newOptions.mintAuthorityAddress && !allowExternalMintAuthorityAddress) {
+      // Validate that the mint authority address belongs to the wallet
+      if (!this.isAddressMine(newOptions.mintAuthorityAddress)) {
+        return Promise.reject({ success: false, message: 'The mint authority address must belong to your wallet.' });
+      }
     }
 
     const mintAddress = newOptions.address || this.getCurrentAddress().address;
@@ -1845,7 +1854,10 @@ class HathorWallet extends EventEmitter {
    *                                   (if not sent we choose the next available address to use)
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {boolean} [options.createAnotherMint] boolean to create another mint authority or not
+   *                                              for the wallet
    * @param {string} [options.mintAuthorityAddress] the address to send the new mint authority created
+   * @param {boolean} [options.allowExternalMintAuthorityAddress=false] allow the mint authority address
+   *                                                                    to be from another wallet
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this
    *
@@ -1871,6 +1883,7 @@ class HathorWallet extends EventEmitter {
    *   'changeAddress': address of the change output
    *   'createAnotherMelt': boolean to create another melt authority or not for the wallet
    *   'meltAuthorityAddress': string The address to send the new melt authority created
+   *   'allowExternalMeltAuthorityAddress': boolean allow the melt authority address to be from another wallet (default false)
    *   'startMiningTx': boolean to trigger start mining (default true)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
    *  }
@@ -1891,6 +1904,7 @@ class HathorWallet extends EventEmitter {
       changeAddress: null,
       createAnotherMelt: true,
       meltAuthorityAddress: null,
+      allowExternalMeltAuthorityAddress: false,
       startMiningTx: true,
       pinCode: null,
     }, options);
@@ -1898,6 +1912,13 @@ class HathorWallet extends EventEmitter {
     const pin = newOptions.pinCode || this.pinCode;
     if (!pin) {
       return Promise.reject({success: false, message: ERROR_MESSAGE_PIN_REQUIRED, error: ERROR_CODE_PIN_REQUIRED});
+    }
+
+    if (newOptions.meltAuthorityAddress && !allowExternalMeltAuthorityAddress) {
+      // Validate that the melt authority address belongs to the wallet
+      if (!this.isAddressMine(newOptions.meltAuthorityAddress)) {
+        return Promise.reject({ success: false, message: 'The melt authority address must belong to your wallet.' });
+      }
     }
 
     const meltInput = this.selectAuthorityUtxo(tokenUid, wallet.isMeltOutput.bind(wallet));
@@ -1937,6 +1958,8 @@ class HathorWallet extends EventEmitter {
    * @param {boolean} [options.createAnotherMelt] boolean to create another melt authority or not
    *                                              for the wallet
    * @param {string} [options.meltAuthorityAddress] the address to send the new melt authority created
+   * @param {boolean} [options.allowExternalMeltAuthorityAddress=false] allow the melt authority address
+   *                                                                    to be from another wallet
    * @param {boolean} [options.startMiningTx=true] boolean to trigger start mining (default true)
    * @param {string} [options.pinCode] pin to decrypt xpriv information.
    *                                   Optional but required if not set in this

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -655,7 +655,7 @@ const tokens = {
    * @inner
    */
   createMeltData(meltInput, token, amount, createAnotherMelt, options = { depositAddress: null, changeAddress: null, meltAuthorityAddress: null }) {
-    const { depositAddress, changeAddress } = options;
+    const { depositAddress, changeAddress, meltAuthorityAddress } = options;
     // Get inputs that sum at least the amount requested to melt
     const result = this.getMeltInputs(amount, token);
 

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -454,6 +454,7 @@ const tokens = {
    * }
    * @param {Object} options {
    *   {boolean} createAnotherMint If should create another mint output after spending this one
+   *   {string} mintAuthorityAddress The address to send the new mint authority created
    *   {boolean} createMelt If should create a melt output (useful when creating a new token)
    *   {string} changeAddress Address to send the change of HTR after mint deposit
    *   {boolean} isNFT If it's getting mint data for an NFT
@@ -469,12 +470,13 @@ const tokens = {
   createMintData(mintInput, token, address, amount, depositInputs, options) {
     const fnOptions = Object.assign({
       createAnotherMint: true,
+      mintAuthorityAddress: null,
       createMelt: false,
       changeAddress: null,
       isNFT: false,
     }, options);
 
-    const { createAnotherMint, createMelt, changeAddress, isNFT } = fnOptions;
+    const { createAnotherMint, mintAuthorityAddress, createMelt, changeAddress, isNFT } = fnOptions;
     const inputs = [];
     const outputs = [];
 
@@ -507,7 +509,7 @@ const tokens = {
 
     if (createAnotherMint) {
       // Output2: new mint authority for this wallet
-      const newAddress = wallet.getAddressToUse();
+      const newAddress = mintAuthorityAddress || wallet.getAddressToUse();
       outputs.push({'address': newAddress, 'value': TOKEN_MINT_MASK, 'tokenData': AUTHORITY_TOKEN_DATA});
     }
 
@@ -550,6 +552,7 @@ const tokens = {
    * @param {Object} options {
    *   {number} minimumTimestamp Tx minimum timestamp (default = 0)
    *   {boolean} createAnotherMint If should create another mint output after spending this one
+   *   {string} mintAuthorityAddress The address to send the new mint authority created
    *   {boolean} createMelt If should create a melt output (useful when creating a new token)
    *   {string} changeAddress Address to send the change of HTR after mint deposit
    * }
@@ -564,6 +567,7 @@ const tokens = {
   generateMintData(mintInput, token, address, amount, depositInputs, pin, options) {
     const fnOptions = Object.assign({
       createAnotherMint: true,
+      mintAuthorityAddress: null,
       createMelt: false,
       minimumTimestamp: 0,
       changeAddress: null,
@@ -642,6 +646,7 @@ const tokens = {
    *  {
    *   'depositAddress': address of the HTR deposit back
    *   'changeAddress': address of the change output
+   *   'meltAuthorityAddress': the address to send the new melt authority created
    *  }
    *
    * @return {Object} Melt data {'inputs', 'outputs', 'tokens'}
@@ -649,7 +654,7 @@ const tokens = {
    * @memberof Tokens
    * @inner
    */
-  createMeltData(meltInput, token, amount, createAnotherMelt, options = { depositAddress: null, changeAddress: null }) {
+  createMeltData(meltInput, token, amount, createAnotherMelt, options = { depositAddress: null, changeAddress: null, meltAuthorityAddress: null }) {
     const { depositAddress, changeAddress } = options;
     // Get inputs that sum at least the amount requested to melt
     const result = this.getMeltInputs(amount, token);
@@ -671,7 +676,7 @@ const tokens = {
 
     if (createAnotherMelt) {
       // New melt authority for this wallet
-      const newAddress = wallet.getAddressToUse();
+      const newAddress = meltAuthorityAddress || wallet.getAddressToUse();
       outputs.push({'address': newAddress, 'value': TOKEN_MELT_MASK, 'tokenData': AUTHORITY_TOKEN_DATA});
     }
 
@@ -703,6 +708,7 @@ const tokens = {
    *  {
    *   'depositAddress': address of the HTR deposit back
    *   'changeAddress': address of the change output for the custom token melt
+   *   'meltAuthorityAddress': the address to send the new melt authority created
    *  }
    *
    * @return {Object} Prepared transaction data with signed inputs, weight, timestamp
@@ -710,7 +716,7 @@ const tokens = {
    * @memberof Tokens
    * @inner
    */
-  generateMeltData(meltInput, token, amount, pin, createAnotherMelt, options = { depositAddress: null, changeAddress: null }) {
+  generateMeltData(meltInput, token, amount, pin, createAnotherMelt, options = { depositAddress: null, changeAddress: null, meltAuthorityAddress: null }) {
     // Get melt data
     const newTxData = this.createMeltData(meltInput, token, amount, createAnotherMelt, options);
     if (!newTxData) {


### PR DESCRIPTION
### Acceptance Criteria
- Add parameter to set new created authority address when minting/melting tokens
- This address by default must belong to the same wallet but another parameter was added to allow external addresses.
- I decided not to add it to the wallet service facade because it's a specific request and it will be added to both facades in the release candidate version
- Added the stable master branch to the github workflow files just to trigger the CI, it will be removed before merging


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
