### PR TITLE
fix: in some cases we could stop sending pings in the websocket

### DIFF
--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -191,10 +191,7 @@ abstract class BaseWebSocket extends EventEmitter {
       this.latestRTT = dt;
       this.latestPingDate = null;
     }
-    if (this.timeoutTimer) {
-      clearTimeout(this.timeoutTimer);
-      this.timeoutTimer = null;
-    }
+    this.clearPongTimeoutTimer();
   }
 
   /**
@@ -224,6 +221,7 @@ abstract class BaseWebSocket extends EventEmitter {
     this.removeAllListeners();
     this.endConnection();
     this.clearSetupTimer();
+    this.clearPongTimeoutTimer();
   }
 
   /**
@@ -237,16 +235,28 @@ abstract class BaseWebSocket extends EventEmitter {
   }
 
   /**
+   * Clears the pong timeout timer if it exists
+   */
+  clearPongTimeoutTimer() {
+    if (this.timeoutTimer) {
+      clearTimeout(this.timeoutTimer);
+      this.timeoutTimer = null;
+    }
+  }
+
+  /**
    * Method called when websocket connection is closed
    */
   onClose() {
     this.started = false;
     this.connected = false;
     this.connectedDate = null;
+    this.latestPingDate = null;
     this.setIsOnline(false);
     this.closeWs();
 
     this.clearSetupTimer();
+    this.clearPongTimeoutTimer();
     this.setupTimer = setTimeout(() => this.setup(), this.retryConnectionInterval);
     // @ts-ignore
     clearInterval(this.heartbeat);


### PR DESCRIPTION
### Acceptance Criteria
We should make sure some variables related to the ping/pong in the fullnode websocket are cleared in case the connection is closed for whatever reason.

I've seen in some tests that the ping could stop being sent, specifically because the variable `latestPingDate` wouldn't be cleared, since it's checked before sending the ping.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
