### PR TITLE
feat: add new parameter to set authority address for mint/melt when creating a token

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -2689,7 +2689,7 @@ describe('createNFT', () => {
     const addr0 = hWallet.getAddressAtIndex(0);
     const addr10 = hWallet.getAddressAtIndex(10);
     const addr11 = hWallet.getAddressAtIndex(11);
-    await GenesisWalletHelper.injectFunds(addr0, 1);
+    await GenesisWalletHelper.injectFunds(addr0, 10);
 
     // Creating the new token
     const newTokenResponse = await hWallet.createNFT(
@@ -2741,7 +2741,7 @@ describe('createNFT', () => {
     const addr0 = hWallet.getAddressAtIndex(0);
     const addr2_0 = hWallet2.getAddressAtIndex(0);
     const addr2_1 = hWallet2.getAddressAtIndex(1);
-    await GenesisWalletHelper.injectFunds(addr0, 1);
+    await GenesisWalletHelper.injectFunds(addr0, 10);
 
     // Error creating token with external address
     await expect(hWallet.createNFT(

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1735,6 +1735,7 @@ describe('createNewToken', () => {
   it('Create token using mint/melt address', async () => {
     // Creating the wallet with the funds
     const hWallet = await generateWalletHelper();
+    const addr0 = hWallet.getAddressAtIndex(0);
     const addr10 = hWallet.getAddressAtIndex(10);
     const addr11 = hWallet.getAddressAtIndex(11);
     await GenesisWalletHelper.injectFunds(addr0, 1);
@@ -1747,13 +1748,14 @@ describe('createNewToken', () => {
       {
         createMint: true,
         mintAuthorityAddress: addr10,
-        createMelt: true
+        createMelt: true,
         meltAuthorityAddress: addr11,
       }
     );
 
     // Validating the creation tx
     expect(newTokenResponse).toHaveProperty('hash');
+    await waitForTxReceived(hWallet, newTokenResponse.hash);
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(
@@ -1763,16 +1765,16 @@ describe('createNewToken', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput.parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the mint output was sent to the correct address
-    expect(mintP2pkh.address.base58).toEqual(address10);
+    expect(mintP2pkh.address.base58).toEqual(addr10);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput.parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the melt output was sent to the correct address
-    expect(meltP2pkh.address.base58).toEqual(address11);
+    expect(meltP2pkh.address.base58).toEqual(addr11);
 
     // Validating custom token balance
     const tokenBalance = await hWallet.getBalance(newTokenResponse.hash);
@@ -1784,6 +1786,7 @@ describe('createNewToken', () => {
     // Creating the wallet with the funds
     const hWallet = await generateWalletHelper();
     const hWallet2 = await generateWalletHelper();
+    const addr0 = hWallet.getAddressAtIndex(0);
     const addr2_0 = hWallet2.getAddressAtIndex(0);
     const addr2_1 = hWallet2.getAddressAtIndex(1);
     await GenesisWalletHelper.injectFunds(addr0, 1);
@@ -1824,7 +1827,7 @@ describe('createNewToken', () => {
         createMint: true,
         mintAuthorityAddress: addr2_0,
         allowExternalMintAuthorityAddress: true,
-        createMelt: true
+        createMelt: true,
         meltAuthorityAddress: addr2_1,
         allowExternalMeltAuthorityAddress: true,
       }
@@ -1832,6 +1835,7 @@ describe('createNewToken', () => {
 
     // Validating the creation tx
     expect(newTokenResponse).toHaveProperty('hash');
+    await waitForTxReceived(hWallet, newTokenResponse.hash);
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(
@@ -1841,16 +1845,16 @@ describe('createNewToken', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput.parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the mint output was sent to the correct address
-    expect(mintP2pkh.address.base58).toEqual(address2_0);
+    expect(mintP2pkh.address.base58).toEqual(addr2_0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput.parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the melt output was sent to the correct address
-    expect(meltP2pkh.address.base58).toEqual(address2_1);
+    expect(meltP2pkh.address.base58).toEqual(addr2_1);
 
     // Validating custom token balance
     const tokenBalance = await hWallet.getBalance(newTokenResponse.hash);
@@ -2682,6 +2686,7 @@ describe('createNFT', () => {
   it('Create token using mint/melt address', async () => {
     // Creating the wallet with the funds
     const hWallet = await generateWalletHelper();
+    const addr0 = hWallet.getAddressAtIndex(0);
     const addr10 = hWallet.getAddressAtIndex(10);
     const addr11 = hWallet.getAddressAtIndex(11);
     await GenesisWalletHelper.injectFunds(addr0, 1);
@@ -2695,13 +2700,14 @@ describe('createNFT', () => {
       {
         createMint: true,
         mintAuthorityAddress: addr10,
-        createMelt: true
+        createMelt: true,
         meltAuthorityAddress: addr11,
       }
     );
 
     // Validating the creation tx
     expect(newTokenResponse).toHaveProperty('hash');
+    await waitForTxReceived(hWallet, newTokenResponse.hash);
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(
@@ -2711,16 +2717,16 @@ describe('createNFT', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput.parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the mint output was sent to the correct address
-    expect(mintP2pkh.address.base58).toEqual(address10);
+    expect(mintP2pkh.address.base58).toEqual(addr10);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput.parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the melt output was sent to the correct address
-    expect(meltP2pkh.address.base58).toEqual(address11);
+    expect(meltP2pkh.address.base58).toEqual(addr11);
 
     // Validating custom token balance
     const tokenBalance = await hWallet.getBalance(newTokenResponse.hash);
@@ -2732,6 +2738,7 @@ describe('createNFT', () => {
     // Creating the wallet with the funds
     const hWallet = await generateWalletHelper();
     const hWallet2 = await generateWalletHelper();
+    const addr0 = hWallet.getAddressAtIndex(0);
     const addr2_0 = hWallet2.getAddressAtIndex(0);
     const addr2_1 = hWallet2.getAddressAtIndex(1);
     await GenesisWalletHelper.injectFunds(addr0, 1);
@@ -2775,7 +2782,7 @@ describe('createNFT', () => {
         createMint: true,
         mintAuthorityAddress: addr2_0,
         allowExternalMintAuthorityAddress: true,
-        createMelt: true
+        createMelt: true,
         meltAuthorityAddress: addr2_1,
         allowExternalMeltAuthorityAddress: true,
       }
@@ -2783,6 +2790,7 @@ describe('createNFT', () => {
 
     // Validating the creation tx
     expect(newTokenResponse).toHaveProperty('hash');
+    await waitForTxReceived(hWallet, newTokenResponse.hash);
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(
@@ -2792,16 +2800,16 @@ describe('createNFT', () => {
     const mintOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MINT_MASK
     );
-    const mintP2pkh = mintOutput.parseScript(hWallet.getNetworkObject());
+    const mintP2pkh = mintOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the mint output was sent to the correct address
-    expect(mintP2pkh.address.base58).toEqual(address2_0);
+    expect(mintP2pkh.address.base58).toEqual(addr2_0);
 
     const meltOutput = authorityOutputs.filter(
       o => o.value === TOKEN_MELT_MASK
     );
-    const meltP2pkh = meltOutput.parseScript(hWallet.getNetworkObject());
+    const meltP2pkh = meltOutput[0].parseScript(hWallet.getNetworkObject());
     // Validate that the melt output was sent to the correct address
-    expect(meltP2pkh.address.base58).toEqual(address2_1);
+    expect(meltP2pkh.address.base58).toEqual(addr2_1);
 
     // Validating custom token balance
     const tokenBalance = await hWallet.getBalance(newTokenResponse.hash);

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -333,7 +333,9 @@ const tokens = {
    *  {
    *   'changeAddress': address of the change output,
    *   'createMint': if should create another mint authority
+   *   'mintAuthorityAddress': the address to send the mint authority created
    *   'createMelt': if should create melt authority
+   *   'meltAuthorityAddress': the address to send the melt authority created
    *   'nftData': Data for NFT first output,
    *  }
    *
@@ -346,16 +348,27 @@ const tokens = {
     const newOptions = Object.assign({
       changeAddress: null,
       createMint: true,
+      mintAuthorityAddress: null,
       createMelt: true,
+      meltAuthorityAddress: null,
       nftData: null
     }, options);
-    const { changeAddress, createMint, createMelt, nftData } = newOptions;
+    const {
+      changeAddress,
+      createMint,
+      mintAuthorityAddress,
+      createMelt,
+      meltAuthorityAddress,
+      nftData
+    } = newOptions;
 
     const isNFT = nftData !== null;
 
     const mintOptions = {
       createAnotherMint: createMint,
+      mintAuthorityAddress,
       createMelt,
+      meltAuthorityAddress,
       changeAddress,
       isNFT,
     };
@@ -456,6 +469,7 @@ const tokens = {
    *   {boolean} createAnotherMint If should create another mint output after spending this one
    *   {string} mintAuthorityAddress The address to send the new mint authority created
    *   {boolean} createMelt If should create a melt output (useful when creating a new token)
+   *   {string} meltAuthorityAddress The address to send the new melt authority created
    *   {string} changeAddress Address to send the change of HTR after mint deposit
    *   {boolean} isNFT If it's getting mint data for an NFT
    * }
@@ -472,11 +486,12 @@ const tokens = {
       createAnotherMint: true,
       mintAuthorityAddress: null,
       createMelt: false,
+      meltAuthorityAddress: null,
       changeAddress: null,
       isNFT: false,
     }, options);
 
-    const { createAnotherMint, mintAuthorityAddress, createMelt, changeAddress, isNFT } = fnOptions;
+    const { createAnotherMint, mintAuthorityAddress, createMelt, meltAuthorityAddress, changeAddress, isNFT } = fnOptions;
     const inputs = [];
     const outputs = [];
 
@@ -515,7 +530,7 @@ const tokens = {
 
     if (createMelt) {
       // We create a melt output for this wallet when creating the token
-      const newAddress2 = wallet.getAddressToUse();
+      const newAddress2 = meltAuthorityAddress || wallet.getAddressToUse();
       outputs.push({'address': newAddress2, 'value': TOKEN_MELT_MASK, 'tokenData': AUTHORITY_TOKEN_DATA});
     }
 


### PR DESCRIPTION
### Acceptance Criteria
- Create token and create NFT methods must have a parameter to set the address to send the authority (mint/melt) output created.
- This feature is a back port, so it was just done in the old facade because it doesn't need support for the wallet service facade for now.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
