### PR TITLE
feat: add method to iterate over all registered nano contracts on storage

### DIFF
--- a/__tests__/storage/storage.test.js
+++ b/__tests__/storage/storage.test.js
@@ -64,6 +64,13 @@ describe('handleStop', () => {
       outputs: [],
     });
     await storage.registerToken(testToken);
+    const testNano = {
+      ncId: 'abc',
+      address: 'nanoAddress',
+      blueprintId: 'blueprintId',
+      blueprintName: 'blueprintName',
+    };
+    await storage.registerNanoContract('abc', testNano);
     // We have 1 transaction
     await expect(store.historyCount()).resolves.toEqual(1);
     // 20 addresses
@@ -72,6 +79,10 @@ describe('handleStop', () => {
     let tokens = await toArray(storage.getRegisteredTokens());
     expect(tokens).toHaveLength(1);
     expect(tokens[0]).toEqual(testToken);
+    // And 1 registered nano contract
+    let nanos = await toArray(storage.getRegisteredNanoContracts());
+    expect(nanos).toHaveLength(1);
+    expect(nanos[0]).toEqual(testNano);
 
     storage.version = 'something';
     // handleStop with defaults
@@ -82,9 +93,13 @@ describe('handleStop', () => {
     await expect(store.historyCount()).resolves.toEqual(1);
     await expect(store.addressCount()).resolves.toEqual(20);
     await expect(store.isTokenRegistered(testToken.uid)).resolves.toBeTruthy();
+    await expect(store.isNanoContractRegistered(testNano.ncId)).resolves.toBeTruthy();
     tokens = await toArray(storage.getRegisteredTokens());
     expect(tokens).toHaveLength(1);
     expect(tokens[0]).toEqual(testToken);
+    nanos = await toArray(storage.getRegisteredNanoContracts());
+    expect(nanos).toHaveLength(1);
+    expect(nanos[0]).toEqual(testNano);
 
     // handleStop with cleanStorage = true
     await storage.handleStop({ cleanStorage: true });
@@ -92,9 +107,13 @@ describe('handleStop', () => {
     await expect(store.historyCount()).resolves.toEqual(0);
     await expect(store.addressCount()).resolves.toEqual(20);
     await expect(store.isTokenRegistered(testToken.uid)).resolves.toBeTruthy();
+    await expect(store.isNanoContractRegistered(testNano.ncId)).resolves.toBeTruthy();
     tokens = await toArray(storage.getRegisteredTokens());
     expect(tokens).toHaveLength(1);
     expect(tokens[0]).toEqual(testToken);
+    nanos = await toArray(storage.getRegisteredNanoContracts());
+    expect(nanos).toHaveLength(1);
+    expect(nanos[0]).toEqual(testNano);
 
     await storage.addTx({
       tx_id: 'another-new-tx',
@@ -109,9 +128,13 @@ describe('handleStop', () => {
     await expect(store.historyCount()).resolves.toEqual(1);
     await expect(store.addressCount()).resolves.toEqual(0);
     await expect(store.isTokenRegistered(testToken.uid)).resolves.toBeTruthy();
+    await expect(store.isNanoContractRegistered(testNano.ncId)).resolves.toBeTruthy();
     tokens = await toArray(storage.getRegisteredTokens());
     expect(tokens).toHaveLength(1);
     expect(tokens[0]).toEqual(testToken);
+    nanos = await toArray(storage.getRegisteredNanoContracts());
+    expect(nanos).toHaveLength(1);
+    expect(nanos[0]).toEqual(testNano);
 
     // handleStop with cleanAddresses = true
     await loadAddresses(0, 20, storage);
@@ -120,6 +143,12 @@ describe('handleStop', () => {
     await expect(store.historyCount()).resolves.toEqual(1);
     await expect(store.addressCount()).resolves.toEqual(20);
     await expect(store.isTokenRegistered(testToken.uid)).resolves.toBeFalsy();
+    await expect(store.isNanoContractRegistered(testNano.ncId)).resolves.toBeFalsy();
+
+    tokens = await toArray(storage.getRegisteredTokens());
+    expect(tokens).toHaveLength(0);
+    nanos = await toArray(storage.getRegisteredNanoContracts());
+    expect(nanos).toHaveLength(0);
 
     // Access data is untouched when stopping the wallet
     // XXX: since we stringify to save on store, the optional undefined properties are removed

--- a/src/storage/leveldb/nanocontract_index.ts
+++ b/src/storage/leveldb/nanocontract_index.ts
@@ -69,6 +69,19 @@ export default class LevelNanoContractIndex implements IKVNanoContractIndex {
   }
 
   /**
+   * Iterate over all registered nano contracts in the database
+   *
+   * @async
+   * @generator
+   * @returns {AsyncGenerator<INcData>}
+   */
+  async *registeredNanoContractsIter(): AsyncGenerator<INcData> {
+    for await (const ncData of this.registeredDB.values()) {
+      yield ncData;
+    }
+  }
+
+  /**
    * Get a nano contract data on database from the ncId.
    *
    * @param ncId Nano Contract ID.

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -387,6 +387,19 @@ export default class LevelDBStore implements IStore {
   }
 
   /**
+   * Iterate over all registered nano contracts in the database
+   *
+   * @async
+   * @generator
+   * @returns {AsyncGenerator<INcData>}
+   */
+  async *registeredNanoContractsIter(): AsyncGenerator<INcData> {
+    for await (const ncData of this.nanoContractIndex.registeredNanoContractsIter()) {
+      yield ncData;
+    }
+  }
+
+  /**
    * Get a nano contract data on storage from the ncId.
    *
    * @param ncId Nano Contract Id.

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -908,6 +908,19 @@ export class MemoryStore implements IStore {
   }
 
   /**
+   * Iterate on registered nano contracts.
+   *
+   * @async
+   * @generator
+   * @returns {AsyncGenerator<INcData>}
+   */
+  async *registeredNanoContractsIter(): AsyncGenerator<INcData> {
+    for (const ncData of this.registeredNanoContracts.values()) {
+      yield ncData;
+    }
+  }
+
+  /**
    * Get a nano contract data on storage from the ncId.
    *
    * @param ncId Nano Contract ID.

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -986,6 +986,19 @@ export class Storage implements IStorage {
   }
 
   /**
+   * Iterate on all registered nano contracts of the wallet.
+   *
+   * @async
+   * @generator
+   * @returns {AsyncGenerator<INcData>}
+   */
+  async *getRegisteredNanoContracts(): AsyncGenerator<INcData> {
+    for await (const ncData of this.store.registeredNanoContractsIter()) {
+      yield ncData;
+    }
+  }
+
+  /**
    * Get nano contract data.
    * @param ncId Nano Contract ID.
    * @returns An instance of Nano Contract data.

--- a/src/types.ts
+++ b/src/types.ts
@@ -401,6 +401,7 @@ export interface IStore {
 
   // Nano Contract methods
   isNanoContractRegistered(ncId: string): Promise<boolean>;
+  registeredNanoContractsIter(): AsyncGenerator<INcData>;
   getNanoContract(ncId: string): Promise<INcData | null>;
   registerNanoContract(ncId: string, ncValue: INcData): Promise<void>;
   unregisterNanoContract(ncId: string): Promise<void>;
@@ -595,6 +596,7 @@ export interface IKVNanoContractIndex extends IKVStoreIndex<void> {
 
 export interface INcData {
   ncId: string;
+  address: string;
   blueprintId: string;
   blueprintName: string;
 }


### PR DESCRIPTION
### Acceptance Criteria
- Add method to iterate through registered nano contracts on storage and in both implemented stores (memory and leveldb).
- Add `address` to `INcData`.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
