### PR TITLE
chore: use new hathor-core health endpoint

### DIFF
--- a/__tests__/api/health.test.ts
+++ b/__tests__/api/health.test.ts
@@ -15,7 +15,7 @@ describe('healthApi', () => {
 
   it('getHealth should return health data', async () => {
     const data = { status: 'pass' };
-    mock.onGet('version').reply(200, data);
+    mock.onGet('health').reply(200, data);
 
     const result = await healthApi.getHealth();
 
@@ -23,7 +23,7 @@ describe('healthApi', () => {
   });
 
   it('getHealth should allow capturing errors in case of network error', async () => {
-    mock.onGet('version').networkError();
+    mock.onGet('health').networkError();
 
     await expect(healthApi.getHealth()).rejects.toThrow();
   });

--- a/src/api/health.js
+++ b/src/api/health.js
@@ -23,8 +23,7 @@ const healthApi = {
    */
   async getHealth() {
     return new Promise((resolve, reject) => {
-      // TODO: We should chage this to get `health` instead of `version`
-      createRequestInstance(resolve).get(`version`).then((res) => {
+      createRequestInstance(resolve).get(`health`).then((res) => {
         resolve(res.data);
       }, (err) => {
         reject(err);


### PR DESCRIPTION
### Acceptance Criteria
- We should use the actual `/health` endpoint on hathor-core when getting its health. We previously used the `/version` because the health one hadn't been implemented yet.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
