### PR TITLE
refactor: use getAddressFromPubkey to parse address in the nano parser class

### DIFF
--- a/src/nano_contracts/parser.ts
+++ b/src/nano_contracts/parser.ts
@@ -12,6 +12,7 @@ import ncApi from '../api/nano';
 import { Address as bitcoreAddress, PublicKey as bitcorePublicKey } from 'bitcore-lib';
 import { get, has } from 'lodash';
 import { hexToBuffer, unpackToInt } from '../utils/buffer';
+import { getAddressFromPubkey } from '../utils/address';
 import { NanoContractTransactionParseError } from '../errors';
 import { MethodArgInfo, NanoContractParsedArgument } from './types';
 
@@ -34,15 +35,13 @@ class NanoContractTransactionParser {
   }
 
   /**
-   * Parse the nano public key to a base58 address
+   * Parse the nano public key to an address object
    *
    * @memberof NanoContractTransactionParser
    * @inner
    */
   parseAddress(network: Network) {
-    const pubkeyBuffer = hexToBuffer(this.publicKey);
-    const base58 = new bitcoreAddress(bitcorePublicKey(pubkeyBuffer), network.bitcoreNetwork).toString()
-    this.address = new Address(base58, { network });
+    this.address = getAddressFromPubkey(this.publicKey, network);
   }
 
   /**


### PR DESCRIPTION
### Acceptance Criteria
- Use `getAddressFromPubkey` to parse address in the nano parser class


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
