### PR TITLE
test: Add NodeJS v16 and v18 for tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
         # https://github.com/actions/checkout/releases/tag/v3.5.0
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run the tests
         run: npm run test_integration

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 40  # default is 360
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
     steps:
       # https://github.com/actions/checkout/releases/tag/v3.5.0
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
@@ -26,7 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
-      run: npm install
+      run: npm ci
     - name: Build
       run: npm run build
     - name: Test


### PR DESCRIPTION
### Acceptance Criteria
- Add NodeJS v16 and v18 when running tests.
- Add NodeJS v18 when running integration tests.
- Use `npm ci` instead of `npm install`.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
