### PR TITLE
feat: new address scanning policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 40  # default is 360
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [12.x, 14.x]
     steps:
       # https://github.com/actions/checkout/releases/tag/v3.5.0
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 40  # default is 360
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x, 16.x]
     steps:
       # https://github.com/actions/checkout/releases/tag/v3.5.0
     - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3

--- a/__tests__/integration/configuration/test-constants.js
+++ b/__tests__/integration/configuration/test-constants.js
@@ -102,5 +102,5 @@ export const NETWORK_NAME = 'privatenet';
 export const FULLNODE_URL = 'http://localhost:8083/v1a/';
 export const TX_MINING_URL = 'http://localhost:8035/';
 
-export const TX_TIMEOUT_DEFAULT = 5000;
+export const TX_TIMEOUT_DEFAULT = 10000;
 export const DEBUG_LOGGING = true;

--- a/__tests__/integration/configuration/test-constants.js
+++ b/__tests__/integration/configuration/test-constants.js
@@ -102,5 +102,5 @@ export const NETWORK_NAME = 'privatenet';
 export const FULLNODE_URL = 'http://localhost:8083/v1a/';
 export const TX_MINING_URL = 'http://localhost:8035/';
 
-export const TX_TIMEOUT_DEFAULT = 10000;
+export const TX_TIMEOUT_DEFAULT = 15000;
 export const DEBUG_LOGGING = true;

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1156,6 +1156,7 @@ describe('sendTransaction', () => {
 
     // Validating all fields
     await waitForTxReceived(hWallet, tx1.hash);
+    await delay(2000)
     expect(tx1).toMatchObject({
       hash: expect.any(String),
       inputs: expect.any(Array),
@@ -1186,6 +1187,7 @@ describe('sendTransaction', () => {
       { changeAddress: await hWallet.getAddressAtIndex(5) }
     );
     await waitForTxReceived(hWallet, tx2Hash);
+    await delay(2000);
 
     // Balance was reduced
     htrBalance = await hWallet.getBalance(HATHOR_TOKEN_CONFIG.uid);

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -157,7 +157,7 @@ describe('getTxById', () => {
        * TODO: The amount of transactions is often 8 but should be 1. Ref #397
        * @see https://github.com/HathorNetwork/hathor-wallet-lib/issues/397
        */
-      // transactions: 1, 
+      // transactions: 1,
     });
     // Get balance for the token creation transaction
     const result = await hWallet.getTxById(tokenUid);
@@ -1220,6 +1220,7 @@ describe('sendTransaction', () => {
         changeAddress: await hWallet.getAddressAtIndex(6)
       }
     );
+    await delay(10000);
     await waitForTxReceived(hWallet, tx1.hash);
 
     // Validating balance stays the same for internal transactions
@@ -1887,6 +1888,7 @@ describe('mintTokens', () => {
     let mintResponse;
     mintResponse = await hWallet.mintTokens(tokenUid, 1);
     expectedHtrFunds -= 1;
+    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1894,6 +1896,7 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 100);
     expectedHtrFunds -= 1;
+    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1901,6 +1904,7 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 101);
     expectedHtrFunds -= 2;
+    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1908,6 +1912,7 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 200);
     expectedHtrFunds -= 2;
+    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1915,6 +1920,7 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 201);
     expectedHtrFunds -= 3;
+    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
   });
@@ -2030,6 +2036,7 @@ describe('meltTokens', () => {
     let meltResponse;
     // Melting less than 1.00 tokens recovers 0 HTR
     meltResponse = await hWallet.meltTokens(tokenUid, 99);
+    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -2037,6 +2044,7 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 100);
     expectedHtrFunds += 1;
+    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     await delay(100);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
@@ -2045,6 +2053,7 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 199);
     expectedHtrFunds += 1;
+    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -2052,6 +2061,7 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 200);
     expectedHtrFunds += 2;
+    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -2059,6 +2069,7 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 299);
     expectedHtrFunds += 2;
+    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
   });
@@ -2287,6 +2298,7 @@ describe('delegateAuthority', () => {
       await hWallet1.getAddressAtIndex(1),
       { createAnother: true }
     );
+    await delay(10000);
     await waitForTxReceived(hWallet1, duplicateMeltAuth);
 
     // Confirming two authority tokens on wallet1
@@ -2313,6 +2325,7 @@ describe('delegateAuthority', () => {
       await hWallet2.getAddressAtIndex(1),
       { createAnother: false }
     );
+    await delay(10000);
     await waitForTxReceived(hWallet1, delegateMintAuth);
 
     // Confirming only one authority token was sent from wallet1 to wallet2

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -657,7 +657,7 @@ describe('addresses methods', () => {
     // Expect the "current address" to change when a transaction arrives at the current one
     currentAddress = await hWallet.getCurrentAddress();
     await GenesisWalletHelper.injectFunds(currentAddress.address, 1);
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await delay(1000);
     const currentAfterTx = await hWallet.getCurrentAddress();
     expect(currentAfterTx).toMatchObject({
       index: currentAddress.index + 1,
@@ -704,11 +704,11 @@ describe('addresses methods', () => {
     // We will assume the wallet never received txs, which is to be expected for the addresses test
     expect((await mshWallet.getCurrentAddress()).address).toStrictEqual(WALLET_CONSTANTS.multisig.addresses[0]);
 
-    for (let i=0; i < 21; ++i) {
+    for (let i = 0; i < 21; ++i) {
       expect(await mshWallet.getAddressAtIndex(i))
         .toStrictEqual(WALLET_CONSTANTS.multisig.addresses[i]);
     }
-  })
+  });
 });
 
 describe('getBalance', () => {
@@ -735,6 +735,7 @@ describe('getBalance', () => {
     // Generating one transaction to validate its effects
     const injectedValue = getRandomInt(10, 2);
     await GenesisWalletHelper.injectFunds(await hWallet.getAddressAtIndex(0), injectedValue);
+    await delay(1000);
 
     // Validating the transaction effects
     const balance1 = await hWallet.getBalance(HATHOR_TOKEN_CONFIG.uid);
@@ -889,6 +890,7 @@ describe('getFullHistory', () => {
       await hWallet.getAddressAtIndex(0),
       10
     );
+    await delay(1000);
     const tokenName = 'Full History Token';
     const tokenSymbol = 'FHT';
     const { hash: tokenUid } = await createTokenHelper(
@@ -1150,13 +1152,14 @@ describe('sendTransaction', () => {
   it('should send HTR transactions', async () => {
     const hWallet = await generateWalletHelper();
     await GenesisWalletHelper.injectFunds(await hWallet.getAddressAtIndex(0), 10);
+    await delay(1000);
 
     // Sending a transaction inside the same wallet
     const tx1 = await hWallet.sendTransaction(await hWallet.getAddressAtIndex(2), 6);
 
     // Validating all fields
     await waitForTxReceived(hWallet, tx1.hash);
-    await delay(2000)
+    await delay(2000);
     expect(tx1).toMatchObject({
       hash: expect.any(String),
       inputs: expect.any(Array),
@@ -1212,6 +1215,7 @@ describe('sendTransaction', () => {
       'TTS',
       100
     );
+    await delay(1000);
 
     const tx1 = await hWallet.sendTransaction(
       await hWallet.getAddressAtIndex(5),

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1220,7 +1220,6 @@ describe('sendTransaction', () => {
         changeAddress: await hWallet.getAddressAtIndex(6)
       }
     );
-    await delay(10000);
     await waitForTxReceived(hWallet, tx1.hash);
 
     // Validating balance stays the same for internal transactions
@@ -1888,7 +1887,6 @@ describe('mintTokens', () => {
     let mintResponse;
     mintResponse = await hWallet.mintTokens(tokenUid, 1);
     expectedHtrFunds -= 1;
-    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1896,7 +1894,6 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 100);
     expectedHtrFunds -= 1;
-    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1904,7 +1901,6 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 101);
     expectedHtrFunds -= 2;
-    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1912,7 +1908,6 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 200);
     expectedHtrFunds -= 2;
-    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -1920,7 +1915,6 @@ describe('mintTokens', () => {
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
     mintResponse = await hWallet.mintTokens(tokenUid, 201);
     expectedHtrFunds -= 3;
-    await delay(10000);
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
   });
@@ -2036,7 +2030,6 @@ describe('meltTokens', () => {
     let meltResponse;
     // Melting less than 1.00 tokens recovers 0 HTR
     meltResponse = await hWallet.meltTokens(tokenUid, 99);
-    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -2044,7 +2037,6 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 100);
     expectedHtrFunds += 1;
-    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     await delay(100);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
@@ -2053,7 +2045,6 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 199);
     expectedHtrFunds += 1;
-    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -2061,7 +2052,6 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 200);
     expectedHtrFunds += 2;
-    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
@@ -2069,7 +2059,6 @@ describe('meltTokens', () => {
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
     meltResponse = await hWallet.meltTokens(tokenUid, 299);
     expectedHtrFunds += 2;
-    await delay(10000);
     await waitForTxReceived(hWallet, meltResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
   });
@@ -2298,7 +2287,6 @@ describe('delegateAuthority', () => {
       await hWallet1.getAddressAtIndex(1),
       { createAnother: true }
     );
-    await delay(10000);
     await waitForTxReceived(hWallet1, duplicateMeltAuth);
 
     // Confirming two authority tokens on wallet1
@@ -2325,7 +2313,6 @@ describe('delegateAuthority', () => {
       await hWallet2.getAddressAtIndex(1),
       { createAnother: false }
     );
-    await delay(10000);
     await waitForTxReceived(hWallet1, delegateMintAuth);
 
     // Confirming only one authority token was sent from wallet1 to wallet2

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1228,6 +1228,7 @@ describe('sendTransaction', () => {
       }
     );
     await waitForTxReceived(hWallet, tx1.hash);
+    await delay(1000);
 
     // Validating balance stays the same for internal transactions
     let htrBalance = await hWallet.getBalance(tokenUid);
@@ -1239,6 +1240,7 @@ describe('sendTransaction', () => {
     // Transaction outside the wallet
     const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
     await waitUntilNextTimestamp(hWallet, tx1.hash);
+    await delay(1000);
     const { hash: tx2Hash } = await hWallet.sendTransaction(
       await gWallet.getAddressAtIndex(0),
       80,
@@ -1247,6 +1249,7 @@ describe('sendTransaction', () => {
         changeAddress: await hWallet.getAddressAtIndex(12)
       }
     );
+    await delay(1000);
     await waitForTxReceived(hWallet, tx2Hash);
 
     // Balance was reduced
@@ -1897,34 +1900,43 @@ describe('mintTokens', () => {
     mintResponse = await hWallet.mintTokens(tokenUid, 1);
     expectedHtrFunds -= 1;
     await waitForTxReceived(hWallet, mintResponse.hash);
-    expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
+    await delay(500);
+    await expect(getHtrBalance(hWallet)).resolves.toBe(expectedHtrFunds);
 
     // Minting exactly 1.00 tokens consumes 0.01 HTR
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
+    await delay(500);
     mintResponse = await hWallet.mintTokens(tokenUid, 100);
     expectedHtrFunds -= 1;
     await waitForTxReceived(hWallet, mintResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Minting between 1.00 and 2.00 tokens consumes 0.02 HTR
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
+    await delay(500);
     mintResponse = await hWallet.mintTokens(tokenUid, 101);
     expectedHtrFunds -= 2;
     await waitForTxReceived(hWallet, mintResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Minting exactly 2.00 tokens consumes 0.02 HTR
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
+    await delay(500);
     mintResponse = await hWallet.mintTokens(tokenUid, 200);
     expectedHtrFunds -= 2;
     await waitForTxReceived(hWallet, mintResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Minting between 2.00 and 3.00 tokens consumes 0.03 HTR
     await waitUntilNextTimestamp(hWallet, mintResponse.hash);
+    await delay(500);
     mintResponse = await hWallet.mintTokens(tokenUid, 201);
     expectedHtrFunds -= 3;
     await waitForTxReceived(hWallet, mintResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
   });
 });
@@ -2034,41 +2046,50 @@ describe('meltTokens', () => {
       'TMELT',
       1900
     );
+    await delay(500);
     let expectedHtrFunds = 1;
 
     let meltResponse;
     // Melting less than 1.00 tokens recovers 0 HTR
     meltResponse = await hWallet.meltTokens(tokenUid, 99);
     await waitForTxReceived(hWallet, meltResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Melting exactly 1.00 tokens recovers 0.01 HTR
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
+    await delay(500);
     meltResponse = await hWallet.meltTokens(tokenUid, 100);
     expectedHtrFunds += 1;
     await waitForTxReceived(hWallet, meltResponse.hash);
-    await delay(100);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Melting between 1.00 and 2.00 tokens recovers 0.01 HTR
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
+    await delay(500);
     meltResponse = await hWallet.meltTokens(tokenUid, 199);
     expectedHtrFunds += 1;
     await waitForTxReceived(hWallet, meltResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Melting exactly 2.00 tokens recovers 0.02 HTR
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
+    await delay(500);
     meltResponse = await hWallet.meltTokens(tokenUid, 200);
     expectedHtrFunds += 2;
     await waitForTxReceived(hWallet, meltResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
 
     // Melting between 2.00 and 3.00 tokens recovers 0.02 HTR
     await waitUntilNextTimestamp(hWallet, meltResponse.hash);
+    await delay(500);
     meltResponse = await hWallet.meltTokens(tokenUid, 299);
     expectedHtrFunds += 2;
     await waitForTxReceived(hWallet, meltResponse.hash);
+    await delay(500);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
   });
 });

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -16,19 +16,18 @@ import {
 } from './helpers/wallet.helper';
 import HathorWallet from '../../src/new/wallet';
 import { HATHOR_TOKEN_CONFIG, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
-import { NETWORK_NAME, TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test-constants';
+import { TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test-constants';
 import dateFormatter from '../../src/utils/date';
 import { verifyMessage } from '../../src/utils/crypto';
 import { loggers } from './utils/logger.util';
-import { TxNotFoundError, SendTxError, WalletFromXPubGuard } from '../../src/errors';
+import { TxNotFoundError, WalletFromXPubGuard } from '../../src/errors';
 import SendTransaction from '../../src/new/sendTransaction';
-import walletUtils from '../../src/utils/wallet';
 import { ConnectionState } from '../../src/wallet/types';
 import transaction from '../../src/utils/transaction';
 import Mnemonic from 'bitcore-mnemonic/lib/mnemonic';
 import { P2PKH_ACCT_PATH } from '../../src/constants';
 import Network from '../../src/models/network';
-import { WalletType, WALLET_FLAGS } from '../../src/types';
+import { WalletType } from '../../src/types';
 
 const fakeTokenUid = '008a19f84f2ae284f19bf3d03386c878ddd15b8b0b604a3a3539aa9d714686e1';
 const sampleNftData = 'ipfs://bafybeiccfclkdtucu6y4yc5cpr6y3yuinr67svmii46v5cfcrkp47ihehy/albums/QXBvbGxvIDEwIE1hZ2F6aW5lIDI3L04=/21716695748_7390815218_o.jpg';

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1204,11 +1204,13 @@ describe('sendTransaction', () => {
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(4))).toHaveProperty('numTransactions', 0);
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty('numTransactions', 1);
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(6))).toHaveProperty('numTransactions', 0);
+    await delay(1000);
   });
 
   it('should send custom token transactions', async () => {
     const hWallet = await generateWalletHelper();
     await GenesisWalletHelper.injectFunds(await hWallet.getAddressAtIndex(0), 10);
+    await delay(1000);
     const { hash: tokenUid } = await createTokenHelper(
       hWallet,
       'Token to Send',
@@ -1558,6 +1560,7 @@ describe('createNewToken', () => {
     const hWallet = await generateWalletHelper();
     const addr0 = await hWallet.getAddressAtIndex(0);
     await GenesisWalletHelper.injectFunds(addr0, 10);
+    await delay(1000);
 
     // Creating the new token
     const newTokenResponse = await hWallet.createNewToken(
@@ -1642,6 +1645,7 @@ describe('createNewToken', () => {
     const addr10 = await hWallet.getAddressAtIndex(10);
     const addr11 = await hWallet.getAddressAtIndex(11);
     await GenesisWalletHelper.injectFunds(addr0, 1);
+    await delay(1000);
 
     // Creating the new token
     const newTokenResponse = await hWallet.createNewToken(
@@ -2293,6 +2297,7 @@ describe('delegateAuthority', () => {
       { createAnother: true }
     );
     await waitForTxReceived(hWallet1, duplicateMeltAuth);
+    await delay(1000);
 
     // Confirming two authority tokens on wallet1
     let auth1 = await hWallet1.getMeltAuthority(tokenUid, { many: true });

--- a/__tests__/integration/hathorwallet_others.test.js
+++ b/__tests__/integration/hathorwallet_others.test.js
@@ -1172,7 +1172,7 @@ describe('index-limit address scanning policy', () => {
       scanPolicy: {
         policy: 'index-limit',
         startIndex: 0,
-        endIndex: 10,
+        endIndex: 9,
       },
     });
   });
@@ -1182,12 +1182,15 @@ describe('index-limit address scanning policy', () => {
   });
 
   it('should start a wallet configured to index-limit', async () => {
+    // 0-9 addresses = 10
     await expect(hWallet.storage.store.addressCount()).resolves.toEqual(10);
 
+    // 0-14 addresses = 15
     await hWallet.indexLimitLoadMore(5);
     await expect(hWallet.storage.store.addressCount()).resolves.toEqual(15);
 
-    await hWallet.indexLimitSetEndIndex(25);
+    // 0-24 addresses = 25
+    await hWallet.indexLimitSetEndIndex(24);
     await expect(hWallet.storage.store.addressCount()).resolves.toEqual(25);
 
     // Setting below current loaded index will be a no-op

--- a/__tests__/integration/hathorwallet_others.test.js
+++ b/__tests__/integration/hathorwallet_others.test.js
@@ -1167,7 +1167,8 @@ describe('index-limit address scanning policy', () => {
   beforeAll(async () => {
     const walletData = precalculationHelpers.test.getPrecalculatedWallet();
     hWallet = await generateWalletHelper({
-      ...walletData,
+      seed: walletData.words,
+      addresses: walletData.addresses,
       scanPolicy: {
         policy: 'index-limit',
         startIndex: 0,

--- a/__tests__/integration/helpers/genesis-wallet.helper.js
+++ b/__tests__/integration/helpers/genesis-wallet.helper.js
@@ -81,6 +81,7 @@ export class GenesisWalletHelper {
 
       await waitForTxReceived(this.hWallet, result.hash, options.waitTimeout);
       await waitUntilNextTimestamp(this.hWallet, result.hash);
+      await delay(1000);
       return result;
     } catch (e) {
       loggers.test.error(`Failed to inject funds: ${e.message}`);

--- a/__tests__/integration/helpers/wallet.helper.js
+++ b/__tests__/integration/helpers/wallet.helper.js
@@ -244,7 +244,7 @@ export async function createTokenHelper(hWallet, name, symbol, amount, options) 
   const tokenUid = newTokenResponse.hash;
   await waitForTxReceived(hWallet, tokenUid);
   await waitUntilNextTimestamp(hWallet, tokenUid);
-  await delay(1000);
+  await delay(2000);
   return newTokenResponse;
 }
 
@@ -338,13 +338,13 @@ export async function waitForTxReceived(hWallet, txId, timeout) {
        * memory. The code below tries to eliminate these short time-senstive issues with a minimum
        * of delays.
        */
-      await delay(500);
+      await delay(1000);
       let txObj = await hWallet.getTx(txId);
       while (!txObj) {
         if (DEBUG_LOGGING) {
-          loggers.test.warn(`Tx was not available on history. Waiting for 50ms and retrying.`);
+          loggers.test.warn(`Tx was not available on history. Waiting for 100ms and retrying.`);
         }
-        await delay(50);
+        await delay(100);
         txObj = await hWallet.getTx(txId);
       }
       resolve(newTx);
@@ -377,7 +377,7 @@ export async function waitUntilNextTimestamp(hWallet, txId) {
   }
 
   // We are still within an invalid time to generate a new timestamp. Waiting for some time...
-  const timeToWait = nextValidMilliseconds - nowMilliseconds + 10;
+  const timeToWait = nextValidMilliseconds - nowMilliseconds + 100;
   loggers.test.log(`Waiting for ${timeToWait}ms for the next timestamp.`);
   await delay(timeToWait);
 }

--- a/__tests__/integration/helpers/wallet.helper.js
+++ b/__tests__/integration/helpers/wallet.helper.js
@@ -244,7 +244,7 @@ export async function createTokenHelper(hWallet, name, symbol, amount, options) 
   const tokenUid = newTokenResponse.hash;
   await waitForTxReceived(hWallet, tokenUid);
   await waitUntilNextTimestamp(hWallet, tokenUid);
-  await delay(2000);
+  await delay(1000);
   return newTokenResponse;
 }
 
@@ -338,13 +338,13 @@ export async function waitForTxReceived(hWallet, txId, timeout) {
        * memory. The code below tries to eliminate these short time-senstive issues with a minimum
        * of delays.
        */
-      await delay(1000);
+      await delay(500);
       let txObj = await hWallet.getTx(txId);
       while (!txObj) {
         if (DEBUG_LOGGING) {
-          loggers.test.warn(`Tx was not available on history. Waiting for 100ms and retrying.`);
+          loggers.test.warn(`Tx was not available on history. Waiting for 50ms and retrying.`);
         }
-        await delay(100);
+        await delay(50);
         txObj = await hWallet.getTx(txId);
       }
       resolve(newTx);
@@ -377,7 +377,7 @@ export async function waitUntilNextTimestamp(hWallet, txId) {
   }
 
   // We are still within an invalid time to generate a new timestamp. Waiting for some time...
-  const timeToWait = nextValidMilliseconds - nowMilliseconds + 100;
+  const timeToWait = nextValidMilliseconds - nowMilliseconds + 10;
   loggers.test.log(`Waiting for ${timeToWait}ms for the next timestamp.`);
   await delay(timeToWait);
 }

--- a/__tests__/integration/helpers/wallet.helper.js
+++ b/__tests__/integration/helpers/wallet.helper.js
@@ -341,7 +341,7 @@ export async function waitForTxReceived(hWallet, txId, timeout) {
        * memory. The code below tries to eliminate these short time-senstive issues with a minimum
        * of delays.
        */
-      await delay(500);
+      await delay(1000);
       let txObj = await hWallet.getTx(txId);
       while (!txObj) {
         if (DEBUG_LOGGING) {

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -325,6 +325,9 @@ test('getWalletInputInfo', async () => {
 
 test('processTxQueue', async () => {
   const hWallet = new FakeHathorWallet();
+  hWallet.storage = {
+    processHistory: jest.fn(),
+  };
 
   const processedTxs = [];
   hWallet.onNewTx.mockImplementation(data => {
@@ -340,6 +343,7 @@ test('processTxQueue', async () => {
 
   await hWallet.processTxQueue();
   expect(processedTxs).toStrictEqual([1, 2, 3]);
+  expect(hWallet.storage.processHistory).toBeCalledTimes(1);
 });
 
 test('handleWebsocketMsg', async () => {

--- a/__tests__/storage/common_store.test.js
+++ b/__tests__/storage/common_store.test.js
@@ -205,7 +205,47 @@ describe('scanning policy methods', () => {
 
   async function testScanningPolicyes(store) {
     const storage = new Storage(store);
+    // Default is gap-limit
     await expect(storage.getGapLimit()).resolves.toEqual(GAP_LIMIT);
     await expect(storage.getScanningPolicy()).resolves.toEqual('gap-limit');
+    await expect(storage.getScanningPolicyData()).resolves.toEqual({
+      policy: 'gap-limit',
+      gapLimit: GAP_LIMIT,
+    });
+
+    // Setting gap-limit to 27
+    await storage.setScanningPolicyData({ policy: 'gap-limit', gapLimit: 27 });
+    await expect(storage.getGapLimit()).resolves.toEqual(27);
+    await expect(storage.getScanningPolicy()).resolves.toEqual('gap-limit');
+    await expect(storage.getScanningPolicyData()).resolves.toEqual({
+      policy: 'gap-limit',
+      gapLimit: 27,
+    });
+
+    // Setting gap-limit to 127 via setGapLimit
+    await storage.setGapLimit(127);
+    await expect(storage.getGapLimit()).resolves.toEqual(127);
+    await expect(storage.getScanningPolicy()).resolves.toEqual('gap-limit');
+    await expect(storage.getScanningPolicyData()).resolves.toEqual({
+      policy: 'gap-limit',
+      gapLimit: 127,
+    });
+
+    // Setting index-limit
+    await storage.setScanningPolicyData({
+      policy: 'index-limit',
+      startIndex: 27,
+      endIndex: 42,
+    });
+    await expect(storage.getScanningPolicy()).resolves.toEqual('index-limit');
+    await expect(storage.getScanningPolicyData()).resolves.toEqual({
+      policy: 'index-limit',
+      startIndex: 27,
+      endIndex: 42,
+    });
+    await expect(storage.getIndexLimit()).resolves.toEqual({
+      startIndex: 27,
+      endIndex: 42,
+    });
   }
 });

--- a/__tests__/storage/common_store.test.js
+++ b/__tests__/storage/common_store.test.js
@@ -7,7 +7,7 @@
 
 import { LevelDBStore, MemoryStore, Storage } from "../../src/storage";
 import { HDPrivateKey } from "bitcore-lib";
-import { TOKEN_AUTHORITY_MASK, TOKEN_MINT_MASK } from "../../src/constants";
+import { TOKEN_AUTHORITY_MASK, TOKEN_MINT_MASK, GAP_LIMIT } from "../../src/constants";
 import walletUtils from "../../src/utils/wallet";
 
 const DATA_DIR = './testdata.leveldb';
@@ -187,5 +187,25 @@ describe('registered tokens', () => {
     await storage.registerToken({ uid: 'abc1', name: 'test token 1', symbol: 'TST1' });
     await expect(storage.isTokenRegistered('abc1')).resolves.toEqual(true);
     await expect(storage.isTokenRegistered('abc2')).resolves.toEqual(false);
+  }
+});
+
+describe('scanning policy methods', () => {
+  it('should work with memory store', async () => {
+    const store = new MemoryStore();
+    await testScanningPolicyes(store);
+  });
+
+  it('should work with leveldb store', async () => {
+    const xpriv = new HDPrivateKey();
+    const walletId = walletUtils.getWalletIdFromXPub(xpriv.xpubkey);
+    const store = new LevelDBStore(walletId, DATA_DIR);
+    await testScanningPolicyes(store);
+  });
+
+  async function testScanningPolicyes(store) {
+    const storage = new Storage(store);
+    await expect(storage.getGapLimit()).resolves.toEqual(GAP_LIMIT);
+    await expect(storage.getScanningPolicy()).resolves.toEqual('gap-limit');
   }
 });

--- a/__tests__/storage/leveldb/leveldb_store.test.js
+++ b/__tests__/storage/leveldb/leveldb_store.test.js
@@ -5,15 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HATHOR_TOKEN_CONFIG } from "../../../src/constants";
-import { LevelDBStore, Storage } from "../../../src/storage";
-import tx_history from "../../__fixtures__/tx_history";
-import walletApi from "../../../src/api/wallet";
-import { HDPrivateKey } from "bitcore-lib";
-import { encryptData } from "../../../src/utils/crypto";
-import { WalletType } from "../../../src/types";
-import { processHistory } from "../../../src/utils/storage";
-import walletUtils from "../../../src/utils/wallet";
+import { DEFAULT_ADDRESS_SCANNING_POLICY, HATHOR_TOKEN_CONFIG } from '../../../src/constants';
+import { LevelDBStore, Storage } from '../../../src/storage';
+import tx_history from '../../__fixtures__/tx_history';
+import walletApi from '../../../src/api/wallet';
+import { HDPrivateKey } from 'bitcore-lib';
+import { encryptData } from '../../../src/utils/crypto';
+import { WalletType } from '../../../src/types';
+import { processHistory } from '../../../src/utils/storage';
+import walletUtils from '../../../src/utils/wallet';
 
 function _addr_index_key(index) {
   const buf = Buffer.alloc(4);
@@ -383,6 +383,8 @@ test('access data methods', async () => {
         .resolves.toHaveLength(0);
   await expect(asyncGenToArray(store.registeredTokenIter()))
         .resolves.toHaveLength(0);
+
+  await expect(store.getScanningPolicy()).resolves.toEqual(DEFAULT_ADDRESS_SCANNING_POLICY);
 
   await store.destroy();
 });

--- a/__tests__/storage/memory_store.test.js
+++ b/__tests__/storage/memory_store.test.js
@@ -22,8 +22,8 @@ test('default values', async () => {
     lastUsedAddressIndex: -1,
     currentAddressIndex: -1,
     bestBlockHeight: 0,
-    scanPolicy: 'gap-limit',
     scanPolicyData: {
+      policy: 'gap-limit',
       gapLimit: GAP_LIMIT,
     },
   });

--- a/__tests__/storage/memory_store.test.js
+++ b/__tests__/storage/memory_store.test.js
@@ -22,7 +22,10 @@ test('default values', async () => {
     lastUsedAddressIndex: -1,
     currentAddressIndex: -1,
     bestBlockHeight: 0,
-    gapLimit: GAP_LIMIT,
+    scanPolicy: 'gap-limit',
+    scanPolicyData: {
+      gapLimit: GAP_LIMIT,
+    },
   });
 });
 

--- a/__tests__/utils/storage.test.js
+++ b/__tests__/utils/storage.test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { MemoryStore, Storage } from '../../src/storage';
+import { scanPolicyStartAddresses, checkScanningPolicy } from '../../src/utils/storage';
+
+describe('scanning policy methods', () => {
+  it('start addresses', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const gapLimit = 27;
+    jest.spyOn(storage, 'getGapLimit').mockReturnValue(Promise.resolve(gapLimit));
+    const policyMock = jest.spyOn(storage, 'getScanningPolicy');
+
+    policyMock.mockReturnValue(Promise.resolve('gap-limit'));
+    await expect(scanPolicyStartAddresses(storage)).resolves.toEqual({
+      nextIndex: 0,
+      count: gapLimit,
+    });
+  });
+
+  it('check address scanning policy', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const gapLimit = 27;
+    jest.spyOn(storage, 'getGapLimit').mockReturnValue(Promise.resolve(gapLimit));
+    const policyMock = jest.spyOn(storage, 'getScanningPolicy');
+
+    policyMock.mockReturnValue(Promise.resolve('gap-limit'));
+    await expect(checkScanningPolicy(storage)).resolves.toEqual({
+      nextIndex: 1,
+      count: 19,
+    });
+
+    policyMock.mockReturnValue(Promise.resolve('invalid-policy'));
+    await expect(checkScanningPolicy(storage)).resolves.toEqual(null);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { AddressScanPolicy } from "./types";
+
 
 /**
  * Constants defined for the Hathor Wallet
@@ -256,3 +258,8 @@ export const P2PKH_ACCT_PATH = `m/44'/${HATHOR_BIP44_CODE}'/0'`;
  * String to be prefixed before signed messages using bitcore-message
  */
 export const HATHOR_MAGIC_BYTES = 'Hathor Signed Message:\n';
+
+/**
+ * Default address scanning policy
+ */
+export const DEFAULT_ADDRESS_SCANNING_POLICY: AddressScanPolicy = 'gap-limit';

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -285,7 +285,10 @@ class HathorWallet extends EventEmitter {
       return;
     }
 
-    const limits = this.storage.getIndexLimit();
+    const limits = await this.storage.getIndexLimit();
+    if (!limits) {
+      return;
+    }
     const newEndIndex = limits.endIndex + count;
     await this.indexLimitSetEndIndex(newEndIndex);
   }
@@ -302,7 +305,10 @@ class HathorWallet extends EventEmitter {
       return;
     }
 
-    const limits = this.storage.getIndexLimit();
+    const limits = await this.storage.getIndexLimit();
+    if (!limits) {
+      return;
+    }
 
     if (endIndex <= limits.endIndex) {
       // Cannot unload addresses from storage.

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -5,7 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { AddressScanPolicy, IAddressInfo, IAddressMetadata, IHistoryTx, ILockedUtxo, IStore, ITokenData, ITokenMetadata, IUtxo, IUtxoFilterOptions, IWalletAccessData, IWalletData } from '../../types';
+import {
+  AddressScanPolicy,
+  AddressScanPolicyData,
+  IAddressInfo,
+  IAddressMetadata,
+  IHistoryTx,
+  IIndexLimitAddressScanPolicy,
+  ILockedUtxo,
+  IStore,
+  ITokenData,
+  ITokenMetadata,
+  IUtxo,
+  IUtxoFilterOptions,
+  IWalletAccessData,
+  IWalletData,
+} from '../../types';
 import path from 'path';
 import LevelAddressIndex from './address_index';
 import LevelHistoryIndex from './history_index';
@@ -302,8 +317,20 @@ export default class LevelDBStore implements IStore {
     return this.walletIndex.getGapLimit();
   }
 
+  async getIndexLimit(): Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'> | null> {
+    return this.walletIndex.getIndexLimit();
+  }
+
   async getScanningPolicy(): Promise<AddressScanPolicy> {
     return this.walletIndex.getScanningPolicy();
+  }
+
+  async setScanningPolicyData(data: AddressScanPolicyData): Promise<void> {
+    await this.walletIndex.setScanningPolicyData(data);
+  }
+
+  async getScanningPolicyData(): Promise<AddressScanPolicyData> {
+    return this.walletIndex.getScanningPolicyData();
   }
 
   async getWalletData(): Promise<IWalletData> {

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IAddressInfo, IAddressMetadata, IHistoryTx, ILockedUtxo, IStore, ITokenData, ITokenMetadata, IUtxo, IUtxoFilterOptions, IWalletAccessData, IWalletData } from '../../types';
+import { AddressScanPolicy, IAddressInfo, IAddressMetadata, IHistoryTx, ILockedUtxo, IStore, ITokenData, ITokenMetadata, IUtxo, IUtxoFilterOptions, IWalletAccessData, IWalletData } from '../../types';
 import path from 'path';
 import LevelAddressIndex from './address_index';
 import LevelHistoryIndex from './history_index';
@@ -300,6 +300,10 @@ export default class LevelDBStore implements IStore {
 
   async getGapLimit(): Promise<number> {
     return this.walletIndex.getGapLimit();
+  }
+
+  async getScanningPolicy(): Promise<AddressScanPolicy> {
+    return this.walletIndex.getScanningPolicy();
   }
 
   async getWalletData(): Promise<IWalletData> {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -28,6 +28,8 @@ import {
   IFillTxOptions,
   IBalance,
   AddressScanPolicy,
+  AddressScanPolicyData,
+  IIndexLimitAddressScanPolicy,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import { processHistory, processUtxoUnlock } from '../utils/storage';
@@ -866,11 +868,33 @@ export class Storage implements IStorage {
   }
 
   /**
+   * Get the index limit.
+   * @returns {Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'>>}
+   */
+  async getIndexLimit(): Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'> | null> {
+    return this.store.getIndexLimit();
+  }
+
+  /**
    * Get the scanning policy.
    * @returns {Promise<AddressScanPolicy>}
    */
   async getScanningPolicy(): Promise<AddressScanPolicy> {
     return this.store.getScanningPolicy();
+  }
+
+  /**
+   * Set the scanning policy data.
+   * @param {AddressScanPolicyData | null} data
+   * @returns {Promise<void>}
+   */
+  async setScanningPolicyData(data: AddressScanPolicyData | null): Promise<void> {
+      if (!data) return;
+      await this.store.setScanningPolicyData(data);
+  }
+
+  async getScanningPolicyData(): Promise<AddressScanPolicyData> {
+    return this.store.getScanningPolicyData();
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -27,6 +27,7 @@ import {
   IDataOutput,
   IFillTxOptions,
   IBalance,
+  AddressScanPolicy,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import { processHistory, processUtxoUnlock } from '../utils/storage';
@@ -862,6 +863,14 @@ export class Storage implements IStorage {
    */
   async getGapLimit(): Promise<number> {
     return this.store.getGapLimit();
+  }
+
+  /**
+   * Get the scanning policy.
+   * @returns {Promise<AddressScanPolicy>}
+   */
+  async getScanningPolicy(): Promise<AddressScanPolicy> {
+    return this.store.getScanningPolicy();
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Config } from "./config";
-import Input from "./models/input";
+import { Config } from './config';
+import Input from './models/input';
 import FullNodeConnection from './new/connection';
 
 export interface IAddressInfo {
@@ -209,12 +209,38 @@ export interface IWalletAccessData {
   walletFlags: number;
 }
 
+export interface IGapLimitAddressScanPolicy {
+  gapLimit: number;
+}
+
+export interface IManualAddressScanPolicy {
+  startIndex: number;
+  endIndex: number;
+}
+
+/**
+ * This is a request from the scanning policy to load `count` addresses starting from nextIndex.
+ */
+export interface IScanPolicyLoadAddresses {
+  nextIndex: number;
+  count: number;
+}
+
+export type AddressScanPolicy = 'gap-limit' | 'manual';
+
+export type AddressScanPolicyData = IGapLimitAddressScanPolicy | IManualAddressScanPolicy;
+
+export function isGapLimitScanPolicy(scanPolicyData: AddressScanPolicyData): scanPolicyData is IGapLimitAddressScanPolicy {
+  return (scanPolicyData as IGapLimitAddressScanPolicy).gapLimit !== undefined;
+}
+
 export interface IWalletData {
   lastLoadedAddressIndex: number;
   lastUsedAddressIndex: number;
   currentAddressIndex: number;
   bestBlockHeight: number;
-  gapLimit: number;
+  scanPolicy: AddressScanPolicy;
+  scanPolicyData: AddressScanPolicyData;
 }
 
 export interface IEncryptedData {
@@ -326,6 +352,7 @@ export interface IStore {
   setCurrentAddressIndex(index: number): Promise<void>;
   setGapLimit(value: number): Promise<void>;
   getGapLimit(): Promise<number>;
+  getScanningPolicy(): Promise<AddressScanPolicy>;
 
   // Generic storage keys
   getItem(key: string): Promise<any>;
@@ -398,6 +425,7 @@ export interface IStorage {
   checkPin(pinCode: string): Promise<boolean>;
   checkPassword(password: string): Promise<boolean>;
   isHardwareWallet(): Promise<boolean>;
+  getScanningPolicy(): Promise<AddressScanPolicy>;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,10 +210,12 @@ export interface IWalletAccessData {
 }
 
 export interface IGapLimitAddressScanPolicy {
+  policy: 'gap-limit';
   gapLimit: number;
 }
 
-export interface IManualAddressScanPolicy {
+export interface IIndexLimitAddressScanPolicy {
+  policy: 'index-limit';
   startIndex: number;
   endIndex: number;
 }
@@ -226,12 +228,16 @@ export interface IScanPolicyLoadAddresses {
   count: number;
 }
 
-export type AddressScanPolicy = 'gap-limit' | 'manual';
+export type AddressScanPolicy = 'gap-limit' | 'index-limit';
 
-export type AddressScanPolicyData = IGapLimitAddressScanPolicy | IManualAddressScanPolicy;
+export type AddressScanPolicyData = IGapLimitAddressScanPolicy | IIndexLimitAddressScanPolicy;
 
 export function isGapLimitScanPolicy(scanPolicyData: AddressScanPolicyData): scanPolicyData is IGapLimitAddressScanPolicy {
-  return (scanPolicyData as IGapLimitAddressScanPolicy).gapLimit !== undefined;
+  return scanPolicyData.policy === 'gap-limit';
+}
+
+export function isIndexLimitScanPolicy(scanPolicyData: AddressScanPolicyData): scanPolicyData is IIndexLimitAddressScanPolicy {
+  return scanPolicyData.policy === 'index-limit';
 }
 
 export interface IWalletData {
@@ -239,7 +245,6 @@ export interface IWalletData {
   lastUsedAddressIndex: number;
   currentAddressIndex: number;
   bestBlockHeight: number;
-  scanPolicy: AddressScanPolicy;
   scanPolicyData: AddressScanPolicyData;
 }
 
@@ -352,7 +357,10 @@ export interface IStore {
   setCurrentAddressIndex(index: number): Promise<void>;
   setGapLimit(value: number): Promise<void>;
   getGapLimit(): Promise<number>;
+  getIndexLimit(): Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'> | null>;
   getScanningPolicy(): Promise<AddressScanPolicy>;
+  setScanningPolicyData(data: AddressScanPolicyData): Promise<void>;
+  getScanningPolicyData(): Promise<AddressScanPolicyData>;
 
   // Generic storage keys
   getItem(key: string): Promise<any>;
@@ -419,6 +427,7 @@ export interface IStorage {
   changePassword(oldPassword: string, newPassword: string): Promise<void>;
   setGapLimit(value: number): Promise<void>;
   getGapLimit(): Promise<number>;
+  getIndexLimit(): Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'> | null>;
   cleanStorage(cleanHistory?: boolean, cleanAddresses?: boolean, cleanTokens?: boolean): Promise<void>;
   handleStop(options: {connection?: FullNodeConnection, cleanStorage?: boolean, cleanAddresses?: boolean}): Promise<void>;
   getTokenDepositPercentage(): number;
@@ -426,6 +435,8 @@ export interface IStorage {
   checkPassword(password: string): Promise<boolean>;
   isHardwareWallet(): Promise<boolean>;
   getScanningPolicy(): Promise<AddressScanPolicy>;
+  getScanningPolicyData(): Promise<AddressScanPolicyData>;
+  setScanningPolicyData(data: AddressScanPolicyData | null): Promise<void>;
 }
 
 /**
@@ -508,6 +519,10 @@ export interface IKVWalletIndex extends IKVStoreIndex<void> {
   getCurrentAddressIndex(): Promise<number>;
   setGapLimit(value: number): Promise<void>;
   getGapLimit(): Promise<number>;
+  getIndexLimit(): Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'> | null>;
+  getScanningPolicy(): Promise<AddressScanPolicy>;
+  setScanningPolicyData(data: AddressScanPolicyData): Promise<void>;
+  getScanningPolicyData(): Promise<AddressScanPolicyData>;
 
   getItem(key: string): Promise<any>;
   setItem(key: string, value: any): Promise<void>;


### PR DESCRIPTION
### Acceptance Criteria

- Create a new address scanning policy called index-limit
  - This should be configured with a start and end index and should keep only these addresses loaded.
- Create methods on storage to configure scanning policies
- Change utils to check the scanning policy when loading addresses or processing history
- Allow the wallet facade to configure the scanning policy
- Create methods on the wallet facade to load more addresses when using the index-limit scanning policy

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
