### PR TITLE
fix: address index method should return null in case the address does not belong to the wallet

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -716,6 +716,21 @@ describe('addresses methods', () => {
         .toStrictEqual(WALLET_CONSTANTS.multisig.addresses[i]);
     }
   })
+
+  it('should correctly get index of address using getAddressIndex', async () => {
+    // Creating a wallet
+    const hWallet = await generateWalletHelper();
+    const address = await hWallet.getAddressAtIndex(2);
+
+    const index = await hWallet.getAddressIndex(address);
+
+    expect(index).toBe(2);
+
+    // Address that does not belong to the wallet returns null
+    const nullIndex = await hWallet.getAddressIndex('test');
+
+    expect(nullIndex).toBe(null);
+  })
 });
 
 describe('getBalance', () => {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2215,10 +2215,7 @@ class HathorWallet extends EventEmitter {
    **/
   async getAddressIndex(address) {
     const addressInfo = await this.storage.getAddressInfo(address);
-    if (!addressInfo) {
-      return null;
-    }
-    return addressInfo.bip32AddressIndex;
+    return get(addressInfo, 'bip32AddressIndex', null);
   }
 
   /**

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2211,7 +2211,7 @@ class HathorWallet extends EventEmitter {
    *
    * @param {string} address Address to get the index
    *
-   * @return {Promise<number>}
+   * @return {Promise<number | null>}
    **/
   async getAddressIndex(address) {
     const addressInfo = await this.storage.getAddressInfo(address);

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2214,8 +2214,11 @@ class HathorWallet extends EventEmitter {
    * @return {Promise<number>}
    **/
   async getAddressIndex(address) {
-    const addresInfo = await this.storage.getAddressInfo(address);
-    return addresInfo.bip32AddressIndex;
+    const addressInfo = await this.storage.getAddressInfo(address);
+    if (!addressInfo) {
+      return null;
+    }
+    return addressInfo.bip32AddressIndex;
   }
 
   /**


### PR DESCRIPTION
### Motivation

Calling `getAddressIndex` with an address that does not belong to the wallet is throwing an error but should return `null`, according to the documentation.

```
  /**
   * Get index of address
   * Returns null if address does not belong to the wallet
   *
   * @param {string} address Address to get the index
   *
   * @return {Promise<number | null>}
   **/
```



### Acceptance Criteria
- Return `null` for the `getAddressIndex` method, if the address does not belong to the wallet.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
