### PR TITLE
feat: do not throw on getAccessData

### DIFF
--- a/__tests__/storage/leveldb/leveldb_store.test.js
+++ b/__tests__/storage/leveldb/leveldb_store.test.js
@@ -329,7 +329,7 @@ test('access data methods', async () => {
     walletType: WalletType.P2PKH,
   };
 
-  await expect(store.getAccessData()).rejects.toThrow();
+  await expect(store.getAccessData()).resolves.toEqual(null);
   await store.saveAccessData(accessData);
   await expect(store.getAccessData()).resolves.toMatchObject(accessData);
 

--- a/__tests__/storage/memory_store.test.js
+++ b/__tests__/storage/memory_store.test.js
@@ -274,7 +274,7 @@ test('access data methods', async () => {
     walletType: WalletType.P2PKH,
   };
 
-  await expect(store.getAccessData()).rejects.toThrow();
+  await expect(store.getAccessData()).resolves.toEqual(null);
   await store.saveAccessData(accessData);
   expect(store.accessData).toBe(accessData);
   await expect(store.getAccessData()).resolves.toBe(accessData);

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -17,7 +17,7 @@ import { createP2SHRedeemScript } from '../utils/scripts';
 import walletUtils from '../utils/wallet';
 import SendTransaction from './sendTransaction';
 import Network from '../models/network';
-import { AddressError, TxNotFoundError, UninitializedWalletError, WalletError, WalletFromXPubGuard } from '../errors';
+import { AddressError, TxNotFoundError, WalletError, WalletFromXPubGuard } from '../errors';
 import { ErrorMessages } from '../errorMessages';
 import P2SHSignature from '../models/p2sh_signature';
 import { HDPrivateKey } from 'bitcore-lib';
@@ -1270,20 +1270,8 @@ class HathorWallet extends EventEmitter {
       }
     }
 
-    let hasAccessData;
-    try {
-      const accessData = await this.storage.getAccessData();
-      hasAccessData = !!accessData;
-    } catch (err) {
-      if (err instanceof UninitializedWalletError) {
-        hasAccessData = false;
-      } else {
-        // Do not hide unexpected errors
-        throw err;
-      }
-    }
-    if (!hasAccessData) {
-      let accessData;
+    let accessData = await this.storage.getAccessData();
+    if (!accessData) {
       if (this.seed) {
         accessData = walletUtils.generateAccessDataFromSeed(
           this.seed,

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -12,7 +12,6 @@ import LevelHistoryIndex from './history_index';
 import LevelUtxoIndex from './utxo_index';
 import LevelWalletIndex from './wallet_index';
 import LevelTokenIndex from './token_index';
-import { UninitializedWalletError } from '../../errors';
 
 export default class LevelDBStore implements IStore {
   addressIndex: LevelAddressIndex;
@@ -272,11 +271,7 @@ export default class LevelDBStore implements IStore {
   }
 
   async getAccessData(): Promise<IWalletAccessData | null> {
-    const accessData = await this.walletIndex.getAccessData();
-    if (accessData === null) {
-      throw new UninitializedWalletError();
-    }
-    return accessData;
+    return this.walletIndex.getAccessData();
   }
 
   async getLastLoadedAddressIndex(): Promise<number> {

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -20,7 +20,6 @@ import {
 } from '../types';
 import { BLOCK_VERSION, GAP_LIMIT, HATHOR_TOKEN_CONFIG } from '../constants';
 import { orderBy } from 'lodash';
-import { UninitializedWalletError } from '../errors';
 
 
 const DEFAULT_ADDRESSES_WALLET_DATA = {
@@ -693,9 +692,6 @@ export class MemoryStore implements IStore {
    * @returns {Promise<IWalletAccessData | null>} A promise with the wallet access data.
    */
   async getAccessData(): Promise<IWalletAccessData | null> {
-    if (this.accessData === null) {
-      throw new UninitializedWalletError();
-    }
     return this.accessData;
   }
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -36,6 +36,7 @@ import FullNodeConnection from '../new/connection';
 import { getAddressType } from '../utils/address';
 import walletUtils from '../utils/wallet';
 import { HATHOR_TOKEN_CONFIG, MAX_INPUTS, MAX_OUTPUTS, TOKEN_DEPOSIT_PERCENTAGE } from '../constants';
+import { UninitializedWalletError } from '../errors';
 
 const DEFAULT_ADDRESS_META: IAddressMetadata = {
   numTransactions: 0,
@@ -634,7 +635,7 @@ export class Storage implements IStorage {
   async _getValidAccessData(): Promise<IWalletAccessData> {
     const accessData = await this.getAccessData();
     if (!accessData) {
-      throw new Error('Wallet was not initialized');
+      throw new UninitializedWalletError();
     }
     return accessData;
   }


### PR DESCRIPTION
### Acceptance Criteria

- Allow getAccessData to return null when it is not set, methods that require access data to be set should throw `UninitializedWalletError`


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
