### PR TITLE
feat: add processingStatus to getTxHistory result [2]

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -726,6 +726,7 @@ class HathorWallet extends EventEmitter {
    * @property {number} timestamp
    * @property {boolean} voided
    * @property {number} version
+   * @property {TxHistoryProcessingStatus} processingStatus
    * @property {string} [ncId] - Nano Contract transaction hash
    * @property {string} [ncMethod] - Nano Contract method called
    * @property {Address} [ncCaller] - Nano Contract transaction's signing address
@@ -766,6 +767,7 @@ class HathorWallet extends EventEmitter {
         voided: tx.is_voided,
         balance: txbalance[uid] || 0,
         version: tx.version,
+        processingStatus: tx.processingStatus,
         ncId: tx.nc_id,
         ncMethod: tx.nc_method,
         ncCaller: tx.nc_pubkey && getAddressFromPubkey(tx.nc_pubkey),


### PR DESCRIPTION
### Motivation

This information is used to present the nano contract transaction status in the TxDetailsModal on wallet-mobile.

### Acceptance Criteria
- Add processingStatus to `getTxHistory` result


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
