### PR TITLE
fix: Failing tests on CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -41,8 +41,10 @@ jobs:
           name: test-transacion-logs
           path: tmp
       - name: Upload coverage
-        # https://github.com/codecov/codecov-action/releases/tag/v3.1.1
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        # https://github.com/codecov/codecov-action/releases/tag/v4.3.0
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: ${{ matrix.node-version }} == 14.x
         with:
           verbose: true

--- a/__tests__/wallet/mineTransaction.test.ts
+++ b/__tests__/wallet/mineTransaction.test.ts
@@ -9,15 +9,29 @@ test('Handle Rate Limit', (done) => {
   });
 
   const rawTx = '00010001020082c7dd1f0ceb8867219dcca68540abe77222d11bb2dc67a7af1f04640ea1f701006a473045022100e41968f863dc3372c96a944641f2361ed86849249822b5988804adba1683b3ec02201877dd97d0c85d3754f3378828a4484de407ed2985fcf87782d90cce8f72ec9c2103168e0d873a5bbd75c90c24a68071ea05b9c10996d0cadb543ca650aa76607a260000006400001976a9143f207b6b6fdc624f6c4aff52daf5b80f7f15caf988ac0000001700001976a9143f207b6b6fdc624f6c4aff52daf5b80f7f15caf988ac40200000218def4160dcc22702006f1ebedd590bb5db5c71adbdeaa9b15f7f75c6257c26b11781dc1a5b20f83300b96fdd7a445e063326bbba979919be3b76add5b9cac9ff3330aa2bb804fb0e000000f4';
+  const expectedErrorMessage = 'Too many transactions sent in a short time-span.\n\nAll transactions need to solve a proof-of-work as an anti spam mechanism. Currently, Hathor Labs provides a tx mining service for free, but there are limits to the number of transactions someone can mine using it to avoid abuse.\n\nPlease try again in a few seconds.';
 
   const network = new Network('testnet');
   const tx = helpers.createTxFromHex(rawTx, network);
+  const messagesValidated = {};
+  function validateErrorMessages(source: string) {
+    messagesValidated[source] = true;
+
+    // We should wait until both handlers receive the error with the correct message
+    if (Object.keys(messagesValidated).length === 2) {
+      done();
+    }
+  }
 
   const mineTransaction = new MineTransaction(tx, { maxTxMiningRetries: 1 });
-  mineTransaction.start();
-
-  mineTransaction.on('error', (message) => {
-    expect(message).toBe('Too many transactions sent in a short time-span.\n\nAll transactions need to solve a proof-of-work as an anti spam mechanism. Currently, Hathor Labs provides a tx mining service for free, but there are limits to the number of transactions someone can mine using it to avoid abuse.\n\nPlease try again in a few seconds.');
-    done();
+  mineTransaction.promise.catch(e => {
+    expect(e?.message).toBe(expectedErrorMessage);
+    validateErrorMessages('promise');
   });
+  mineTransaction.on('error', (message) => {
+    expect(message).toBe(expectedErrorMessage);
+    validateErrorMessages('error_event');
+  });
+
+  mineTransaction.start();
 });

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -415,6 +415,6 @@ export default class LevelDBStore implements IStore {
    * @async
    */
   async unregisterNanoContract(ncId: string): Promise<void> {
-    await this.nanoContractIndex.unregisterNanoContract(ncId);
+    return this.nanoContractIndex.unregisterNanoContract(ncId);
   }
 }

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -415,6 +415,6 @@ export default class LevelDBStore implements IStore {
    * @async
    */
   async unregisterNanoContract(ncId: string): Promise<void> {
-    this.nanoContractIndex.unregisterNanoContract(ncId);
+    await this.nanoContractIndex.unregisterNanoContract(ncId);
   }
 }

--- a/src/wallet/mineTransaction.ts
+++ b/src/wallet/mineTransaction.ts
@@ -67,6 +67,9 @@ class MineTransaction extends EventEmitter {
 
     // Promise that resolves when push tx finishes with success
     // or rejects in case of an error
+    // TODO: If this promise is not handled properly we crash the client application with a
+    //       misleading error message. This should be refactored to a more stable solution with
+    //       better user experience
     this.promise = new Promise((resolve, reject) => {
       this.on('success', (data) => {
         resolve(data);


### PR DESCRIPTION
This PR aims to fix minor bugs on the CI tests before upgrading to NodeJS 20 on #635 :

After upgrading to NodeJS 20, the `mineTransaction.test.ts` unit tests started failing. This was due to a stricter policy by Node of crashing whenever there is an unhandled promise in the application, instead of just emitting a warning as it was on NodeJS 14.

### Acceptance Criteria
- Promises on `MineTransaction` tests should always be handled
- The CI must be passing for all PRs

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
