### PR TITLE
feat: add support for multiple data script outputs when creating a token

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -20,7 +20,7 @@ import { NETWORK_NAME, TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test
 import dateFormatter from '../../src/utils/date';
 import { verifyMessage } from '../../src/utils/crypto';
 import { loggers } from './utils/logger.util';
-import { TxNotFoundError, SendTxError, WalletFromXPubGuard } from '../../src/errors';
+import { NftValidationError, TxNotFoundError, SendTxError, WalletFromXPubGuard } from '../../src/errors';
 import SendTransaction from '../../src/new/sendTransaction';
 import walletUtils from '../../src/utils/wallet';
 import { ConnectionState } from '../../src/wallet/types';
@@ -2466,6 +2466,10 @@ describe('create token with data outputs', () => {
     expect(outputBeforeLast.tokenData).toBe(0);
     const outputBeforeLastScript = parseScriptData(outputBeforeLast.script);
     expect(outputBeforeLastScript.data).toBe('test1');
+
+    expect(() => {
+      tx.validateNft(hWallet.getNetworkObject())
+    }).toThrow(NftValidationError);
   });
 });
 

--- a/__tests__/utils/tokens.test.js
+++ b/__tests__/utils/tokens.test.js
@@ -118,8 +118,8 @@ test('Token deposit', () => {
   expect(tokens.getDepositAmount(550)).toBe(6);
 });
 
-test('NFT creation fee', () => {
-  expect(tokens.getNFTCreationFee()).toBe(1);
+test('Fee for data script output', () => {
+  expect(tokens.getDataScriptOutputFee()).toBe(1);
 });
 
 test('Token withdraw', () => {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1501,7 +1501,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.meltAuthorityAddress] the address to send the melt authority created
    * @param {boolean} [options.allowExternalMeltAuthorityAddress=false] allow the melt authority address
    *                                                                    to be from another wallet
-   * @param {string[]=null} [options.data] list of data strings to add each as a data script output
+   * @param {string[]=null} [options.data] list of data strings using utf8 encoding to add each as a data script output
    *
    * @param {boolean} [options.signTx] sign transaction instance (default true)
    * @param {boolean} [options.isCreateNFT=false] if the create token is an NFT creation call
@@ -1622,7 +1622,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.meltAuthorityAddress] the address to send the melt authority created
    * @param {boolean} [options.allowExternalMeltAuthorityAddress=false] allow the melt authority address
    *                                                                    to be from another wallet
-   * @param {string[]=null} [options.data] list of data strings to add each as a data script output
+   * @param {string[]=null} [options.data] list of data strings using utf8 encoding to add each as a data script output
    *
    * @return {Promise<CreateNewTokenResponse>}
    * @memberof HathorWallet
@@ -2271,7 +2271,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} name Name of the token
    * @param {string} symbol Symbol of the token
    * @param {number} amount Quantity of the token to be minted
-   * @param {string} data NFT data string
+   * @param {string} data NFT data string using utf8 encoding
    * @param [options] Options parameters
    * @param {string} [options.address] address of the minted token,
    * @param {string} [options.changeAddress] address of the change output,

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1501,9 +1501,10 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.meltAuthorityAddress] the address to send the melt authority created
    * @param {boolean} [options.allowExternalMeltAuthorityAddress=false] allow the melt authority address
    *                                                                    to be from another wallet
-   * @param {string} [options.nftData] data string for NFT
+   * @param {string[]=null} [options.data] list of data strings to add each as a data script output
    *
    * @param {boolean} [options.signTx] sign transaction instance (default true)
+   * @param {boolean} [options.isCreateNFT=false] if the create token is an NFT creation call
    *
    * @return {CreateTokenTransaction} Promise that resolves with transaction object if succeeds
    * or with error message if it fails
@@ -1526,7 +1527,8 @@ class HathorWallet extends EventEmitter {
       createMelt: true,
       meltAuthorityAddress: null,
       allowExternalMeltAuthorityAddress: false,
-      nftData: null,
+      data: null,
+      isCreateNFT: false,
       signTx: true,
     }, options);
 
@@ -1565,7 +1567,8 @@ class HathorWallet extends EventEmitter {
         mintAuthorityAddress: newOptions.mintAuthorityAddress,
         createMelt: newOptions.createMelt,
         meltAuthorityAddress: newOptions.meltAuthorityAddress,
-        nftData: newOptions.nftData
+        data: newOptions.data,
+        isCreateNFT: newOptions.isCreateNFT,
       },
     );
     return await transactionUtils.prepareTransaction(
@@ -1619,6 +1622,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.meltAuthorityAddress] the address to send the melt authority created
    * @param {boolean} [options.allowExternalMeltAuthorityAddress=false] allow the melt authority address
    *                                                                    to be from another wallet
+   * @param {string[]=null} [options.data] list of data strings to add each as a data script output
    *
    * @return {Promise<CreateNewTokenResponse>}
    * @memberof HathorWallet
@@ -2301,7 +2305,8 @@ class HathorWallet extends EventEmitter {
       meltAuthorityAddress: null,
       allowExternalMeltAuthorityAddress: false,
     }, options);
-    newOptions['nftData'] = data;
+    newOptions.data = [data];
+    newOptions.isCreateNFT = true;
     const tx = await this.prepareCreateNewToken(name, symbol, amount, newOptions);
     return this.handleSendPreparedTransaction(tx);
   }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -544,6 +544,7 @@ const tokens = {
         // We currently have an external service that identifies NFT tokens with the first output as the data output
         // that's why we are keeping like this
         // However, this will change after a new project is completed to better identify an NFT token
+        // the method that validates the NFT is in src/models/CreateTokenTransaction.validateNft
         if (isCreateNFT) {
           txData.outputs.unshift(outputData);
         } else {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -273,7 +273,7 @@ const tokens = {
    * @param {boolean} [options.createAnotherMint=true] If a mint authority should be created on the transaction.
    * @param {string|null} [options.mintAuthorityAddress=null] The address to send the new mint authority created
    * @param {string|null} [options.changeAddress=null] The address to send any change output.
-   * @param {string[]|null} [options.data=null] list of data strings to add each as a data script output
+   * @param {string[]|null} [options.data=null] list of data strings using utf8 encoding to add each as a data script output
    * @param {function} [options.utxoSelection=bestUtxoSelection] Algorithm to select utxos. Use the best method by default
    *
    * @returns {Promise<IDataTx>} The transaction data
@@ -483,7 +483,7 @@ const tokens = {
    * @param {string} [options.mintAuthorityAddress] the address to send the mint authority created
    * @param {boolean} [options.createMelt=true] Whether to create a melt output
    * @param {string} [options.meltAuthorityAddress] the address to send the melt authority created
-   * @param {string[]|null} [options.data=null] list of data strings to add each as a data script output
+   * @param {string[]|null} [options.data=null] list of data strings using utf8 encoding to add each as a data script output
    * @param {boolean} [options.isCreateNFT=false] if the create token is an NFT creation call
    * @returns {Promise<IDataTx>} The transaction data to create the token
    */

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -539,7 +539,7 @@ const tokens = {
           value: 1,
           token: HATHOR_TOKEN_CONFIG.uid,
           authorities: 0,
-        };
+        } as IDataOutput;
 
         // We currently have an external service that identifies NFT tokens with the first output as the data output
         // that's why we are keeping like this


### PR DESCRIPTION
### Motivation

A use case needs to create tokens with data script outputs (more than one in the same create token transaction, if possible). This is similar to the Create NFT transaction, however we would be marking this token as an NFT in our metadata bucket, which is bad for the use case.

Because of that, we decided to add support to data script outputs in the lib methods adding them in the last positions of outputs, because the NFT standard expects the data output to be in the first output.

This is a short term solution and a new project will be created to define better how to better identify an NFT token, without fixing where the data output must be.

### Acceptance Criteria
- Add support for one or many data script outputs in a token create transaction.
  - This token can't be identified as an NFT by our wallet service lambda.
- Change `getNFTCreationFee` method name to `getDataScriptOutputFee`.
  - Even though this is a breaking change and not critical for the new feature, this improves the method name.
- The method to create NFT continues accepting only one data script output, so we don't change the method signature.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
