### PR TITLE
chore: Upgrades `ws`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "level": "8.0.0",
         "lodash": "4.17.21",
         "long": "4.0.0",
-        "ws": "7.5.9"
+        "ws": "8.17.0"
       },
       "devDependencies": {
         "@babel/cli": "7.21.0",
@@ -11614,15 +11614,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
+      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "level": "8.0.0",
     "lodash": "4.17.21",
     "long": "4.0.0",
-    "ws": "7.5.9"
+    "ws": "8.17.0"
   },
   "scripts": {
     "test": "jest --env=node --forceExit",


### PR DESCRIPTION
### Acceptance Criteria
- Upgrades `ws` from `7.5.9` to `8.17.0`

### Notes
There is a list of breaking changes on [v8's release notes](https://github.com/websockets/ws/releases/tag/8.0.0), most notably the deprecation of NodeJS < 10 and changes to the lib's error handling methods.

To validate for these changes, besides this repository unit and integration tests, the built version was tested manually on the Desktop Wallet and passed the full automated test suite for the Headless Wallet.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
