### PR TITLE
feat: wallet service storage argument

### DIFF
--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -1348,4 +1348,16 @@ test('start', async () => {
     authKey: expect.anything(),
   });
   await wallet.stop();
+
+  // Check we throw an error when giving an invalid authxpriv
+  expect(() => {
+    return new HathorWalletServiceWallet({
+      requestPassword,
+      xpriv: acctKey,
+      authxpriv: 'invalid-xprivkey',
+      network,
+      passphrase: '',
+      storage,
+    });
+  }).toThrow('authxpriv parameter is an invalid hd privatekey');
 });

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -21,6 +21,11 @@ import { TxNotFoundError, SendTxError } from '../../src/errors';
 import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
 import transaction from '../../src/utils/transaction';
 import { TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
+import { MemoryStore, Storage } from '../../src/storage';
+import walletApi from '../../src/wallet/api/walletApi';
+import { WalletStatus } from '../../src/wallet/types';
+import wallet from '../../src/utils/wallet';
+import { resolve } from 'path';
 
 // Mock SendTransactionWalletService class so we don't try to send actual transactions
 // TODO: We should refactor the way we use classes from inside other classes. Using dependency injection would facilitate unit tests a lot and avoid mocks like this.
@@ -798,7 +803,7 @@ test('prepareDestroyAuthority', async () => {
   // Clear mocks
   spy1.mockRestore();
   spy2.mockRestore();
-  spy3.mockRestore();  
+  spy3.mockRestore();
 });
 
 test('destroyAuthority should throw if wallet is not ready', async () => {
@@ -1260,4 +1265,50 @@ test('createNFTs', async () => {
   spy2.mockRestore();
   spy3.mockRestore();
   spy4.mockRestore();
+});
+
+test('start', async () => {
+  const requestPassword = jest.fn();
+  const network = new Network('testnet');
+  const seed = defaultWalletSeed;
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+
+  jest.spyOn(HathorWalletServiceWallet.prototype, 'pollForWalletStatus').mockImplementation(() => Promise.resolve());
+  jest.spyOn(HathorWalletServiceWallet.prototype, 'setupConnection').mockImplementation(jest.fn());
+  jest.spyOn(walletApi, 'getNewAddresses')
+    .mockImplementation(() => Promise.resolve({ success: true, addresses: [] }));
+  jest.spyOn(walletApi, 'createWallet')
+    .mockImplementation(() => Promise.resolve({
+      success: true,
+      status: {
+        walletId: 'id',
+        xpubkey: 'xpub',
+        status: 'creating',
+        maxGap: 20,
+        createdAt: 0,
+        readyAt: 0,
+      },
+    }));
+
+  const wallet1 = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    storage,
+  });
+  await wallet1.start({ pinCode: '1234', password: '1234' });
+  await wallet1.stop();
+
+  // The storage should have the accessData
+  const wallet2 = new HathorWalletServiceWallet({
+    requestPassword,
+    seed,
+    network,
+    passphrase: '',
+    storage,
+  });
+  await wallet2.start({ pinCode: '1234', password: '1234' });
+  await wallet2.stop();
 });

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -462,6 +462,7 @@ const wallet = {
    * @param {string} [options.pin]
    * @param {string | undefined} [options.seed=undefined]
    * @param {string | undefined} [options.password=undefined]
+   * @param {string | undefined} [options.authXpriv=undefined]
    * @returns {IWalletAccessData}
    */
   generateAccessDataFromXpriv(

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -15,7 +15,7 @@ import Network from '../models/network';
 import _ from 'lodash';
 import helpers from './helpers';
 
-import { IMultisigData, IWalletAccessData, WalletType, WALLET_FLAGS } from '../types';
+import { IEncryptedData, IMultisigData, IWalletAccessData, WalletType, WALLET_FLAGS } from '../types';
 import { encryptData, decryptData } from './crypto';
 
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -65,7 +65,7 @@ export interface AddressInfoObject {
 export interface WalletStatusResponseData {
   success: boolean;
   status: WalletStatus;
-  error: string | undefined; // Optional error code when there is a problem creating the wallet
+  error?: string | undefined; // Optional error code when there is a problem creating the wallet
 }
 
 export interface WalletStatus {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -358,10 +358,10 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
           changeLevelPrivKey.xprivkey,
           {
             pin: pinCode,
+            authXpriv: this.authPrivKey.xprivkey!,
             // multisig: not implemented on wallet service yet
           },
         );
-        accessData.authKey = encryptData(this.authPrivKey.xprivkey!, pinCode);
       } else {
         throw new Error('This should never happen.');
       }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -95,7 +95,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   private xpub: string | null;
   // Xpriv of the wallet on the account derivation path
   private xpriv: string | null;
-  private authxpriv: string | null;
   // Xpriv of the auth derivation path
   private authPrivKey: bitcore.HDPrivateKey | null;
   // State of the wallet. One of the walletState enum options
@@ -177,9 +176,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.state = walletState.NOT_STARTED;
 
     this.xpriv = xpriv;
-    this.authxpriv = authxpriv;
     this.seed = seed;
     this.xpub = xpub;
+    this.authPrivKey = authxpriv ? bitcore.HDPrivateKey(authxpriv) : null;
 
     this.passphrase = passphrase
 
@@ -190,7 +189,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     this.isSendingTx = false;
     this.txProposalId = null;
     this.xpub = null;
-    this.authPrivKey = null;
 
     this.network = network;
     networkInstance.setNetwork(this.network.name);
@@ -363,7 +361,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
             // multisig: not implemented on wallet service yet
           },
         );
-        accessData.authKey = encryptData(this.authxpriv!, pinCode);
+        accessData.authKey = encryptData(this.authPrivKey.xprivkey!, pinCode);
       } else {
         throw new Error('This should never happen.');
       }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -134,8 +134,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     xpub?: string | null,
     network: Network,
     passphrase?: string,
-    enableWs: boolean,
-    storage: IStorage | null,
+    enableWs?: boolean,
+    storage?: IStorage | null,
   }) {
     super();
 
@@ -994,13 +994,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  stop({ cleanStorage = true } = {}) {
+  async stop({ cleanStorage = true } = {}) {
     this.walletId = null;
     this.state = walletState.NOT_STARTED;
     this.firstConnection = true;
     this.removeAllListeners();
 
-    this.storage.handleStop({ cleanStorage });
+    await this.storage.handleStop({ cleanStorage });
     this.conn.stop();
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- Allow starting a wallet-service facade passing the storage as argument
- When starting the wallet-service facade, use the accessData present on the storage if it exists.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
