### PR TITLE
fix: getTxHistory [1]

### DIFF
--- a/__tests__/integration/nanocontracts/bet.test.js
+++ b/__tests__/integration/nanocontracts/bet.test.js
@@ -302,9 +302,9 @@ describe('full cycle of bet nano contract', () => {
       expect(txIds).toContain(tx.hash);
     }
 
-    // Get tx history, it must be greater then zero
+    // Get tx history with success
     const txHistory = await wallet.getTxHistory();
-    expect(txHistory).not.toHaveLength(0);
+    expect(txHistory).toHaveLength(4);
   }
 
   it('bet deposit', async () => {

--- a/__tests__/integration/nanocontracts/bet.test.js
+++ b/__tests__/integration/nanocontracts/bet.test.js
@@ -301,6 +301,10 @@ describe('full cycle of bet nano contract', () => {
     for (const tx of ncHistory2.history) {
       expect(txIds).toContain(tx.hash);
     }
+
+    // Get tx history, it must be greater then zero
+    const txHistory = await wallet.getTxHistory();
+    expect(txHistory).not.toHaveLength(0);
   }
 
   it('bet deposit', async () => {

--- a/__tests__/new/hathorwallet.test.js
+++ b/__tests__/new/hathorwallet.test.js
@@ -777,6 +777,9 @@ test('checkPinAndPassword', async () => {
 });
 
 test('getTxHistory', async () => {
+  const fakeNetwork = new Network('testnet');
+  const fakePubkey = Buffer.from('abcd', 'hex');
+
   const store = new MemoryStore();
   const storage = new Storage(store);
 
@@ -790,6 +793,9 @@ test('getTxHistory', async () => {
       version: 1,
       timestamp: 123,
       is_voided: false,
+      nc_id: 'mock-nc-id',
+      nc_method: 'mock-nc-method',
+      nc_pubkey: fakePubkey,
     };
   }
 
@@ -798,6 +804,11 @@ test('getTxHistory', async () => {
   }));
   jest.spyOn(storage, 'tokenHistory').mockImplementation(historyMock);
 
+  hWallet.getNetworkObject = jest.fn().mockReturnValue(fakeNetwork);
+  const addrFromPubkey = jest.spyOn(addressUtils, 'getAddressFromPubkey').mockReturnValue(
+    { base58: 'mock-address' }
+  );
+
   await expect(hWallet.getTxHistory({ token_id: 'mock-token-uid' }))
     .resolves.toStrictEqual([{
       txId: 'mock-tx-id',
@@ -805,9 +816,9 @@ test('getTxHistory', async () => {
       voided: false,
       balance: 456,
       version: 1,
-      ncId: undefined,
-      ncMethod: undefined,
-      ncCaller: undefined,
+      ncId: 'mock-nc-id',
+      ncMethod: 'mock-nc-method',
+      ncCaller: { base58: 'mock-address' },
     }]);
 
   await expect(hWallet.getTxHistory({ token_id: 'mock-token-uid2' }))
@@ -817,10 +828,13 @@ test('getTxHistory', async () => {
       voided: false,
       balance: 0,
       version: 1,
-      ncId: undefined,
-      ncMethod: undefined,
-      ncCaller: undefined,
+      ncId: 'mock-nc-id',
+      ncMethod: 'mock-nc-method',
+      ncCaller: { base58: 'mock-address' },
     }]);
+
+  expect(addrFromPubkey).toBeCalledTimes(2);
+  expect(addrFromPubkey).toBeCalledWith(fakePubkey, fakeNetwork);
 });
 
 test('isHardwareWallet', async () => {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -768,7 +768,7 @@ class HathorWallet extends EventEmitter {
         version: tx.version,
         ncId: tx.nc_id,
         ncMethod: tx.nc_method,
-        ncCaller: tx.nc_pubkey && getAddressFromPubkey(tx.nc_pubkey),
+        ncCaller: tx.nc_pubkey && getAddressFromPubkey(tx.nc_pubkey, this.getNetworkObject()),
       };
       txs.push(txHistory);
       count--;


### PR DESCRIPTION
### Motivation

It causes error when calling getTxHistory in the saga effect to fetch tx history on wallet-mobile.

### Acceptance Criteria
- Fix `getTxHistory` by passing network object to `getAddressFromPubkey`


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
