### PR TITLE
fix: call getHDPrivateKeyFromAddress with options as second param

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2642,7 +2642,7 @@ class HathorWallet extends EventEmitter {
     }
 
     // Get private key that will sign the nano contract transaction
-    const derivedKey = await this.getHDPrivateKeyFromAddress(address, pin);
+    const derivedKey = await this.getHDPrivateKeyFromAddress(address, options);
     const privateKey = derivedKey.privateKey;
 
     // Build and send transaction


### PR DESCRIPTION
This function extracts the pin from options or get the default value from the wallet. However, it causes an error in the wallet-mobile because the wallet doesn't have a default pin.

### Acceptance Criteria
- Pass the right argument to the `getHDPrivateKeyFromAddress` function.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
