### PR TITLE
fix: async registerNanoContract call

### DIFF
--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -405,7 +405,7 @@ export default class LevelDBStore implements IStore {
    * @async
    */
   async registerNanoContract(ncId: string, ncValue: INcData): Promise<void> {
-    this.nanoContractIndex.registerNanoContract(ncId, ncValue);
+    return this.nanoContractIndex.registerNanoContract(ncId, ncValue);
   }
 
   /**


### PR DESCRIPTION
We were having intermittent failures on the CI ( [example](https://github.com/HathorNetwork/hathor-wallet-lib/actions/runs/9003097793/job/24732955502) ) due to a NanoContract registration promise being out of sync with the flow of the test suite. This PR ensures they stay in sync by returning the lower level promise instead of just firing it.

This is a similar solution as the one applied [on 641](https://github.com/HathorNetwork/hathor-wallet-lib/pull/641/files#diff-f46b617cbedd7301cb4b8766792b1a9ecb39300f645dc17ac13fd3cc9b969c33).

### Acceptance Criteria
- The `registerNanoContract` method should return its underlying operation `Promise<void>`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
