### PR TITLE
chore: storage method to sign tx with custom override

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.js
+++ b/__tests__/integration/hathorwallet_facade.test.js
@@ -16,19 +16,18 @@ import {
 } from './helpers/wallet.helper';
 import HathorWallet from '../../src/new/wallet';
 import { HATHOR_TOKEN_CONFIG, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
-import { NETWORK_NAME, TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test-constants';
+import { TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test-constants';
 import dateFormatter from '../../src/utils/date';
 import { verifyMessage } from '../../src/utils/crypto';
 import { loggers } from './utils/logger.util';
-import { NftValidationError, TxNotFoundError, SendTxError, WalletFromXPubGuard } from '../../src/errors';
+import { NftValidationError, TxNotFoundError, WalletFromXPubGuard } from '../../src/errors';
 import SendTransaction from '../../src/new/sendTransaction';
-import walletUtils from '../../src/utils/wallet';
 import { ConnectionState } from '../../src/wallet/types';
 import transaction from '../../src/utils/transaction';
 import Mnemonic from 'bitcore-mnemonic/lib/mnemonic';
 import { P2PKH_ACCT_PATH } from '../../src/constants';
 import Network from '../../src/models/network';
-import { WalletType, WALLET_FLAGS } from '../../src/types';
+import { WalletType } from '../../src/types';
 import { parseScriptData } from '../../src/utils/scripts';
 
 const fakeTokenUid = '008a19f84f2ae284f19bf3d03386c878ddd15b8b0b604a3a3539aa9d714686e1';
@@ -732,7 +731,15 @@ describe('addresses methods', () => {
     const nullIndex = await hWallet.getAddressIndex('test');
 
     expect(nullIndex).toBe(null);
-  })
+  });
+
+  it('should derive an address if it has not been generated yet', async () => {
+    const hWallet = await generateWalletHelper();
+    await expect(hWallet.getAddressAtIndex(50)).resolves.toBeDefined();
+
+    const mshWallet = await generateMultisigWalletHelper({ walletIndex: 0 });
+    await expect(mshWallet.getAddressAtIndex(50)).resolves.toBeDefined();
+  });
 });
 
 describe('getBalance', () => {
@@ -3030,5 +3037,42 @@ describe('storage methods', () => {
 
     const hWalletRO = await generateWalletHelperRO({ hardware: true });
     await expect(hWalletRO.isHardwareWallet()).resolves.toBe(true);
+  });
+});
+
+describe('getWalletInputInfo', () => {
+  afterEach(async () => {
+    await stopAllWallets();
+    await GenesisWalletHelper.clearListeners();
+  });
+
+  it.only('should return the address index and address path', async () => {
+    const hWallet = await generateWalletHelper();
+    const address = await hWallet.getAddressAtIndex(1);
+
+    const network = hWallet.getNetworkObject();
+    await GenesisWalletHelper.injectFunds(hWallet, address, 10);
+
+    const sendTransaction = new SendTransaction(
+      {
+        storage: hWallet.storage,
+        outputs: [
+          {
+            address: await hWallet.getAddressAtIndex(2),
+            value: 5,
+            token: HATHOR_TOKEN_CONFIG.uid,
+          },
+        ],
+      },
+    );
+    const txData = await sendTransaction.prepareTxData();
+    const tx = transaction.createTransactionFromData(txData, network);
+    tx.prepareToSend();
+
+    await expect(hWallet.getWalletInputInfo(tx)).resolves.toEqual([{
+      inputIndex: 0,
+      addressIndex: 1,
+      addressPath: "m/44'/280'/0'/0/1",
+    }]);
   });
 });

--- a/__tests__/integration/storage/storage.test.js
+++ b/__tests__/integration/storage/storage.test.js
@@ -120,7 +120,7 @@ describe('custom signature method', () => {
     const address = await hwallet.getAddressAtIndex(0);
     await GenesisWalletHelper.injectFunds(hwallet, address, 10);
 
-    const customSignFunc = jest.fn().mockImplementation(transactionUtils.getSignatureForTx);
+    const customSignFunc = jest.fn().mockImplementation(transactionUtils.getSignatureForTx.bind(transactionUtils));
     hwallet.storage.setTxSignatureMethod(customSignFunc);
     const address2 = await hwallet.getAddressAtIndex(2);
     await hwallet.sendTransaction(address2, 10);

--- a/__tests__/integration/storage/storage.test.js
+++ b/__tests__/integration/storage/storage.test.js
@@ -115,13 +115,26 @@ describe('custom signature method', () => {
     await GenesisWalletHelper.clearListeners();
   });
 
+  it('should check that we have an external signature method', async () => {
+    const hwallet = await generateWalletHelper();
+    const address = await hwallet.getAddressAtIndex(0);
+    await GenesisWalletHelper.injectFunds(hwallet, address, 10);
+
+    expect(hwallet.storage.hasTxSignatureMethod()).toEqual(false);
+    const customSignFunc = jest.fn().mockImplementation(transactionUtils.getSignatureForTx.bind(transactionUtils));
+    hwallet.storage.setTxSignatureMethod(customSignFunc);
+    expect(hwallet.storage.hasTxSignatureMethod()).toEqual(true);
+  });
+
   it('should sign transactions with custom signature method', async () => {
     const hwallet = await generateWalletHelper();
     const address = await hwallet.getAddressAtIndex(0);
     await GenesisWalletHelper.injectFunds(hwallet, address, 10);
 
     const customSignFunc = jest.fn().mockImplementation(transactionUtils.getSignatureForTx.bind(transactionUtils));
+    expect(storage.hasTxSignatureMethod()).toEqual(false);
     hwallet.storage.setTxSignatureMethod(customSignFunc);
+    expect(storage.hasTxSignatureMethod()).toEqual(true);
     const address2 = await hwallet.getAddressAtIndex(2);
     await hwallet.sendTransaction(address2, 10);
 

--- a/__tests__/integration/storage/storage.test.js
+++ b/__tests__/integration/storage/storage.test.js
@@ -132,9 +132,9 @@ describe('custom signature method', () => {
     await GenesisWalletHelper.injectFunds(hwallet, address, 10);
 
     const customSignFunc = jest.fn().mockImplementation(transactionUtils.getSignatureForTx.bind(transactionUtils));
-    expect(storage.hasTxSignatureMethod()).toEqual(false);
+    expect(hwallet.storage.hasTxSignatureMethod()).toEqual(false);
     hwallet.storage.setTxSignatureMethod(customSignFunc);
-    expect(storage.hasTxSignatureMethod()).toEqual(true);
+    expect(hwallet.storage.hasTxSignatureMethod()).toEqual(true);
     const address2 = await hwallet.getAddressAtIndex(2);
     await hwallet.sendTransaction(address2, 10);
 

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -215,7 +215,7 @@ test('Protected xpub wallet methods', async () => {
 test('getSignatures', async () => {
   const store = new MemoryStore();
   const storage = new Storage(store);
-  // jest.spyOn(storage, 'isReadonly').mockReturnValue(Promise.resolve(false));
+  jest.spyOn(storage, 'isReadonly').mockReturnValue(Promise.resolve(false));
   jest.spyOn(storage, 'getWalletType').mockReturnValue(Promise.resolve(WalletType.P2PKH));
   jest.spyOn(storage, 'signTx').mockReturnValue(Promise.resolve([
     {

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -207,7 +207,7 @@ test('Protected xpub wallet methods', async () => {
   await expect(hWallet.prepareMeltTokensData()).rejects.toThrow(WalletFromXPubGuard);
   await expect(hWallet.prepareDelegateAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
   await expect(hWallet.prepareDestroyAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
-  await expect(hWallet.getAllSignatures()).rejects.toThrow(WalletFromXPubGuard);
+  // await expect(hWallet.getAllSignatures()).rejects.toThrow(WalletFromXPubGuard);
   // await expect(hWallet.getSignatures()).rejects.toThrow(WalletFromXPubGuard);
   // await expect(hWallet.signTx()).rejects.toThrow(WalletFromXPubGuard);
 });

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -237,15 +237,15 @@ test('getSignatures', async () => {
   const signatures = await hWallet.getSignatures('a-transaction', { pinCode: '123' });
   expect(signatures.length).toEqual(2);
   expect(signatures[0]).toMatchObject({
-    signature: Buffer.from('cafe', 'hex'),
-    pubkey: Buffer.from('abcd', 'hex'),
+    signature: 'cafe',
+    pubkey: 'abcd',
     inputIndex: 0,
     addressIndex: 1,
     addressPath: "m/44'/280'/0'/0/1",
   });
   expect(signatures[1]).toMatchObject({
-    signature: Buffer.from('1234', 'hex'),
-    pubkey: Buffer.from('d00d', 'hex'),
+    signature: '1234',
+    pubkey: 'd00d',
     inputIndex: 0,
     addressIndex: 2,
     addressPath: "m/44'/280'/0'/0/2",

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -217,7 +217,7 @@ test('getSignatures', async () => {
   const storage = new Storage(store);
   jest.spyOn(storage, 'isReadonly').mockReturnValue(Promise.resolve(false));
   jest.spyOn(storage, 'getWalletType').mockReturnValue(Promise.resolve(WalletType.P2PKH));
-  jest.spyOn(storage, 'signTx').mockReturnValue(Promise.resolve([
+  jest.spyOn(storage, 'getTxSignatures').mockReturnValue(Promise.resolve([
     {
       signature: Buffer.from('cafe', 'hex'),
       pubkey: Buffer.from('abcd', 'hex'),

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -207,9 +207,9 @@ test('Protected xpub wallet methods', async () => {
   await expect(hWallet.prepareMeltTokensData()).rejects.toThrow(WalletFromXPubGuard);
   await expect(hWallet.prepareDelegateAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
   await expect(hWallet.prepareDestroyAuthorityData()).rejects.toThrow(WalletFromXPubGuard);
-  // await expect(hWallet.getAllSignatures()).rejects.toThrow(WalletFromXPubGuard);
-  // await expect(hWallet.getSignatures()).rejects.toThrow(WalletFromXPubGuard);
-  // await expect(hWallet.signTx()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.getAllSignatures()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.getSignatures()).rejects.toThrow(WalletFromXPubGuard);
+  await expect(hWallet.signTx()).rejects.toThrow(WalletFromXPubGuard);
 });
 
 test('getSignatures', async () => {

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -979,3 +979,11 @@ describe('prepare transactions without signature', () => {
   });
 });
 
+test('setExternalTxSigningMethod', async () => {
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+  const hwallet = new FakeHathorWallet();
+  hwallet.storage = storage;
+  hwallet.setExternalTxSigningMethod(async () => {});
+  expect(hwallet.isSignedExternally).toBe(true);
+});

--- a/__tests__/utils/transaction.test.js
+++ b/__tests__/utils/transaction.test.js
@@ -89,8 +89,10 @@ test('signTransaction', async () => {
     }
   });
   async function* getSpentMock(inputs) {
+    let index = 0;
     for (const inp of inputs) {
       yield {
+        index,
         input: inp,
         tx: {
           outputs: [
@@ -100,6 +102,7 @@ test('signTransaction', async () => {
           ],
         }
       };
+      index += 1;
     }
   }
   jest.spyOn(storage, 'getSpentTxs').mockImplementation(getSpentMock);

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2365,11 +2365,15 @@ class HathorWallet extends EventEmitter {
    */
   async getSignatures(tx, { pinCode = null } = {}) {
     const pin = pinCode || this.pinCode;
-    const signatures = await this.storage.signTxP2PKH(tx, pin);
-    return signatures.map(sigData => ({
-      ...sigData,
-      addressPath: this.getAddressPathForIndex(sigData.addressIndex),
-    }));
+    const signatures = await this.storage.signTx(tx, pin);
+    const ret = [];
+    for (const sigData of signatures) {
+      ret.push({
+        ...sigData,
+        addressPath: await this.getAddressPathForIndex(sigData.addressIndex),
+      });
+    }
+    return ret;
   }
 
   /**

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -505,7 +505,7 @@ class HathorWallet extends EventEmitter {
     // only works because the serialized signature starts with the account path pubkey.
     const p2shSignatures = signatures.sort().map(sig => P2SHSignature.deserialize(sig));
 
-    for await (const {tx: spentTx, input, index} of this.storage.getSpentTxs(tx.inputs)) {
+    for await (const { tx: spentTx, input, index } of this.storage.getSpentTxs(tx.inputs)) {
       const spentUtxo = spentTx.outputs[input.index];
       const storageAddress = (await this.storage.getAddressInfo(spentUtxo.decoded.address));
       if (storageAddress === null) {
@@ -524,7 +524,7 @@ class HathorWallet extends EventEmitter {
           sigs.push(hexToBuffer(p2shSig.signatures[index]));
         } catch (e) {
           // skip if there is no signature, or if it's not hex
-          continue
+          continue;
         }
       }
       const inputData = walletUtils.getP2SHInputData(sigs, redeemScript);
@@ -2370,6 +2370,7 @@ class HathorWallet extends EventEmitter {
     for (const sigData of signatures) {
       ret.push({
         ...sigData,
+        signature: sigData.signature.toString('hex'),
         addressPath: await this.getAddressPathForIndex(sigData.addressIndex),
       });
     }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2755,10 +2755,10 @@ class HathorWallet extends EventEmitter {
 
   /**
    * Set the external tx signing method.
-   * @param {EcdsaTxSign} method
+   * @param {EcdsaTxSign|null} method
    */
   setExternalTxSigningMethod(method) {
-    this.isSignedExternally = true;
+    this.isSignedExternally = !!method;
     this.storage.setTxSignatureMethod(method);
   }
 }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2366,16 +2366,16 @@ class HathorWallet extends EventEmitter {
   async getSignatures(tx, { pinCode = null } = {}) {
     const pin = pinCode || this.pinCode;
     const signatures = await this.storage.signTx(tx, pin);
-    const ret = [];
+    const sigInfoArray = [];
     for (const sigData of signatures) {
-      ret.push({
+      sigInfoArray.push({
         ...sigData,
         pubkey: sigData.pubkey.toString('hex'),
         signature: sigData.signature.toString('hex'),
         addressPath: await this.getAddressPathForIndex(sigData.addressIndex),
       });
     }
-    return ret;
+    return sigInfoArray;
   }
 
   /**

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2337,7 +2337,7 @@ class HathorWallet extends EventEmitter {
   async getWalletInputInfo(tx) {
     const walletInputs = [];
 
-    for await (const {tx: spentTx, input, index} of this.storage.getSpentTxs(tx.inputs)) {
+    for await (const { tx: spentTx, input, index } of this.storage.getSpentTxs(tx.inputs)) {
       const addressInfo = await this.storage.getAddressInfo(spentTx.outputs[input.index].decoded.address);
       if (addressInfo === null) {
         continue;

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2370,6 +2370,7 @@ class HathorWallet extends EventEmitter {
     for (const sigData of signatures) {
       ret.push({
         ...sigData,
+        pubkey: sigData.pubkey.toString('hex'),
         signature: sigData.signature.toString('hex'),
         addressPath: await this.getAddressPathForIndex(sigData.addressIndex),
       });

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -454,9 +454,9 @@ class HathorWallet extends EventEmitter {
    * @inner
    */
   async getAllSignatures(txHex, pin) {
-    if (await this.storage.isReadonly()) {
-      throw new WalletFromXPubGuard('getAllSignatures');
-    }
+    // if (await this.storage.isReadonly()) {
+    //   throw new WalletFromXPubGuard('getAllSignatures');
+    // }
     const tx = helpers.createTxFromHex(txHex, this.getNetworkObject());
     const accessData = await this.storage.getAccessData();
     if (accessData === null) {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2375,7 +2375,7 @@ class HathorWallet extends EventEmitter {
       throw new WalletFromXPubGuard('getSignatures');
     }
     const pin = pinCode || this.pinCode;
-    const signatures = await this.storage.signTx(tx, pin);
+    const signatures = await this.storage.getTxSignatures(tx, pin);
     const sigInfoArray = [];
     for (const sigData of signatures) {
       sigInfoArray.push({

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -90,6 +90,7 @@ class HathorWallet extends EventEmitter {
    * @param {{pubkeys:string[],numSignatures:number}} [param.multisig]
    * @param {string[]} [param.preCalculatedAddresses] An array of pre-calculated addresses
    * @param {import('../types').AddressScanPolicyData} [param.scanPolicy] config specific to
+   * @param {boolean} [param.disableXpubGuard=false] Whether we should disable the xpub guard
    * the address scan policy.
    */
   constructor({
@@ -115,6 +116,7 @@ class HathorWallet extends EventEmitter {
     multisig = null,
     preCalculatedAddresses = null,
     scanPolicy = null,
+    disableXpubGuard = false,
   } = {}) {
     super();
 
@@ -203,6 +205,7 @@ class HathorWallet extends EventEmitter {
     this.newTxPromise = Promise.resolve();
 
     this.scanPolicy = scanPolicy;
+    this.disableXpubGuard = disableXpubGuard;
   }
 
   /**
@@ -454,9 +457,9 @@ class HathorWallet extends EventEmitter {
    * @inner
    */
   async getAllSignatures(txHex, pin) {
-    // if (await this.storage.isReadonly()) {
-    //   throw new WalletFromXPubGuard('getAllSignatures');
-    // }
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
+      throw new WalletFromXPubGuard('getAllSignatures');
+    }
     const tx = helpers.createTxFromHex(txHex, this.getNetworkObject());
     const accessData = await this.storage.getAccessData();
     if (accessData === null) {
@@ -1090,7 +1093,7 @@ class HathorWallet extends EventEmitter {
    *
    */
   async consolidateUtxos(destinationAddress, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('consolidateUtxos');
     }
     const { outputs, inputs, utxos, total_amount } = await this.prepareConsolidateUtxosData(destinationAddress, options);
@@ -1265,7 +1268,7 @@ class HathorWallet extends EventEmitter {
    * @return {Promise<Transaction>} Promise that resolves when transaction is sent
    */
   async sendTransaction(address, value, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('sendTransaction');
     }
     const newOptions = Object.assign({
@@ -1300,7 +1303,7 @@ class HathorWallet extends EventEmitter {
    * @return {Promise<Transaction>} Promise that resolves when transaction is sent
    */
   async sendManyOutputsTransaction(outputs, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('sendManyOutputsTransaction');
     }
     const newOptions = Object.assign({
@@ -1522,7 +1525,7 @@ class HathorWallet extends EventEmitter {
    * @inner
    */
   async prepareCreateNewToken(name, symbol, amount, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('createNewToken');
     }
     const newOptions = Object.assign({
@@ -1730,7 +1733,7 @@ class HathorWallet extends EventEmitter {
    * @inner
    **/
   async prepareMintTokensData(tokenUid, amount, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('mintTokens');
     }
     const newOptions = Object.assign({
@@ -1840,7 +1843,7 @@ class HathorWallet extends EventEmitter {
    * @inner
    **/
   async prepareMeltTokensData(tokenUid, amount, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('meltTokens');
     }
     const newOptions = Object.assign({
@@ -1942,7 +1945,7 @@ class HathorWallet extends EventEmitter {
    * @inner
    **/
   async prepareDelegateAuthorityData(tokenUid, type, destinationAddress, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('delegateAuthority');
     }
     const newOptions = Object.assign({ createAnother: true, pinCode: null }, options);
@@ -2018,7 +2021,7 @@ class HathorWallet extends EventEmitter {
    * @inner
    **/
   async prepareDestroyAuthorityData(tokenUid, type, count, options = {}) {
-    if (await this.storage.isReadonly()) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('destroyAuthority');
     }
     const newOptions = Object.assign({ pinCode: null }, options);
@@ -2364,6 +2367,9 @@ class HathorWallet extends EventEmitter {
    * }>} Input and signature information
    */
   async getSignatures(tx, { pinCode = null } = {}) {
+    if ((!this.disableXpubGuard) && await this.storage.isReadonly()) {
+      throw new WalletFromXPubGuard('getSignatures');
+    }
     const pin = pinCode || this.pinCode;
     const signatures = await this.storage.signTx(tx, pin);
     const sigInfoArray = [];

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1580,7 +1580,7 @@ class HathorWallet extends EventEmitter {
         isCreateNFT: newOptions.isCreateNFT,
       },
     );
-    return await transactionUtils.prepareTransaction(
+    return transactionUtils.prepareTransaction(
       txData,
       pin,
       this.storage,
@@ -1777,7 +1777,7 @@ class HathorWallet extends EventEmitter {
       this.storage,
       mintOptions,
     );
-    return await transactionUtils.prepareTransaction(
+    return transactionUtils.prepareTransaction(
       txData,
       pin,
       this.storage,
@@ -1885,7 +1885,7 @@ class HathorWallet extends EventEmitter {
       this.storage,
       meltOptions,
     );
-    return await transactionUtils.prepareTransaction(
+    return transactionUtils.prepareTransaction(
       txData,
       pin,
       this.storage,
@@ -1972,7 +1972,7 @@ class HathorWallet extends EventEmitter {
       createAnother,
     );
 
-    return await transactionUtils.prepareTransaction(txData, pin, this.storage);
+    return transactionUtils.prepareTransaction(txData, pin, this.storage);
   }
 
   /**
@@ -2051,7 +2051,7 @@ class HathorWallet extends EventEmitter {
     }
 
     const txData = tokenUtils.prepareDestroyAuthorityTxData(data);
-    return await transactionUtils.prepareTransaction(txData, pin, this.storage);
+    return transactionUtils.prepareTransaction(txData, pin, this.storage);
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -84,10 +84,20 @@ export class Storage implements IStorage {
     this.version = version;
   }
 
+  /**
+   * Set the tx signing function
+   * @param {EcdsaTxSign} txSign The signing function
+   */
   setTxSign(txSign: EcdsaTxSign): void {
     this.txSignFunc = txSign;
   }
 
+  /**
+   * Sign the transaction
+   * @param {Transaction} tx The transaction to sign
+   * @param {string} pinCode The pin code
+   * @returns {Promise<IInputSignature[]>} The signatures
+   */
   async signTx(tx: Transaction, pinCode: string): Promise<IInputSignature[]> {
     if (this.txSignFunc) {
       return this.txSignFunc(tx, this, pinCode);
@@ -151,6 +161,12 @@ export class Storage implements IStorage {
     return this.store.getAddressAtIndex(index);
   }
 
+  /**
+   * Get the address public key, if not available derive from xpub
+   * @param {number} index
+   * @async
+   * @returns {Promise<string>} The public key DER encoded in hex
+   */
   async getAddressPubkey(index: number): Promise<string> {
     const addressInfo = await this.store.getAddressAtIndex(index);
     if (addressInfo?.publicKey) {

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -85,6 +85,14 @@ export class Storage implements IStorage {
   }
 
   /**
+   * Check if the tx signing method is set
+   * @returns {boolean}
+   */
+  hasTxSignatureMethod(): boolean {
+    return !!this.txSignFunc;
+  }
+
+  /**
    * Set the tx signing function
    * @param {EcdsaTxSign} txSign The signing function
    */

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -88,7 +88,7 @@ export class Storage implements IStorage {
    * Set the tx signing function
    * @param {EcdsaTxSign} txSign The signing function
    */
-  setTxSign(txSign: EcdsaTxSign): void {
+  setTxSignatureMethod(txSign: EcdsaTxSign): void {
     this.txSignFunc = txSign;
   }
 
@@ -98,7 +98,7 @@ export class Storage implements IStorage {
    * @param {string} pinCode The pin code
    * @returns {Promise<IInputSignature[]>} The signatures
    */
-  async signTx(tx: Transaction, pinCode: string): Promise<IInputSignature[]> {
+  async getTxSignatures(tx: Transaction, pinCode: string): Promise<IInputSignature[]> {
     if (this.txSignFunc) {
       return this.txSignFunc(tx, this, pinCode);
     }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -32,6 +32,7 @@ import {
   IIndexLimitAddressScanPolicy,
   SCANNING_POLICY,
   EcdsaTxSignP2PKH,
+  IInputSignature,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import { processHistory, processUtxoUnlock } from '../utils/storage';
@@ -87,11 +88,11 @@ export class Storage implements IStorage {
     this.txSignP2PKH = txSignP2PKH;
   }
 
-  async signTxP2PKH(tx: Transaction, pinCode: string): Promise<Transaction> {
+  async signTxP2PKH(tx: Transaction, pinCode: string): Promise<IInputSignature[]> {
     if (this.txSignP2PKH) {
       return this.txSignP2PKH(tx, this, pinCode);
     }
-    return transactionUtils.signTransaction(tx, this, pinCode);
+    return transactionUtils.getSignatureForTx(tx, this, pinCode);
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -31,7 +31,7 @@ import {
   AddressScanPolicyData,
   IIndexLimitAddressScanPolicy,
   SCANNING_POLICY,
-  EcdsaTxSignP2PKH,
+  EcdsaTxSign,
   IInputSignature,
 } from '../types';
 import transactionUtils from '../utils/transaction';
@@ -56,7 +56,7 @@ export class Storage implements IStorage {
   utxosSelectedAsInput: Map<string, boolean>;
   config: Config;
   version: ApiVersion|null;
-  txSignP2PKH: EcdsaTxSignP2PKH|null;
+  txSignFunc: EcdsaTxSign|null;
   /**
    * This promise is used to chain the calls to process unlocked utxos.
    * This way we can avoid concurrent calls.
@@ -73,7 +73,7 @@ export class Storage implements IStorage {
     this.config = config;
     this.version = null;
     this.utxoUnlockWait = Promise.resolve();
-    this.txSignP2PKH = null;
+    this.txSignFunc = null;
   }
 
   /**
@@ -84,13 +84,13 @@ export class Storage implements IStorage {
     this.version = version;
   }
 
-  setTxSignP2PKH(txSignP2PKH: EcdsaTxSignP2PKH): void {
-    this.txSignP2PKH = txSignP2PKH;
+  setTxSign(txSign: EcdsaTxSign): void {
+    this.txSignFunc = txSign;
   }
 
-  async signTxP2PKH(tx: Transaction, pinCode: string): Promise<IInputSignature[]> {
-    if (this.txSignP2PKH) {
-      return this.txSignP2PKH(tx, this, pinCode);
+  async signTx(tx: Transaction, pinCode: string): Promise<IInputSignature[]> {
+    if (this.txSignFunc) {
+      return this.txSignFunc(tx, this, pinCode);
     }
     return transactionUtils.getSignatureForTx(tx, this, pinCode);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -406,6 +406,7 @@ export interface IStorage {
   config: Config;
   version: ApiVersion|null;
 
+  hasTxSignatureMethod(): boolean;
   setTxSignatureMethod(txSign: EcdsaTxSign): void;
   getTxSignatures(tx: Transaction, pinCode: string): Promise<IInputSignature[]>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,8 +407,8 @@ export interface IStorage {
   config: Config;
   version: ApiVersion|null;
 
-  setTxSign(txSign: EcdsaTxSign): void;
-  signTx(tx: Transaction, pinCode: string): Promise<IInputSignature[]>;
+  setTxSignatureMethod(txSign: EcdsaTxSign): void;
+  getTxSignatures(tx: Transaction, pinCode: string): Promise<IInputSignature[]>;
 
   // Address methods
   getAllAddresses(): AsyncGenerator<IAddressInfo & IAddressMetadata>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,8 +6,16 @@
  */
 
 import { Config } from './config';
+import Transaction from './models/transaction';
 import Input from './models/input';
 import FullNodeConnection from './new/connection';
+
+/**
+ * Signature that receives the data to sign.
+ * For transactions, it should expect the sighash_all hashed once with sha256.
+ * The implementation must take care of the second sha256.
+ */
+export type EcdsaTxSignP2PKH = (tx: Transaction, storage: IStorage, pinCode: string) => Promise<Transaction>;
 
 export interface IAddressInfo {
   base58: string;
@@ -392,10 +400,14 @@ export interface IStorage {
   config: Config;
   version: ApiVersion|null;
 
+  setTxSignP2PKH(txSignP2PKH: EcdsaTxSignP2PKH): void;
+  signTxP2PKH(tx: Transaction, pinCode: string): Promise<Transaction>;
+
   // Address methods
   getAllAddresses(): AsyncGenerator<IAddressInfo & IAddressMetadata>;
   getAddressInfo(base58: string): Promise<(IAddressInfo & IAddressMetadata)|null>;
   getAddressAtIndex(index: number): Promise<IAddressInfo|null>;
+  getAddressPubkey(index: number): Promise<string>;
   saveAddress(info: IAddressInfo): Promise<void>;
   isAddressMine(base58: string): Promise<boolean>;
   getCurrentAddress(markAsUsed?: boolean): Promise<string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,9 +18,8 @@ export interface IInputSignature {
 }
 
 /**
- * Signature that receives the data to sign.
- * For transactions, it should expect the sighash_all hashed once with sha256.
- * The implementation must take care of the second sha256.
+ * This is the method signature for a method that signs a transaction and
+ * returns an array with signature information.
  */
 export type EcdsaTxSign = (tx: Transaction, storage: IStorage, pinCode: string) => Promise<IInputSignature[]>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface IInputSignature {
  * For transactions, it should expect the sighash_all hashed once with sha256.
  * The implementation must take care of the second sha256.
  */
-export type EcdsaTxSignP2PKH = (tx: Transaction, storage: IStorage, pinCode: string) => Promise<IInputSignature[]>;
+export type EcdsaTxSign = (tx: Transaction, storage: IStorage, pinCode: string) => Promise<IInputSignature[]>;
 
 export interface IAddressInfo {
   base58: string;
@@ -407,8 +407,8 @@ export interface IStorage {
   config: Config;
   version: ApiVersion|null;
 
-  setTxSignP2PKH(txSignP2PKH: EcdsaTxSignP2PKH): void;
-  signTxP2PKH(tx: Transaction, pinCode: string): Promise<IInputSignature[]>;
+  setTxSign(txSign: EcdsaTxSign): void;
+  signTx(tx: Transaction, pinCode: string): Promise<IInputSignature[]>;
 
   // Address methods
   getAllAddresses(): AsyncGenerator<IAddressInfo & IAddressMetadata>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,12 +10,19 @@ import Transaction from './models/transaction';
 import Input from './models/input';
 import FullNodeConnection from './new/connection';
 
+export interface IInputSignature {
+  inputIndex: number,
+  addressIndex: number,
+  signature: Buffer,
+  pubkey: Buffer,
+}
+
 /**
  * Signature that receives the data to sign.
  * For transactions, it should expect the sighash_all hashed once with sha256.
  * The implementation must take care of the second sha256.
  */
-export type EcdsaTxSignP2PKH = (tx: Transaction, storage: IStorage, pinCode: string) => Promise<Transaction>;
+export type EcdsaTxSignP2PKH = (tx: Transaction, storage: IStorage, pinCode: string) => Promise<IInputSignature[]>;
 
 export interface IAddressInfo {
   base58: string;
@@ -401,7 +408,7 @@ export interface IStorage {
   version: ApiVersion|null;
 
   setTxSignP2PKH(txSignP2PKH: EcdsaTxSignP2PKH): void;
-  signTxP2PKH(tx: Transaction, pinCode: string): Promise<Transaction>;
+  signTxP2PKH(tx: Transaction, pinCode: string): Promise<IInputSignature[]>;
 
   // Address methods
   getAllAddresses(): AsyncGenerator<IAddressInfo & IAddressMetadata>;

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -164,7 +164,7 @@ const transaction = {
   },
 
   async signTransaction(tx: Transaction, storage: IStorage, pinCode: string): Promise<Transaction> {
-    const signatures = await storage.signTx(tx, pinCode);
+    const signatures = await storage.getTxSignatures(tx, pinCode);
     for (const sigData of signatures) {
       const input = tx.inputs[sigData.inputIndex];
       const inputData = this.createInputData(

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -26,7 +26,7 @@ import CreateTokenTransaction from '../models/create_token_transaction';
 import Input from '../models/input';
 import Output from '../models/output';
 import Network from '../models/network';
-import { IBalance, IStorage, IHistoryTx, IDataOutput, IDataTx, isDataOutputCreateToken, IHistoryOutput, IUtxoId } from '../types';
+import { IBalance, IStorage, IHistoryTx, IDataOutput, IDataTx, isDataOutputCreateToken, IHistoryOutput, IUtxoId, IInputSignature } from '../types';
 import Address from '../models/address';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
@@ -134,12 +134,13 @@ const transaction = {
     return signature.toDER();
   },
 
-  async signTransaction(tx: Transaction, storage: IStorage, pinCode: string): Promise<Transaction> {
+  async getSignatureForTx(tx: Transaction, storage: IStorage, pinCode: string): Promise<IInputSignature[]> {
     const xprivstr = await storage.getMainXPrivKey(pinCode);
     const xprivkey = HDPrivateKey.fromString(xprivstr);
     const dataToSignHash = tx.getDataToSignHash();
+    const signatures: IInputSignature[] = [];
 
-    for await (const {tx: spentTx, input} of storage.getSpentTxs(tx.inputs)) {
+    for await (const {tx: spentTx, input, index: inputIndex} of storage.getSpentTxs(tx.inputs)) {
       const spentOut = spentTx.outputs[input.index];
       if (!spentOut.decoded.address) {
         // This is not a wallet output
@@ -151,13 +152,27 @@ const transaction = {
         continue;
       }
       const xpriv = xprivkey.deriveNonCompliantChild(addressInfo.bip32AddressIndex);
+      signatures.push({
+        inputIndex,
+        addressIndex: addressInfo.bip32AddressIndex,
+        signature: this.getSignature(dataToSignHash, xpriv.privateKey),
+        pubkey: xpriv.publicKey.toDER(),
+      });
+    }
+
+    return signatures;
+  },
+
+  async signTransaction(tx: Transaction, storage: IStorage, pinCode: string): Promise<Transaction> {
+    const signatures = await storage.signTxP2PKH(tx, pinCode);
+    for (const sigData of signatures) {
+      const input = tx.inputs[sigData.inputIndex];
       const inputData = this.createInputData(
-        this.getSignature(dataToSignHash, xpriv.privateKey),
-        xpriv.publicKey.toBuffer(),
+        sigData.signature,
+        sigData.pubkey,
       );
       input.setData(inputData);
     }
-
     return tx;
   },
 
@@ -505,7 +520,7 @@ const transaction = {
     const network = storage.config.getNetwork();
     const tx = this.createTransactionFromData(txData, network);
     if (newOptions.signTx) {
-      await storage.signTxP2PKH(tx, pinCode);
+      await this.signTransaction(tx, storage, pinCode);
     }
     tx.prepareToSend();
 

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -164,7 +164,7 @@ const transaction = {
   },
 
   async signTransaction(tx: Transaction, storage: IStorage, pinCode: string): Promise<Transaction> {
-    const signatures = await storage.signTxP2PKH(tx, pinCode);
+    const signatures = await storage.signTx(tx, pinCode);
     for (const sigData of signatures) {
       const input = tx.inputs[sigData.inputIndex];
       const inputData = this.createInputData(

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -505,7 +505,7 @@ const transaction = {
     const network = storage.config.getNetwork();
     const tx = this.createTransactionFromData(txData, network);
     if (newOptions.signTx) {
-      await this.signTransaction(tx, storage, pinCode);
+      await storage.signTxP2PKH(tx, pinCode);
     }
     tx.prepareToSend();
 

--- a/src/wallet/partialTxProposal.ts
+++ b/src/wallet/partialTxProposal.ts
@@ -367,7 +367,7 @@ class PartialTxProposal {
     }
 
     // sign inputs from the loaded wallet and save input data
-    await transactionUtils.signTransaction(tx, this.storage, pin);
+    await this.storage.signTxP2PKH(tx, pin);
     for (const [index, input] of tx.inputs.entries()) {
       if(input.data) {
         // add all signatures we know of this tx

--- a/src/wallet/partialTxProposal.ts
+++ b/src/wallet/partialTxProposal.ts
@@ -367,7 +367,7 @@ class PartialTxProposal {
     }
 
     // sign inputs from the loaded wallet and save input data
-    await this.storage.signTxP2PKH(tx, pin);
+    await transactionUtils.signTransaction(tx, this.storage, pin);
     for (const [index, input] of tx.inputs.entries()) {
       if(input.data) {
         // add all signatures we know of this tx


### PR DESCRIPTION
### Acceptance Criteria

- Allow the user to override the tx signature method.
- Default to `transactionUtils.signTransaction`, our main signature method.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
