### PR TITLE
feat: stop reversing dataToSignHash

### DIFF
--- a/__tests__/models/transaction.test.js
+++ b/__tests__/models/transaction.test.js
@@ -79,7 +79,7 @@ test('New tx', () => {
   const dataToSign = tx.getDataToSign();
   expect(dataToSign.toString('hex')).toBe(expectedDataToSignHex);
 
-  const expectedDataToSignHashHex = 'df1a5572fa6b4750832c7fc2206a1ca53dbc4872c2a8738116f1801257ee647f';
+  const expectedDataToSignHashHex = '7f64ee571280f1168173a8c27248bc3da51c6a20c27f2c8350476bfa72551adf';
   const dataToSignHash = tx.getDataToSignHash();
   expect(dataToSignHash.toString('hex')).toBe(expectedDataToSignHashHex);
 

--- a/__tests__/utils/transaction.test.js
+++ b/__tests__/utils/transaction.test.js
@@ -58,7 +58,6 @@ test('getSignature', () => {
     hashdata,
     crypto.Signature.fromDER(signatureDER),
     privkey.toPublicKey(),
-    'little', // endianess
   )).toBe(true);
 });
 
@@ -108,7 +107,6 @@ test('signTransaction', async () => {
     hashdata,
     crypto.Signature.fromDER(sig1),
     xpriv.deriveChild(10).publicKey,
-    'little', // endianess
   )).toBe(true);
   expect(input2.data).toEqual(null);
 });

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -17,7 +17,7 @@ import {
   TX_HASH_SIZE_BYTES,
   TX_WEIGHT_CONSTANTS
 } from '../constants'
-import {crypto as cryptoBL, encoding, util, PrivateKey} from 'bitcore-lib'
+import {crypto as cryptoBL, util} from 'bitcore-lib'
 import {
   bufferToHex,
   hexToBuffer,
@@ -258,8 +258,7 @@ class Transaction {
    */
   getDataToSignHash(): Buffer {
     const dataToSign = this.getDataToSign();
-    const hashbuf = cryptoBL.Hash.sha256sha256(dataToSign);
-    return new encoding.BufferReader(hashbuf).readReverse();
+    return cryptoBL.Hash.sha256sha256(dataToSign);
   }
 
   /**

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -117,7 +117,7 @@ const transaction = {
    * @inner
    */
   getSignature(dataToSignHash: Buffer, privateKey: PrivateKey): Buffer {
-    const signature = cryptoBL.ECDSA.sign(dataToSignHash, privateKey, 'little').set({
+    const signature = cryptoBL.ECDSA.sign(dataToSignHash, privateKey).set({
       nhashtype: cryptoBL.Signature.SIGHASH_ALL,
     });
     return signature.toDER();


### PR DESCRIPTION
### Acceptance Criteria
- Do not reverse the hash of the `dataToSign`
- Stop considering signature message as little endian


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
