### PR TITLE
chore: increase coverage target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,7 +6,7 @@ coverage:
     project:
       default:
         # minimum coverage ratio that the commit must meet to be considered a success
-        target: 40%
+        target: 75%
         if_ci_failed: error
         only_pulls: true
     patch:


### PR DESCRIPTION
### Motivation

@pedroferreira1 merged the coverage from the unit and integration tests, this made the project coverage jump to over 75%.

### Acceptance Criteria
- Increase project coverage target to 75%


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
