### PR TITLE
feat: add signTx param to sign transaction as optional

### DIFF
--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -5,12 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import Address from '../../src/models/address';
 import HathorWallet from '../../src/new/wallet';
 import { TxNotFoundError, WalletFromXPubGuard } from '../../src/errors';
 import Network from '../../src/models/network';
 import Transaction from '../../src/models/transaction';
 import Input from '../../src/models/input';
-import { DEFAULT_TX_VERSION, P2PKH_ACCT_PATH } from '../../src/constants';
+import {
+  DEFAULT_TX_VERSION,
+  P2PKH_ACCT_PATH,
+  TOKEN_MINT_MASK,
+  TOKEN_MELT_MASK,
+} from '../../src/constants';
 import { HDPrivateKey } from 'bitcore-lib';
 import transactionUtils from '../../src/utils/transaction';
 import { MemoryStore, Storage } from '../../src/storage';
@@ -820,3 +826,154 @@ test('isHardwareWallet', async () => {
   hwSpy.mockReturnValue(Promise.resolve(false));
   await expect(hWallet.isHardwareWallet()).resolves.toBe(false);
 });
+
+describe('prepare transactions without signature', () => {
+  /**
+   * Generate an async generator that yields utxo.
+   */
+  const generateSelectUtxos = (utxo) => {
+    async function* fakeSelectUtxos(_options) {
+      yield utxo;
+    }
+    return fakeSelectUtxos;
+  }
+
+  /**
+   * Return an instance of Storage with mocks to support the tests.
+   */
+  const getStorage = (params) => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    jest.spyOn(storage, 'isReadonly').mockReturnValue(params.readOnly);
+    jest.spyOn(storage, 'getCurrentAddress').mockResolvedValue(params.currentAddress);
+    jest.spyOn(storage, 'selectUtxos').mockImplementation(params.selectUtxos);
+    return storage;
+  };
+
+  const fakeAddress = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo');
+  const fakeTokenToDepositUtxo = {
+    txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+    index: 0,
+    value: 2,
+    token: '00',
+    address: fakeAddress.base58,
+    authorities: 0,
+  };
+
+  test('prepareCreateNewToken', async () => {
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = getStorage({
+      readOnly: false,
+      currentAddress: fakeAddress.base58,
+      selectUtxos: generateSelectUtxos(fakeTokenToDepositUtxo)
+    });
+
+    // prepare create token
+    const txData = await hWallet.prepareCreateNewToken('01', 'my01', 100, {
+      address: fakeAddress.base58,
+      pinCode: '1234',
+      signTx: false, // skip the signature
+    });
+
+    // assert the transaction is not signed
+    expect(txData.inputs).toHaveLength(1);
+    expect(txData.inputs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        data: null,
+      }),
+    ]));
+  });
+
+  test('prepareMintTokensData', async () => {
+    // fake stuff to support the test
+    const fakeMintAuthority = [{
+      txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+      index: 0,
+      value: 1,
+      token: '01',
+      address: fakeAddress.base58,
+      authorities: TOKEN_MINT_MASK,
+      timelock: null,
+      locked: false,
+    }];
+
+    // wallet and mocks
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = getStorage({
+      readOnly: false,
+      currentAddress: fakeAddress.base58,
+      selectUtxos: generateSelectUtxos(fakeTokenToDepositUtxo),
+    });
+    jest.spyOn(hWallet, 'getMintAuthority').mockReturnValue(fakeMintAuthority);
+
+    // prepare mint
+    const txData = await hWallet.prepareMintTokensData('01', 100, {
+      address: fakeAddress.base58,
+      pinCode: '1234',
+      signTx: false, // skip the signature
+    });
+
+    // assert the transaction is not signed
+    expect(txData.inputs).toHaveLength(2);
+    expect(txData.inputs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        data: null,
+      }),
+      expect.objectContaining({
+        data: null,
+      }),
+    ]));
+  });
+
+  test('prepareMeltTokensData', async () => {
+    // fake stuff to support the test
+    const fakeTokenToMeltUtxo = {
+      txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+      index: 0,
+      value: 100,
+      token: '01',
+      address: fakeAddress.base58,
+      authorities: 0,
+      timelock: null,
+      locked: false,
+    };
+    const fakeMeltAuthority = [{
+      txId: '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
+      index: 0,
+      value: 1,
+      token: '01',
+      address: fakeAddress.base58,
+      authorities: TOKEN_MELT_MASK,
+      timelock: null,
+      locked: false,
+    }];
+
+    // wallet and mocks
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = getStorage({
+      readOnly: false,
+      currentAddress: fakeAddress.base58,
+      selectUtxos: generateSelectUtxos(fakeTokenToMeltUtxo),
+    });
+    jest.spyOn(hWallet, 'getMeltAuthority').mockReturnValue(fakeMeltAuthority);
+
+    // prepare melt
+    const txData = await hWallet.prepareMeltTokensData('01', 100, {
+      address: fakeAddress.base58,
+      pinCode: '1234',
+      signTx: false, // skip the signature
+    });
+
+    // assert the transaction is not signed
+    expect(txData.inputs).toHaveLength(2);
+    expect(txData.inputs).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        data: null,
+      }),
+      expect.objectContaining({
+        data: null,
+      }),
+    ]));
+  });
+});
+

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -524,6 +524,22 @@ test('prepareMintTokens', async () => {
     pinCode: '123456',
   })).rejects.toThrowError(SendTxError);
 
+  // mint data without sign the transaction
+  const mintDataNotSigned = await wallet.prepareMintTokensData('01', 100, {
+    address: addresses[1],
+    mintAuthorityAddress: addresses[2],
+    pinCode: '123456',
+    signTx: false
+  });
+  expect(mintDataNotSigned.inputs).toEqual([
+    expect.objectContaining({
+      data: null,
+    }),
+    expect.objectContaining({
+      data: null,
+    }),
+  ])
+
   // mint data with correct address for authority output
   const mintData = await wallet.prepareMintTokensData('01', 100, {
     address: addresses[1],
@@ -532,6 +548,14 @@ test('prepareMintTokens', async () => {
     pinCode: '123456',
   });
 
+  expect(mintDataNotSigned.inputs).toEqual([
+    expect.objectContaining({
+      data: expect.any(Object),
+    }),
+    expect.objectContaining({
+      data: expect.any(Object),
+    }),
+  ])
   expect(mintData.outputs).toHaveLength(2);
 
   const authorityOutputs = mintData.outputs.filter(
@@ -640,6 +664,22 @@ test('prepareMeltTokens', async () => {
     pinCode: '123456',
   })).rejects.toThrowError(SendTxError);
 
+  // melt data without sign the transaction
+  const meltDataNotSigned = await wallet.prepareMeltTokensData('01', 100, {
+    address: addresses[1],
+    meltAuthorityAddress: addresses[2],
+    pinCode: '123456',
+    signTx: false
+  });
+  expect(meltDataNotSigned.inputs).toEqual([
+    expect.objectContaining({
+      data: null,
+    }),
+    expect.objectContaining({
+      data: null,
+    }),
+  ])
+
   // melt data with correct address for authority output
   const meltData = await wallet.prepareMeltTokensData('01', 1, {
     address: addresses[1],
@@ -648,6 +688,14 @@ test('prepareMeltTokens', async () => {
     pinCode: '123456',
   });
 
+  expect(meltDataNotSigned.inputs).toEqual([
+    expect.objectContaining({
+      data: expect.any(Object),
+    }),
+    expect.objectContaining({
+      data: expect.any(Object),
+    }),
+  ])
   expect(meltData.outputs).toHaveLength(1);
 
   const authorityOutputs = meltData.outputs.filter(
@@ -1129,6 +1177,19 @@ test('createTokens', async () => {
     pinCode: '123456',
   })).rejects.toThrowError(SendTxError);
 
+  // create token without sign the transaction
+  const tokenDataNotSigned = await wallet.prepareCreateNewToken('Test Token', 'TST', 100, {
+    address: addresses[1],
+    mintAuthorityAddress: addresses[2],
+    pinCode: '123456',
+    signTx: false,
+  });
+  expect(tokenDataNotSigned.inputs).toEqual([
+    expect.objectContaining({
+      data: null,
+    }),
+  ])
+
   // create token with correct address for authority output
   const tokenData = await wallet.prepareCreateNewToken('Test Token', 'TST', 100, {
     address: addresses[1],
@@ -1137,6 +1198,11 @@ test('createTokens', async () => {
     pinCode: '123456',
   });
 
+  expect(tokenData.inputs).toEqual([
+    expect.objectContaining({
+      data: expect.any(Object),
+    }),
+  ])
   expect(tokenData.outputs).toHaveLength(3);
 
   const authorityOutputs = tokenData.outputs.filter(

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1421,6 +1421,8 @@ class HathorWallet extends EventEmitter {
    *                                                                    to be from another wallet
    * @param {string} [options.nftData] data string for NFT
    *
+   * @param {boolean} [options.signTx] sign transaction instance (default true)
+   *
    * @return {CreateTokenTransaction} Promise that resolves with transaction object if succeeds
    * or with error message if it fails
    *
@@ -1442,7 +1444,8 @@ class HathorWallet extends EventEmitter {
       createMelt: true,
       meltAuthorityAddress: null,
       allowExternalMeltAuthorityAddress: false,
-      nftData: null
+      nftData: null,
+      signTx: true,
     }, options);
 
     const pin = newOptions.pinCode || this.pinCode;
@@ -1483,7 +1486,12 @@ class HathorWallet extends EventEmitter {
         nftData: newOptions.nftData
       },
     );
-    return await transactionUtils.prepareTransaction(txData, pin, this.storage);
+    return await transactionUtils.prepareTransaction(
+      txData,
+      pin,
+      this.storage,
+      newOptions.signTx
+    );
   }
 
   /**
@@ -1615,6 +1623,7 @@ class HathorWallet extends EventEmitter {
    *   'mintAuthorityAddress': address to send the new mint authority created
    *   'allowExternalMintAuthorityAddress': boolean allow the mint authority address to be from another wallet (default false)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
+   *   'signTx': boolean to sign transaction instance (default true)
    *  }
    *
    * @return {Promise} Promise that resolves with transaction object if succeeds
@@ -1634,6 +1643,7 @@ class HathorWallet extends EventEmitter {
       mintAuthorityAddress: null,
       allowExternalMintAuthorityAddress: false,
       pinCode: null,
+      signTx: true,
     }, options);
 
     const pin = newOptions.pinCode || this.pinCode;
@@ -1670,7 +1680,12 @@ class HathorWallet extends EventEmitter {
       this.storage,
       mintOptions,
     );
-    return await transactionUtils.prepareTransaction(txData, pin, this.storage);
+    return await transactionUtils.prepareTransaction(
+      txData,
+      pin,
+      this.storage,
+      newOptions.signTx
+    );
   }
 
   /**
@@ -1716,6 +1731,7 @@ class HathorWallet extends EventEmitter {
    *   'meltAuthorityAddress': address to send the new melt authority created
    *   'allowExternalMeltAuthorityAddress': boolean allow the melt authority address to be from another wallet (default false)
    *   'pinCode': pin to decrypt xpriv information. Optional but required if not set in this
+   *   'signTx': boolean to sign transaction instance (default true)
    *  }
    *
    * @return {Promise} Promise that resolves with transaction object if succeeds
@@ -1735,6 +1751,7 @@ class HathorWallet extends EventEmitter {
       meltAuthorityAddress: null,
       allowExternalMeltAuthorityAddress: false,
       pinCode: null,
+      signTx: true,
     }, options);
 
     const pin = newOptions.pinCode || this.pinCode;
@@ -1769,7 +1786,12 @@ class HathorWallet extends EventEmitter {
       this.storage,
       meltOptions,
     );
-    return await transactionUtils.prepareTransaction(txData, pin, this.storage);
+    return await transactionUtils.prepareTransaction(
+      txData,
+      pin,
+      this.storage,
+      newOptions.signTx
+    );
   }
 
   /**

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1490,7 +1490,9 @@ class HathorWallet extends EventEmitter {
       txData,
       pin,
       this.storage,
-      newOptions.signTx
+      {
+        signTx: newOptions.signTx,
+      },
     );
   }
 
@@ -1684,7 +1686,9 @@ class HathorWallet extends EventEmitter {
       txData,
       pin,
       this.storage,
-      newOptions.signTx
+      {
+        signTx: newOptions.signTx,
+      },
     );
   }
 
@@ -1790,7 +1794,9 @@ class HathorWallet extends EventEmitter {
       txData,
       pin,
       this.storage,
-      newOptions.signTx
+      {
+        signTx: newOptions.signTx,
+      },
     );
   }
 

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -449,12 +449,15 @@ const transaction = {
    * @param tx tx data to be prepared
    * @param pinCode pin to unlock the mainKey for signatures
    * @param storage Storage to get the mainKey
+   * @param signTx sign transaction instance (default true)
    * @returns {Promise<Transaction>} Prepared transaction
    */
-  async prepareTransaction(txData: IDataTx, pinCode: string, storage: IStorage): Promise<Transaction> {
+  async prepareTransaction(txData: IDataTx, pinCode: string, storage: IStorage, signTx = true): Promise<Transaction> {
     const network = storage.config.getNetwork();
     const tx = this.createTransactionFromData(txData, network);
-    await this.signTransaction(tx, storage, pinCode);
+    if (signTx) {
+      await this.signTransaction(tx, storage, pinCode);
+    }
     tx.prepareToSend();
 
     return tx;

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -449,13 +449,22 @@ const transaction = {
    * @param tx tx data to be prepared
    * @param pinCode pin to unlock the mainKey for signatures
    * @param storage Storage to get the mainKey
-   * @param signTx sign transaction instance (default true)
+   * @param {Object} [options]
+   * @param {boolean} [options.signTx=true] sign transaction instance
    * @returns {Promise<Transaction>} Prepared transaction
    */
-  async prepareTransaction(txData: IDataTx, pinCode: string, storage: IStorage, signTx = true): Promise<Transaction> {
+  async prepareTransaction(
+    txData: IDataTx,
+    pinCode: string,
+    storage: IStorage,
+    options?: { signTx?: boolean },
+  ): Promise<Transaction> {
+    const newOptions = Object.assign({
+      signTx: true,
+    }, options);
     const network = storage.config.getNetwork();
     const tx = this.createTransactionFromData(txData, network);
-    if (signTx) {
+    if (newOptions.signTx) {
       await this.signTransaction(tx, storage, pinCode);
     }
     tx.prepareToSend();

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1173,6 +1173,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       allowExternalMeltAuthorityAddress: boolean | null,
       nftData: string | null,
       pinCode: string | null,
+      signTx: boolean,
     };
     const newOptions: optionsType = Object.assign({
       address: null,
@@ -1185,6 +1186,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       allowExternalMeltAuthorityAddress: false,
       nftData: null,
       pinCode: null,
+      signTx: true,
     }, options);
 
     if (newOptions.mintAuthorityAddress && !newOptions.allowExternalMintAuthorityAddress) {
@@ -1282,21 +1284,24 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new CreateTokenTransaction(name, symbol, inputsObj, outputsObj);
 
-    const dataToSignHash = tx.getDataToSignHash();
+    // Sign transaction
+    if(newOptions.signTx) {
+      const dataToSignHash = tx.getDataToSignHash();
 
-    if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareCreateNewToken options');
-    }
+      if (!newOptions.pinCode) {
+        throw new Error('PIN not specified in prepareCreateNewToken options');
+      }
 
-    const xprivkey = await this.storage.getMainXPrivKey(newOptions.pinCode);
+      const xprivkey = await this.storage.getMainXPrivKey(newOptions.pinCode);
 
-    for (const [idx, inputObj] of tx.inputs.entries()) {
-      const inputData = this.getInputData(
-        xprivkey,
-        dataToSignHash,
-        HathorWalletServiceWallet.getAddressIndexFromFullPath(utxosAddressPath[idx]),
-      );
-      inputObj.setData(inputData);
+      for (const [idx, inputObj] of tx.inputs.entries()) {
+        const inputData = this.getInputData(
+          xprivkey,
+          dataToSignHash,
+          HathorWalletServiceWallet.getAddressIndexFromFullPath(utxosAddressPath[idx]),
+        );
+        inputObj.setData(inputData);
+      }
     }
 
     tx.prepareToSend();
@@ -1411,6 +1416,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       mintAuthorityAddress: string | null,
       allowExternalMintAuthorityAddress: boolean,
       pinCode: string | null,
+      signTx: boolean,
     };
     const newOptions: optionsType = Object.assign({
       address: null,
@@ -1419,6 +1425,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       mintAuthorityAddress: null,
       allowExternalMintAuthorityAddress: false,
       pinCode: null,
+      signTx: true,
     }, options);
 
     if (newOptions.mintAuthorityAddress && !newOptions.allowExternalMintAuthorityAddress) {
@@ -1494,23 +1501,27 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new Transaction(inputsObj, outputsObj);
     tx.tokens = [token];
-    const dataToSignHash = tx.getDataToSignHash();
 
-    if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareMintTokensData options');
-    }
+    // Sign transaction
+    if (newOptions.signTx) {
+      const dataToSignHash = tx.getDataToSignHash();
 
-    const xprivkey = await this.storage.getMainXPrivKey(newOptions.pinCode);
+      if (!newOptions.pinCode) {
+        throw new Error('PIN not specified in prepareMintTokensData options');
+      }
 
-    for (const [idx, inputObj] of tx.inputs.entries()) {
-      // We have an array of utxos and the last input is the one with the authority
-      const addressPath = idx === tx.inputs.length - 1 ? mintUtxo.addressPath : utxos[idx].addressPath;
-      const inputData = this.getInputData(
-        xprivkey,
-        dataToSignHash,
-        HathorWalletServiceWallet.getAddressIndexFromFullPath(addressPath),
-      );
-      inputObj.setData(inputData);
+      const xprivkey = await this.storage.getMainXPrivKey(newOptions.pinCode);
+
+      for (const [idx, inputObj] of tx.inputs.entries()) {
+        // We have an array of utxos and the last input is the one with the authority
+        const addressPath = idx === tx.inputs.length - 1 ? mintUtxo.addressPath : utxos[idx].addressPath;
+        const inputData = this.getInputData(
+          xprivkey,
+          dataToSignHash,
+          HathorWalletServiceWallet.getAddressIndexFromFullPath(addressPath),
+        );
+        inputObj.setData(inputData);
+      }
     }
 
     tx.prepareToSend();
@@ -1559,6 +1570,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       meltAuthorityAddress: string | null,
       allowExternalMeltAuthorityAddress: boolean,
       pinCode: string | null,
+      signTx: boolean,
     };
     const newOptions: optionsType = Object.assign({
       address: null,
@@ -1567,6 +1579,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       meltAuthorityAddress: null,
       allowExternalMeltAuthorityAddress: false,
       pinCode: null,
+      signTx: true,
     }, options);
 
     if (newOptions.meltAuthorityAddress && !newOptions.allowExternalMeltAuthorityAddress) {
@@ -1650,23 +1663,27 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = new Transaction(inputsObj, outputsObj);
     tx.tokens = [token];
-    const dataToSignHash = tx.getDataToSignHash();
 
-    if (!newOptions.pinCode) {
-      throw new Error('PIN not specified in prepareMeltTokensData options');
-    }
+    // Sign transaction
+    if(newOptions.signTx) {
+      const dataToSignHash = tx.getDataToSignHash();
 
-    const xprivkey = await this.storage.getMainXPrivKey(newOptions.pinCode);
+      if (!newOptions.pinCode) {
+        throw new Error('PIN not specified in prepareMeltTokensData options');
+      }
 
-    for (const [idx, inputObj] of tx.inputs.entries()) {
-      // We have an array of utxos and the last input is the one with the authority
-      const addressPath = idx === tx.inputs.length - 1 ? meltUtxo.addressPath : utxos[idx].addressPath;
-      const inputData = this.getInputData(
-        xprivkey,
-        dataToSignHash,
-        HathorWalletServiceWallet.getAddressIndexFromFullPath(addressPath),
-      );
-      inputObj.setData(inputData);
+      const xprivkey = await this.storage.getMainXPrivKey(newOptions.pinCode);
+
+      for (const [idx, inputObj] of tx.inputs.entries()) {
+        // We have an array of utxos and the last input is the one with the authority
+        const addressPath = idx === tx.inputs.length - 1 ? meltUtxo.addressPath : utxos[idx].addressPath;
+        const inputData = this.getInputData(
+          xprivkey,
+          dataToSignHash,
+          HathorWalletServiceWallet.getAddressIndexFromFullPath(addressPath),
+        );
+        inputObj.setData(inputData);
+      }
     }
 
     tx.prepareToSend();

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1285,7 +1285,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const tx = new CreateTokenTransaction(name, symbol, inputsObj, outputsObj);
 
     // Sign transaction
-    if(newOptions.signTx) {
+    if (newOptions.signTx) {
       const dataToSignHash = tx.getDataToSignHash();
 
       if (!newOptions.pinCode) {
@@ -1665,7 +1665,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     tx.tokens = [token];
 
     // Sign transaction
-    if(newOptions.signTx) {
+    if (newOptions.signTx) {
       const dataToSignHash = tx.getDataToSignHash();
 
       if (!newOptions.pinCode) {


### PR DESCRIPTION
### Acceptance Criteria
- add param signTx to prepareTransaction in src/utils/transaction.ts
- add optional attribute to prepareCreateNewToken in src/new/wallet.ts
- add optional attribute to prepareMintTokensData in src/new/wallet.ts
- add optional attribute to prepareMeltTokensData in src/new/wallet.ts


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
