### PR TITLE
tests: start marking utxos as spent when tx is received for integration tests

### DIFF
--- a/__tests__/integration/atomic_swap.test.js
+++ b/__tests__/integration/atomic_swap.test.js
@@ -24,7 +24,7 @@ describe('partial tx proposal', () => {
     const hWallet2 = await generateWalletHelper();
 
     // Injecting funds and creating a new custom token
-    const txI = await GenesisWalletHelper.injectFunds(await hWallet1.getAddressAtIndex(0), 103);
+    const txI = await GenesisWalletHelper.injectFunds(hWallet1, await hWallet1.getAddressAtIndex(0), 103);
     const { hash: token1Uid } = await createTokenHelper(
       hWallet1,
       'Token1',
@@ -33,7 +33,7 @@ describe('partial tx proposal', () => {
     );
 
     // Injecting funds and creating a new custom token
-    await GenesisWalletHelper.injectFunds(await hWallet2.getAddressAtIndex(0), 10);
+    await GenesisWalletHelper.injectFunds(hWallet2, await hWallet2.getAddressAtIndex(0), 10);
     const { hash: token2Uid } = await createTokenHelper(
       hWallet2,
       'Token2',
@@ -99,7 +99,7 @@ describe('partial tx proposal', () => {
     expect(tx.hash).toBeDefined();
 
     await waitForTxReceived(hWallet1, tx.hash);
-    await delay(1000); // This transaction seems to take longer than usual to complete
+    await waitForTxReceived(hWallet2, tx.hash);
 
     // Get the balance states before the exchange
     const w1HTRAfter = await hWallet1.getBalance(HATHOR_TOKEN_CONFIG.uid);

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -306,6 +306,17 @@ describe('start', () => {
     // Send a transaction to one of the wallet's addresses
     const walletData = precalculationHelpers.test.getPrecalculatedWallet();
 
+    // We are not using the injectFunds helper method here because
+    // we want to send this transaction before the wallet is started
+    // then we don't have the wallet object, which is an expected parameter
+    // for the injectFunds method now
+    // Since we start and load the wallet after the transaction is sent to the full node
+    // we don't need to worry for it to be received in the websocket
+    const injectAddress = walletData.addresses[0];
+    const injectValue = getRandomInt(10, 1);
+    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
+    const injectionTx = await gWallet.sendTransaction(injectAddress, injectValue);
+
     // Start the wallet
     const walletConfig = {
       seed: walletData.words,
@@ -317,10 +328,6 @@ describe('start', () => {
     const hWallet = new HathorWallet(walletConfig);
     await hWallet.start();
     await waitForWalletReady(hWallet);
-
-    const injectAddress = walletData.addresses[0];
-    const injectValue = getRandomInt(10, 1);
-    const injectionTx = await GenesisWalletHelper.injectFunds(hWallet, injectAddress, injectValue);
 
     // Validate that it has transactions
     const txHistory = await hWallet.getTxHistory();

--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -1534,7 +1534,6 @@ describe('sendManyOutputsTransaction', () => {
     // Confirm that now the balance is available
     const sendTx = await hWallet.sendTransaction(await hWallet.getAddressAtIndex(4), 8);
     expect(sendTx).toHaveProperty('hash');
-    await waitForTxReceived(hWallet, sendTx.hash);
   });
 });
 

--- a/__tests__/integration/helpers/genesis-wallet.helper.js
+++ b/__tests__/integration/helpers/genesis-wallet.helper.js
@@ -57,6 +57,7 @@ export class GenesisWalletHelper {
 
   /**
    * Internal method to send HTR to another wallet's address.
+   * @param {HathorWallet} destinationWallet Wallet object that we are sending the funds to
    * @param {string} address
    * @param {number} value
    * @param [options]
@@ -65,7 +66,7 @@ export class GenesisWalletHelper {
    * @returns {Promise<BaseTransactionResponse>}
    * @private
    */
-  async _injectFunds(address, value, options = {}) {
+  async _injectFunds(destinationWallet, address, value, options = {}) {
     try {
       const result = await this.hWallet.sendTransaction(
         address,
@@ -80,6 +81,7 @@ export class GenesisWalletHelper {
       }
 
       await waitForTxReceived(this.hWallet, result.hash, options.waitTimeout);
+      await waitForTxReceived(destinationWallet, result.hash, options.waitTimeout);
       await waitUntilNextTimestamp(this.hWallet, result.hash);
       return result;
     } catch (e) {
@@ -107,6 +109,7 @@ export class GenesisWalletHelper {
 
   /**
    * An easy way to send HTR to another wallet's address for testing.
+   * @param {HathorWallet} destinationWallet Wallet object that we are sending the funds to
    * @param {string} address
    * @param {number} value
    * @param [options]
@@ -114,9 +117,9 @@ export class GenesisWalletHelper {
    *                                       Passing 0 here skips this waiting.
    * @returns {Promise<BaseTransactionResponse>}
    */
-  static async injectFunds(address, value, options) {
+  static async injectFunds(destinationWallet, address, value, options) {
     const instance = await GenesisWalletHelper.getSingleton();
-    return instance._injectFunds(address, value, options);
+    return instance._injectFunds(destinationWallet, address, value, options);
   }
 
   /**

--- a/__tests__/integration/helpers/wallet.helper.js
+++ b/__tests__/integration/helpers/wallet.helper.js
@@ -408,7 +408,13 @@ export async function waitNextBlock(storage) {
   const currentHeight = await storage.getCurrentHeight();
   let height = currentHeight;
 
-  const timeout = 120000; // 120s of timeout to find the next block
+  // This timeout is a protection, so the integration tests
+  // don't keep running in case of a problem
+  // After using the timeout as 120s, we had some timeouts
+  // because the CI runs in a free github runner
+  // so we decided to increase this timeout to 600s, so
+  // we don't have this error anymore
+  const timeout = 600000;
   let timeoutReached = false;
   // Timeout handler
   const timeoutHandler = setTimeout(() => {

--- a/__tests__/integration/helpers/wallet.helper.js
+++ b/__tests__/integration/helpers/wallet.helper.js
@@ -314,27 +314,27 @@ export async function waitForTxReceived(hWallet, txId, timeout) {
   if (timeoutReached) {
     // Throw error in case of timeout
     throw new Error(`Timeout of ${timeoutPeriod}ms without receiving the tx with id ${txId}`);
-  } else {
-    const timeDiff = Date.now().valueOf() - startTime;
-    if (DEBUG_LOGGING) {
-      loggers.test.log(`Wait for ${txId} took ${timeDiff}ms.`);
-    }
-
-    if (storageTx.is_voided === false) {
-      // We can't consider the metadata only of the transaction, it affects
-      // also the metadata of the transactions that were spent on it
-      // We could await for the update-tx event of the transactions of the inputs to arrive
-      // before considering the transaction metadata fully updated, however it's complicated
-      // to handle these events, since they might arrive even before we call this method
-      // To simplify everything, here we manually set the utxos as spent and process the history
-      // so after the transaction arrives, all the metadata involved on it is updated and we can
-      // continue running the tests to correctly check balances, addresses, and everyting else
-      await updateInputsSpentBy(hWallet, storageTx);
-      await hWallet.storage.processHistory();
-    }
-
-    return storageTx;
   }
+
+  const timeDiff = Date.now().valueOf() - startTime;
+  if (DEBUG_LOGGING) {
+    loggers.test.log(`Wait for ${txId} took ${timeDiff}ms.`);
+  }
+
+  if (storageTx.is_voided === false) {
+    // We can't consider the metadata only of the transaction, it affects
+    // also the metadata of the transactions that were spent on it
+    // We could await for the update-tx event of the transactions of the inputs to arrive
+    // before considering the transaction metadata fully updated, however it's complicated
+    // to handle these events, since they might arrive even before we call this method
+    // To simplify everything, here we manually set the utxos as spent and process the history
+    // so after the transaction arrives, all the metadata involved on it is updated and we can
+    // continue running the tests to correctly check balances, addresses, and everyting else
+    await updateInputsSpentBy(hWallet, storageTx);
+    await hWallet.storage.processHistory();
+  }
+
+  return storageTx;
 }
 
 /**

--- a/__tests__/integration/helpers/wallet.helper.js
+++ b/__tests__/integration/helpers/wallet.helper.js
@@ -18,6 +18,7 @@ import { multisigWalletsData, precalculationHelpers } from './wallet-precalculat
 import { delay } from '../utils/core.util';
 import { loggers } from '../utils/logger.util';
 import { MemoryStore, Storage } from '../../../src/storage';
+import { TxHistoryProcessingStatus } from '../../../src/types';
 
 /**
  * @typedef SendTxResponse
@@ -295,7 +296,7 @@ export async function waitForTxReceived(hWallet, txId, timeout) {
 
   // We consider that the tx was received after it's in the storage
   // and the history processing is finished
-  while (!storageTx || storageTx.processingStatus !== 'finished') {
+  while (!storageTx || storageTx.processingStatus !== TxHistoryProcessingStatus.FINISHED) {
     if (timeoutReached) {
       break;
     }

--- a/__tests__/integration/storage/leveldb.test.js
+++ b/__tests__/integration/storage/leveldb.test.js
@@ -65,9 +65,8 @@ describe('LevelDB persistent store', () => {
     expect(Object.keys(hWallet.getFullHistory())).toHaveLength(0);
 
     // Injecting some funds on this wallet
-    await GenesisWalletHelper.injectFunds(await hWallet.getAddressAtIndex(1), 10);
+    await GenesisWalletHelper.injectFunds(hWallet, await hWallet.getAddressAtIndex(1), 10);
 
-    await delay(100);
     // Validating the full history increased in one
     expect(Object.keys(await hWallet.getFullHistory())).toHaveLength(1);
 

--- a/__tests__/integration/storage/storage.test.js
+++ b/__tests__/integration/storage/storage.test.js
@@ -65,9 +65,7 @@ describe('locked utxos', () => {
   async function testUnlockWhenSpent(storage, walletData) {
     const hwallet = await startWallet(storage, walletData);
     const address = await hwallet.getAddressAtIndex(0);
-    const tx = await GenesisWalletHelper.injectFunds(address, 1);
-    await waitForTxReceived(hwallet, tx.hash);
-    await delay(500);
+    const tx = await GenesisWalletHelper.injectFunds(hwallet, address, 1);
 
     const sendTx = new SendTransaction({
       storage: hwallet.storage,
@@ -88,7 +86,6 @@ describe('locked utxos', () => {
     // Send a transaction spending the only utxo on the wallet.
     const tx1 = await sendTx.runFromMining();
     await waitForTxReceived(hwallet, tx1.hash);
-    await delay(500);
     await expect(hwallet.storage.isUtxoSelectedAsInput(utxoId)).resolves.toBe(false);
   }
 

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -26,7 +26,7 @@ module.exports = {
     './src/new/wallet.js': {
       statements: 92,
       branches: 85,
-      functions: 91,
+      functions: 90,
       lines: 92
     }
   },

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -27,7 +27,7 @@ import { signMessage } from '../utils/crypto';
 import Transaction from '../models/transaction';
 import Queue from '../models/queue';
 import FullnodeConnection from './connection';
-import { WalletType } from '../types';
+import { TxHistoryProcessingStatus, WalletType } from '../types';
 import { syncHistory, reloadStorage, checkGapLimit } from '../utils/storage';
 import txApi from '../api/txApi';
 import { MemoryStore, Storage } from '../storage';
@@ -1141,6 +1141,8 @@ class HathorWallet extends EventEmitter {
     const storageTx = await this.storage.getTx(newTx.tx_id);
     const isNewTx = storageTx === null;
 
+    newTx.processingStatus = TxHistoryProcessingStatus.PROCESSING;
+
     // Save the transaction in the storage
     await this.storage.addTx(newTx);
 
@@ -1151,6 +1153,10 @@ class HathorWallet extends EventEmitter {
     }
     // Process history to update metadatas
     await this.storage.processHistory();
+
+    newTx.processingStatus = TxHistoryProcessingStatus.FINISHED;
+    // Save the transaction in the storage
+    await this.storage.addTx(newTx);
 
     if (isNewTx) {
       this.emit('new-tx', newTx);

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,12 @@ export interface IHistoryTx {
   token_symbol?: string; // For create token transaction
   tokens: string[];
   height?: number;
+  processingStatus?: TxHistoryProcessingStatus;
+}
+
+export enum TxHistoryProcessingStatus {
+  PROCESSING = 'processing',
+  FINISHED = 'finished',
 }
 
 export interface IHistoryInput {


### PR DESCRIPTION
### Acceptance Criteria
- All inject funds calls must wait for the destination wallet to receive the new transaction, besides the genesis.
- Refactor of `waitForTxReceived` integration tests helper method:
  - Depending on the ws event to handle the tx received could lead to bugs, since the event might arrive even before the `waitForTxReceived`. This used to be handled with a `getTx` method but this may also cause bugs, since the tx must be added AND processed before considered to fully arrived, so all the metadata is updated.
  - Create a new attribute for transactions that arrive from the websocket `processingStatus`, so we know when these transactions have finished processing and its metadata is fully updated.
- When expecting a tx to be received in the websocket, we expect its metadata to be updated. However, the tx also affects the metadata of other transactions, e.g., the utxos that become spent, so we must consider the tx as received only after the utxos are marked as spent.
- Removed many random `delay` calls we used to have to mask these async bugs.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
