### PR TITLE
chore: actually use babel to compile lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "test": "jest --env=node --forceExit",
     "test:watch": "jest --watch --env=node",
-    "build": "babel -d lib/ src && tsc",
+    "build": "babel -d lib --extensions \".ts,.js\" src && tsc",
     "tsc": "tsc",
     "test_integration": "npm run test_network_up && npm run test_network_integration && npm run test_network_down",
     "test_network_up": "docker-compose -f ./__tests__/integration/configuration/docker-compose.yml up -d && mkdir -p tmp && cp ./__tests__/integration/configuration/precalculated-wallets.json ./tmp/wallets.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
     "baseUrl": ".",
     "noImplicitAny": false,
     "rootDir": "./src",
-    "declaration": true
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "isolatedModules": true
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
### Acceptance Criteria

- Use babel to compile lib files

### Summary

The babel was only building js files which are very few after we refactored the lib to use primarily typescript.
To fix this we will use babel to build all js files then use tsc only to type check and emit type declarations.
This idea and configuration was taken from the typescript documentation ([reference](https://www.typescriptlang.org/docs/handbook/babel-with-typescript.html#babel-for-transpiling-tsc-for-types))


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
