### PR TITLE
fix created leveldb dir name

### DIFF
--- a/__tests__/integration/storage/leveldb.test.js
+++ b/__tests__/integration/storage/leveldb.test.js
@@ -1,16 +1,12 @@
 import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import {
-  createTokenHelper,
   DEFAULT_PASSWORD,
   DEFAULT_PIN_CODE,
   generateConnection,
-  generateMultisigWalletHelper,
-  generateWalletHelper,
   stopAllWallets,
   waitForTxReceived,
   waitForWalletReady,
-  waitUntilNextTimestamp
 } from '../helpers/wallet.helper';
 import { delay } from '../utils/core.util';
 
@@ -18,7 +14,6 @@ import { LevelDBStore, Storage } from '../../../src/storage';
 import walletUtils from '../../../src/utils/wallet';
 import HathorWallet from '../../../src/new/wallet';
 import { loggers } from '../utils/logger.util';
-import { crypto } from "bitcore-lib";
 
 const startedWallets = [];
 
@@ -47,7 +42,8 @@ describe('LevelDB persistent store', () => {
     const DATA_DIR = './testdata.leveldb';
     const walletData = precalculationHelpers.test.getPrecalculatedWallet();
     const xpubkey = walletUtils.getXPubKeyFromSeed(walletData.words, { accountDerivationIndex: '0\'/0' });
-    const walletId = crypto.Hash.sha256(Buffer.from(xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpubkey);
+
     const store = new LevelDBStore(walletId, DATA_DIR);
     const storage = new Storage(store);
 

--- a/__tests__/integration/storage/storage.test.js
+++ b/__tests__/integration/storage/storage.test.js
@@ -15,7 +15,6 @@ import SendTransaction from '../../../src/new/sendTransaction';
 import { LevelDBStore, MemoryStore, Storage } from '../../../src/storage';
 import walletUtils from '../../../src/utils/wallet';
 import { HATHOR_TOKEN_CONFIG } from '../../../src/constants';
-import { crypto } from "bitcore-lib";
 
 const startedWallets = [];
 
@@ -105,7 +104,7 @@ describe('locked utxos', () => {
     const DATA_DIR = './testdata.leveldb';
     const walletDataLDB = precalculationHelpers.test.getPrecalculatedWallet();
     const xpubkeyLDB = walletUtils.getXPubKeyFromSeed(walletDataLDB.words, { accountDerivationIndex: '0\'/0' });
-    const walletId = crypto.Hash.sha256(Buffer.from(xpubkeyLDB)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpubkeyLDB);
     const storeLDB = new LevelDBStore(walletId, DATA_DIR);
     const storageLDB = new Storage(storeLDB);
     await testUnlockWhenSpent(storageLDB, walletDataLDB);

--- a/__tests__/storage/common_store.test.js
+++ b/__tests__/storage/common_store.test.js
@@ -8,7 +8,7 @@
 import { LevelDBStore, MemoryStore, Storage } from "../../src/storage";
 import { HDPrivateKey } from "bitcore-lib";
 import { TOKEN_AUTHORITY_MASK, TOKEN_MINT_MASK } from "../../src/constants";
-import { crypto } from "bitcore-lib";
+import walletUtils from "../../src/utils/wallet";
 
 const DATA_DIR = './testdata.leveldb';
 
@@ -34,7 +34,7 @@ describe("locked utxo methods", () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = new HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await testLockedUtxoMethods(store);
   });
@@ -177,7 +177,7 @@ describe('registered tokens', () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = new HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await testRegisteredTokens(store);
   });

--- a/__tests__/storage/common_store.test.js
+++ b/__tests__/storage/common_store.test.js
@@ -177,7 +177,8 @@ describe('registered tokens', () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = new HDPrivateKey();
-    const store = new LevelDBStore(DATA_DIR, xpriv.xpubkey);
+    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const store = new LevelDBStore(walletId, DATA_DIR);
     await testRegisteredTokens(store);
   });
 

--- a/__tests__/storage/leveldb/leveldb_store.test.js
+++ b/__tests__/storage/leveldb/leveldb_store.test.js
@@ -13,7 +13,7 @@ import { HDPrivateKey } from "bitcore-lib";
 import { encryptData } from "../../../src/utils/crypto";
 import { WalletType } from "../../../src/types";
 import { processHistory } from "../../../src/utils/storage";
-import { crypto } from "bitcore-lib";
+import walletUtils from "../../../src/utils/wallet";
 
 function _addr_index_key(index) {
   const buf = Buffer.alloc(4);
@@ -25,7 +25,7 @@ const DATA_DIR = './testdata.leveldb';
 
 test('addresses methods', async () => {
   const xpriv = HDPrivateKey();
-  const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+  const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
   const store = new LevelDBStore(walletId, DATA_DIR);
   const addrBatch = store.addressIndex.addressesDB.batch();
   addrBatch.put('a', { base58: 'a', bip32AddressIndex: 2 });
@@ -87,7 +87,7 @@ test('addresses methods', async () => {
 
 test('history methods', async () => {
   const xpriv = HDPrivateKey();
-  const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+  const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
   const store = new LevelDBStore(walletId, DATA_DIR);
   await store.saveAddress({base58: 'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ', bip32AddressIndex: 0});
   await store.saveAddress({base58: 'WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp', bip32AddressIndex: 1});
@@ -173,7 +173,7 @@ test('history methods', async () => {
 
 test('token methods', async () => {
   const xpriv = HDPrivateKey();
-  const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+  const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
   const store = new LevelDBStore(walletId, DATA_DIR);
 
   store.tokenIndex.saveToken(HATHOR_TOKEN_CONFIG);
@@ -244,7 +244,7 @@ test('utxo methods', async () => {
   const dateLocked = new Date('3000-03-01T12:00');
 
   const xpriv = HDPrivateKey();
-  const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+  const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
   const store = new LevelDBStore(walletId, DATA_DIR);
   const utxos = [
     {
@@ -318,7 +318,7 @@ test('utxo methods', async () => {
 
 test('access data methods', async () => {
   const xpriv = HDPrivateKey();
-  const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+  const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
   const store = new LevelDBStore(walletId, DATA_DIR);
 
   const encryptedMain = encryptData(xpriv.xprivkey, '123');

--- a/__tests__/storage/storage.test.js
+++ b/__tests__/storage/storage.test.js
@@ -528,7 +528,8 @@ describe('getAcctPathXpriv', () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = HDPrivateKey();
-    const store = new LevelDBStore(DATA_DIR, xpriv.xpubkey);
+    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const store = new LevelDBStore(walletId, DATA_DIR);
     await getAcctXprivTest(store);
   });
 
@@ -577,7 +578,8 @@ describe('access data methods', () => {
   });
 
   it('should work with leveldb store', async () => {
-    const store = new LevelDBStore(DATA_DIR, mainKey.xpubkey);
+    const walletId = crypto.Hash.sha256(Buffer.from(mainKey.xpubkey)).toString('hex');
+    const store = new LevelDBStore(walletId, DATA_DIR);
     await accessDataTest(store);
   });
 
@@ -669,7 +671,8 @@ describe('checkPin and checkPassword', () => {
         networkName: 'testnet',
       },
     );
-    const store = new LevelDBStore(DATA_DIR, accessData.xpubkey);
+    const walletId = crypto.Hash.sha256(Buffer.from(accessData.xpubkey)).toString('hex');
+    const store = new LevelDBStore(walletId, DATA_DIR);
     await store.saveAccessData(accessData);
     await checkPinTest(store);
     await checkPasswdTest(store);

--- a/__tests__/storage/storage.test.js
+++ b/__tests__/storage/storage.test.js
@@ -11,7 +11,7 @@ import tx_history from '../__fixtures__/tx_history';
 import { processHistory, loadAddresses } from '../../src/utils/storage';
 import walletUtils from '../../src/utils/wallet';
 import { P2PKH_ACCT_PATH, TOKEN_DEPOSIT_PERCENTAGE, TOKEN_AUTHORITY_MASK, TOKEN_MINT_MASK, WALLET_SERVICE_AUTH_DERIVATION_PATH } from '../../src/constants';
-import { HDPrivateKey, crypto } from "bitcore-lib";
+import { HDPrivateKey } from "bitcore-lib";
 import Mnemonic from 'bitcore-mnemonic';
 import * as cryptoUtils from '../../src/utils/crypto';
 import { InvalidPasswdError } from '../../src/errors';
@@ -38,7 +38,7 @@ describe('handleStop', () => {
   }, 10000);
 
   it('should work with leveldb store', async () => {
-    const walletId = crypto.Hash.sha256(Buffer.from(accessData.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(accessData.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await handleStopTest(store);
   }, 10000);
@@ -252,7 +252,7 @@ describe('process locked utxos', () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await processLockedUtxoTest(store);
   });
@@ -495,7 +495,7 @@ describe('getChangeAddress', () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await getChangeAddressTest(store);
   });
@@ -528,7 +528,7 @@ describe('getAcctPathXpriv', () => {
 
   it('should work with leveldb store', async () => {
     const xpriv = HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await getAcctXprivTest(store);
   });
@@ -578,7 +578,7 @@ describe('access data methods', () => {
   });
 
   it('should work with leveldb store', async () => {
-    const walletId = crypto.Hash.sha256(Buffer.from(mainKey.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(mainKey.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await accessDataTest(store);
   });
@@ -671,7 +671,7 @@ describe('checkPin and checkPassword', () => {
         networkName: 'testnet',
       },
     );
-    const walletId = crypto.Hash.sha256(Buffer.from(accessData.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(accessData.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await store.saveAccessData(accessData);
     await checkPinTest(store);

--- a/__tests__/utils/utxo.test.js
+++ b/__tests__/utils/utxo.test.js
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) Hathor Labs and its affiliates.
- *wallet
+ *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */

--- a/__tests__/utils/utxo.test.js
+++ b/__tests__/utils/utxo.test.js
@@ -1,13 +1,14 @@
 /**
  * Copyright (c) Hathor Labs and its affiliates.
- *
+ *wallet
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HDPrivateKey, crypto } from "bitcore-lib";
+import { HDPrivateKey } from "bitcore-lib";
 import { LevelDBStore, MemoryStore, Storage } from "../../src/storage";
 import { bestUtxoSelection, fastUtxoSelection } from "../../src/utils/utxo";
+import walletUtils from "../../src/utils/wallet";
 
 const DATA_DIR = './testdata.leveldb';
 
@@ -118,7 +119,7 @@ describe('bestUtxoSelection', () => {
 
   test('bestUtxoSelection with indexeddb store', async () => {
     const xpriv = new HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await testBestUtxoSelection(store);
   });
@@ -173,7 +174,7 @@ describe('bestUtxoSelection', () => {
 
   test('fastUtxoSelection with indexeddb store', async () => {
     const xpriv = new HDPrivateKey();
-    const walletId = crypto.Hash.sha256(Buffer.from(xpriv.xpubkey)).toString('hex');
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
     const store = new LevelDBStore(walletId, DATA_DIR);
     await testFastUtxoSelection(store);
   });


### PR DESCRIPTION
### Acceptance Criteria

Some tests merged after we changed how we name the leveldb store used the old naming system.
This only affects some tests but when running they will leave a directory with the xpub name instead of creating inside the `testdata.leveldb` like other tests.

- Use the correct parameters when instantiating the leveldb store on tests

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
