### PR TITLE
feat: add support for optional parameters in nano contract serializer/deserializer

### DIFF
--- a/__tests__/nano_contracts/deserializer.test.js
+++ b/__tests__/nano_contracts/deserializer.test.js
@@ -1,0 +1,175 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Serializer from '../../src/nano_contracts/serializer';
+import Deserializer from '../../src/nano_contracts/deserializer';
+
+
+test('Bool', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const valueFalse = false;
+  const serializedFalse = serializer.serializeFromType(valueFalse, 'bool');
+  const deserializedFalse = deserializer.deserializeFromType(serializedFalse, 'bool');
+  expect(deserializedFalse).toBe(valueFalse);
+
+  const valueTrue = true;
+  const serializedTrue = serializer.serializeFromType(valueTrue, 'bool');
+  const deserializedTrue = deserializer.deserializeFromType(serializedTrue, 'bool');
+  expect(deserializedTrue).toBe(valueTrue);
+})
+
+test('String', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const value = 'test';
+  const serialized = serializer.serializeFromType(value, 'str');
+  const deserialized = deserializer.deserializeFromType(serialized, 'str');
+
+  expect(value).toBe(deserialized);
+})
+
+test('Int', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const value = 300;
+  const serialized = serializer.serializeFromType(value, 'int');
+  const deserialized = deserializer.deserializeFromType(serialized, 'int');
+
+  expect(value).toBe(deserialized);
+})
+
+test('Bytes', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const value = Buffer.from([0x74, 0x65, 0x73, 0x74]);
+  const serialized = serializer.serializeFromType(value, 'bytes');
+  const deserialized = deserializer.deserializeFromType(serialized, 'bytes');
+
+  expect(value.equals(deserialized)).toBe(true);
+})
+
+test('Float', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const value = 10.32134;
+  const serialized = serializer.serializeFromType(value, 'float');
+  const deserialized = deserializer.deserializeFromType(serialized, 'float');
+
+  expect(value).toBe(deserialized);
+})
+
+test('Optional', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const valueEmptyInt = null;
+  const serializedEmptyInt = serializer.serializeFromType(valueEmptyInt, 'int?');
+  const deserializedEmptyInt = deserializer.deserializeFromType(serializedEmptyInt, 'int?');
+
+  expect(deserializedEmptyInt).toBe(valueEmptyInt);
+
+  const valueInt = 300;
+  const serializedInt = serializer.serializeFromType(valueInt, 'int?');
+  const deserializedInt = deserializer.deserializeFromType(serializedInt, 'int?');
+
+  expect(deserializedInt).toBe(valueInt);
+
+  const valueEmptyBool = null;
+  const serializedEmptyBool = serializer.serializeFromType(valueEmptyBool, 'bool?');
+  const deserializedEmptyBool = deserializer.deserializeFromType(serializedEmptyBool, 'bool?');
+
+  expect(deserializedEmptyBool).toBe(valueEmptyBool);
+
+  const valueBool = true;
+  const serializedBool = serializer.serializeFromType(valueBool, 'bool?');
+  const deserializedBool = deserializer.deserializeFromType(serializedBool, 'bool?');
+
+  expect(deserializedBool).toBe(valueBool);
+
+  const valueEmptyStr = null;
+  const serializedEmptyStr = serializer.serializeFromType(valueEmptyStr, 'str?');
+  const deserializedEmptyStr = deserializer.deserializeFromType(serializedEmptyStr, 'str?');
+
+  expect(deserializedEmptyStr).toBe(valueEmptyStr);
+
+  const valueStr = 'test';
+  const serializedStr = serializer.serializeFromType(valueStr, 'str?');
+  const deserializedStr = deserializer.deserializeFromType(serializedStr, 'str?');
+
+  expect(deserializedStr).toBe(valueStr);
+
+  const valueEmptyBytes = null;
+  const serializedEmptyBytes = serializer.serializeFromType(valueEmptyBytes, 'bytes?');
+  const deserializedEmptyBytes = deserializer.deserializeFromType(serializedEmptyBytes, 'bytes?');
+
+  expect(deserializedEmptyBytes).toBe(valueEmptyBytes);
+
+  const valueBytes = Buffer.from([0x74, 0x65, 0x73, 0x74]);
+  const serializedBytes = serializer.serializeFromType(valueBytes, 'bytes?');
+  const deserializedBytes = deserializer.deserializeFromType(serializedBytes, 'bytes?');
+
+  expect(deserializedBytes.equals(valueBytes)).toBe(true);
+
+  const valueEmptyFloat = null;
+  const serializedEmptyFloat = serializer.serializeFromType(valueEmptyFloat, 'float?');
+  const deserializedEmptyFloat = deserializer.deserializeFromType(serializedEmptyFloat, 'float?');
+
+  expect(deserializedEmptyFloat).toBe(valueEmptyFloat);
+
+  const valueFloat = 10.32134;
+  const serializedFloat = serializer.serializeFromType(valueFloat, 'float?');
+  const deserializedFloat = deserializer.deserializeFromType(serializedFloat, 'float?');
+
+  expect(deserializedFloat).toBe(valueFloat);
+})
+
+test('Signed', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const valueInt = '74657374,300,int';
+  const serializedInt = serializer.serializeFromType(valueInt, 'SignedData[int]');
+  const deserializedInt = deserializer.deserializeFromType(serializedInt, 'SignedData[int]');
+
+  expect(valueInt).toBe(deserializedInt);
+
+  const valueStr = '74657374,test,str';
+  const serializedStr = serializer.serializeFromType(valueStr, 'SignedData[str]');
+  const deserializedStr = deserializer.deserializeFromType(serializedStr, 'SignedData[str]');
+
+  expect(valueStr).toBe(deserializedStr);
+
+  const valueBytes = '74657374,74657374,bytes';
+  const serializedBytes = serializer.serializeFromType(valueBytes, 'SignedData[bytes]');
+  const deserializedBytes = deserializer.deserializeFromType(serializedBytes, 'SignedData[bytes]');
+
+  expect(valueBytes).toBe(deserializedBytes);
+
+  const valueFloat = '74657374,10.32134,float';
+  const serializedFloat = serializer.serializeFromType(valueFloat, 'SignedData[float]');
+  const deserializedFloat = deserializer.deserializeFromType(serializedFloat, 'SignedData[float]');
+
+  expect(valueFloat).toBe(deserializedFloat);
+
+  const valueBoolFalse = '74657374,false,bool';
+  const serializedBoolFalse = serializer.serializeFromType(valueBoolFalse, 'SignedData[bool]');
+  const deserializedBoolFalse = deserializer.deserializeFromType(serializedBoolFalse, 'SignedData[bool]');
+
+  expect(valueBoolFalse).toBe(deserializedBoolFalse);
+
+  const valueBoolTrue = '74657374,true,bool';
+  const serializedBoolTrue = serializer.serializeFromType(valueBoolTrue, 'SignedData[bool]');
+  const deserializedBoolTrue = deserializer.deserializeFromType(serializedBoolTrue, 'SignedData[bool]');
+
+  expect(valueBoolTrue).toBe(deserializedBoolTrue);
+})

--- a/__tests__/nano_contracts/serializer.test.js
+++ b/__tests__/nano_contracts/serializer.test.js
@@ -50,20 +50,20 @@ test('List', () => {
 
 test('Optional', () => {
   const serializer = new Serializer();
-  expect(serializer.fromOptional(true, undefined, 'int').equals(Buffer.from([0x00]))).toBe(true);
-  expect(serializer.fromOptional(false, 300, 'int').equals(Buffer.from([0x01, 0x00, 0x00, 0x01, 0x2c]))).toBe(true);
+  expect(serializer.fromOptional(null, 'int').equals(Buffer.from([0x00]))).toBe(true);
+  expect(serializer.fromOptional(300, 'int').equals(Buffer.from([0x01, 0x00, 0x00, 0x01, 0x2c]))).toBe(true);
 
-  expect(serializer.fromOptional(true, undefined, 'bool').equals(Buffer.from([0x00]))).toBe(true);
-  expect(serializer.fromOptional(false, true, 'bool').equals(Buffer.from([0x01, 0x01]))).toBe(true);
+  expect(serializer.fromOptional(null, 'bool').equals(Buffer.from([0x00]))).toBe(true);
+  expect(serializer.fromOptional(true, 'bool').equals(Buffer.from([0x01, 0x01]))).toBe(true);
 
-  expect(serializer.fromOptional(true, undefined, 'str').equals(Buffer.from([0x00]))).toBe(true);
-  expect(serializer.fromOptional(false, 'test', 'str').equals(Buffer.from([0x01, 0x74, 0x65, 0x73, 0x74]))).toBe(true);
+  expect(serializer.fromOptional(null, 'str').equals(Buffer.from([0x00]))).toBe(true);
+  expect(serializer.fromOptional('test', 'str').equals(Buffer.from([0x01, 0x74, 0x65, 0x73, 0x74]))).toBe(true);
 
-  expect(serializer.fromOptional(true, undefined, 'bytes').equals(Buffer.from([0x00]))).toBe(true);
-  expect(serializer.fromOptional(false, [0x74, 0x65, 0x73, 0x74], 'bytes').equals(Buffer.from([0x01, 0x74, 0x65, 0x73, 0x74]))).toBe(true);
+  expect(serializer.fromOptional(null, 'bytes').equals(Buffer.from([0x00]))).toBe(true);
+  expect(serializer.fromOptional([0x74, 0x65, 0x73, 0x74], 'bytes').equals(Buffer.from([0x01, 0x74, 0x65, 0x73, 0x74]))).toBe(true);
 
-  expect(serializer.fromOptional(true, undefined, 'float').equals(Buffer.from([0x00]))).toBe(true);
-  expect(serializer.fromOptional(false, 10.32134, 'float').equals(Buffer.from([0x01, 0x40, 0x24, 0xa4, 0x86, 0xad, 0x2d, 0xcb, 0x14]))).toBe(true);
+  expect(serializer.fromOptional(null, 'float').equals(Buffer.from([0x00]))).toBe(true);
+  expect(serializer.fromOptional(10.32134, 'float').equals(Buffer.from([0x01, 0x40, 0x24, 0xa4, 0x86, 0xad, 0x2d, 0xcb, 0x14]))).toBe(true);
 })
 
 test('Signed', () => {

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -22,6 +22,12 @@ class Deserializer {
    * @inner
    */
   deserializeFromType(value: Buffer, type: string): any {
+    if (type.endsWith('?')) {
+      // It's an optional
+      const optionalType = type.slice(0, -1);
+      return this.toOptional(value, optionalType);
+    }
+
     if (type.startsWith('SignedData[')) {
       return this.toSigned(value, type);
     }
@@ -107,6 +113,30 @@ class Deserializer {
   }
 
   /**
+   * Deserialize an optional value
+   *
+   * First we check the first byte. If it's 0, then we return null.
+   *
+   * Otherwise, we deserialize the rest of the buffer to the type.
+   *
+   * @param {value} Buffer with the optional value
+   * @param {type} Type of the optional without the ?
+   *
+   * @memberof Deserializer
+   * @inner
+   */
+  toOptional(value: Buffer, type: string): any {
+    if (value[0] === 0) {
+      // It's an empty optional
+      return null;
+    }
+
+    // Remove the first byte to deserialize the value, since it's not empty
+    const valueToDeserialize = value.slice(1);
+    return this.deserializeFromType(valueToDeserialize, type);
+  }
+
+  /**
    * Deserialize a signed value
    *
    * The signedData what will be deserialized is
@@ -130,7 +160,11 @@ class Deserializer {
     let size: number;
     // [len(serializedResult)][serializedResult][inputData]
     [size, signedBuffer] = unpackToInt(2, false, signedData);
-    const parsed = this.deserializeFromType(signedBuffer.slice(0, size), valueType);
+    let parsed = this.deserializeFromType(signedBuffer.slice(0, size), valueType);
+    if (valueType === 'bytes') {
+      // If the value is bytes, we should transform into hex to return the string
+      parsed = parsed.toString('hex');
+    }
     signedBuffer = signedBuffer.slice(size);
     return `${bufferToHex(signedBuffer)},${parsed},${valueType}`;
   }


### PR DESCRIPTION
### Acceptance Criteria
- Add support in the serializer and deserializer class for optional parameter.
- Fix bug in the signed data deserializer, where the bytes value was not being converted to hex.

**Note:** Unfortunately, we currently don't have any blueprints with optional parameters, so we can't test this in the integration tests, thus only unit tests were added.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.