### PR TITLE
chore: upgrade crypto-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bitcore-lib": "8.25.10",
         "bitcore-mnemonic": "8.25.10",
         "buffer": "6.0.3",
-        "crypto-js": "3.1.9-1",
+        "crypto-js": "4.2.0",
         "isomorphic-ws": "4.0.1",
         "level": "8.0.0",
         "lodash": "4.17.21",
@@ -6165,9 +6165,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "3.1.9-1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
-      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/cssom": {
       "version": "0.4.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "bitcore-lib": "8.25.10",
     "bitcore-mnemonic": "8.25.10",
     "buffer": "6.0.3",
-    "crypto-js": "3.1.9-1",
+    "crypto-js": "4.2.0",
     "isomorphic-ws": "4.0.1",
     "level": "8.0.0",
     "lodash": "4.17.21",


### PR DESCRIPTION
### Acceptance Criteria

- Upgrade crypto-js to most recent version (4.2.0).


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
