### PR TITLE
feat: add methods to update nano contract address in storage and store

### DIFF
--- a/__tests__/storage/leveldb/leveldb_store.test.js
+++ b/__tests__/storage/leveldb/leveldb_store.test.js
@@ -405,9 +405,11 @@ test('nano contract methods', async () => {
   await store.registerNanoContract('001', {
     ncId: '001',
     blueprintId: '001',
-    blueprintName: 'Bet'
+    blueprintName: 'Bet',
+    address: 'abc',
   });
   await expect(store.getNanoContract('001')).resolves.toBeDefined();
+  await expect(store.getNanoContract('001')).resolves.toMatchObject({ address: 'abc' });
   await expect(store.isNanoContractRegistered('001')).resolves.toBeTruthy();
   await expect(asyncGenToArray(store.nanoContractIndex.registeredDB.iterator()))
         .resolves.toHaveLength(1);
@@ -415,7 +417,8 @@ test('nano contract methods', async () => {
   await store.registerNanoContract('002', {
     ncId: '002',
     blueprintId: '001',
-    blueprintName: 'Bet'
+    blueprintName: 'Bet',
+    address: 'abc',
   });
   await expect(store.getNanoContract('002')).resolves.toBeDefined();
   await expect(store.isNanoContractRegistered('002')).resolves.toBeTruthy();
@@ -428,6 +431,10 @@ test('nano contract methods', async () => {
   await expect(store.isNanoContractRegistered('002')).resolves.toBeFalsy();
   await expect(asyncGenToArray(store.nanoContractIndex.registeredDB.iterator()))
         .resolves.toHaveLength(1);
+
+  // Test update address of registered nano contract
+  await store.updateNanoContractRegisteredAddress('001', 'def');
+  await expect(store.getNanoContract('001')).resolves.toMatchObject({ address: 'def' });
 
   // Asserts store is cleaned only when tokens are cleaned too
   await store.cleanStorage(false, false, false); // not cleaning tokens

--- a/__tests__/storage/memory_store.test.js
+++ b/__tests__/storage/memory_store.test.js
@@ -345,16 +345,19 @@ test('nano contract methods', async () => {
   await store.registerNanoContract('001', {
     ncId: '001',
     blueprintId: '001',
-    blueprintName: 'Bet'
+    blueprintName: 'Bet',
+    address: 'abc',
   });
   await expect(store.getNanoContract('001')).resolves.toBeDefined();
+  await expect(store.getNanoContract('001')).resolves.toMatchObject({ address: 'abc' });
   await expect(store.isNanoContractRegistered('001')).resolves.toBeTruthy();
   expect(store.registeredNanoContracts.size).toEqual(1);
 
   await store.registerNanoContract('002', {
     ncId: '002',
     blueprintId: '001',
-    blueprintName: 'Bet'
+    blueprintName: 'Bet',
+    address: 'abc',
   });
   await expect(store.getNanoContract('002')).resolves.toBeDefined();
   await expect(store.isNanoContractRegistered('002')).resolves.toBeTruthy();
@@ -365,6 +368,10 @@ test('nano contract methods', async () => {
   await expect(store.getNanoContract('002')).resolves.toBeNull();
   await expect(store.isNanoContractRegistered('002')).resolves.toBeFalsy();
   expect(store.registeredNanoContracts.size).toEqual(1);
+
+  // Test update address of registered nano contract
+  await store.updateNanoContractRegisteredAddress('001', 'def');
+  await expect(store.getNanoContract('001')).resolves.toMatchObject({ address: 'def' });
 
   // Asserts store is cleaned only when tokens are cleaned too
   await store.cleanStorage(false, false, false); // not cleaning tokens

--- a/__tests__/storage/storage.test.js
+++ b/__tests__/storage/storage.test.js
@@ -64,9 +64,11 @@ describe('handleStop', () => {
       outputs: [],
     });
     await storage.registerToken(testToken);
+    const address0 = await storage.getAddressAtIndex(0);
+    const address1 = await storage.getAddressAtIndex(1);
     const testNano = {
       ncId: 'abc',
-      address: 'nanoAddress',
+      address: address0.base58,
       blueprintId: 'blueprintId',
       blueprintName: 'blueprintName',
     };
@@ -85,12 +87,12 @@ describe('handleStop', () => {
     expect(nanos[0]).toEqual(testNano);
 
     // Test address update
-    await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: 'nanoAddress' });
-    await storage.updateNanoContractRegisteredAddress('abc', 'nanoAddress2');
-    await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: 'nanoAddress2' });
+    await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: address0.base58 });
+    await storage.updateNanoContractRegisteredAddress('abc', address1.base58);
+    await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: address1.base58 });
 
     // Go back to default address
-    await storage.updateNanoContractRegisteredAddress('abc', 'nanoAddress');
+    await storage.updateNanoContractRegisteredAddress('abc', address0.base58);
 
     storage.version = 'something';
     // handleStop with defaults

--- a/__tests__/storage/storage.test.js
+++ b/__tests__/storage/storage.test.js
@@ -91,6 +91,8 @@ describe('handleStop', () => {
     await storage.updateNanoContractRegisteredAddress('abc', address1.base58);
     await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: address1.base58 });
 
+    await expect(storage.updateNanoContractRegisteredAddress('abc', 'abc')).rejects.toThrow(Error);
+
     // Go back to default address
     await storage.updateNanoContractRegisteredAddress('abc', address0.base58);
 

--- a/__tests__/storage/storage.test.js
+++ b/__tests__/storage/storage.test.js
@@ -84,6 +84,14 @@ describe('handleStop', () => {
     expect(nanos).toHaveLength(1);
     expect(nanos[0]).toEqual(testNano);
 
+    // Test address update
+    await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: 'nanoAddress' });
+    await storage.updateNanoContractRegisteredAddress('abc', 'nanoAddress2');
+    await expect(store.getNanoContract('abc')).resolves.toMatchObject({ address: 'nanoAddress2' });
+
+    // Go back to default address
+    await storage.updateNanoContractRegisteredAddress('abc', 'nanoAddress');
+
     storage.version = 'something';
     // handleStop with defaults
     await storage.handleStop()

--- a/src/storage/leveldb/nanocontract_index.ts
+++ b/src/storage/leveldb/nanocontract_index.ts
@@ -120,4 +120,19 @@ export default class LevelNanoContractIndex implements IKVNanoContractIndex {
   async unregisterNanoContract(ncId: string): Promise<void> {
     await this.registeredDB.del(ncId);
   }
+
+
+  /**
+   * Update nano contract registered address.
+   *
+   * @param ncId Nano Contract ID.
+   * @param address Nano Contract registered address.
+   * @async
+   */
+  async updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void> {
+    const currentNanoContractData = await this.getNanoContract(ncId);
+    if (currentNanoContractData !== null) {
+      return this.registeredDB.put(ncId, Object.assign(currentNanoContractData, { address }));
+    }
+  }
 }

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -430,4 +430,14 @@ export default class LevelDBStore implements IStore {
   async unregisterNanoContract(ncId: string): Promise<void> {
     return this.nanoContractIndex.unregisterNanoContract(ncId);
   }
+
+  /**
+   * Update nano contract registered address.
+   *
+   * @param ncId Nano Contract ID.
+   * @param address Nano Contract registered address.
+   */
+  async updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void> {
+    return this.nanoContractIndex.updateNanoContractRegisteredAddress(ncId, address);
+  }
 }

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -950,4 +950,17 @@ export class MemoryStore implements IStore {
   async unregisterNanoContract(ncId: string): Promise<void> {
     this.registeredNanoContracts.delete(ncId);
   }
+
+  /**
+   * Update nano contract registered address.
+   *
+   * @param ncId Nano Contract ID.
+   * @param address Nano Contract registered address.
+   */
+  async updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void> {
+    const currentNanoContractData = await this.getNanoContract(ncId);
+    if (currentNanoContractData !== null) {
+      this.registeredNanoContracts.set(ncId, Object.assign(currentNanoContractData, { address }));
+    }
+  }
 }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1023,4 +1023,13 @@ export class Storage implements IStorage {
   async unregisterNanoContract(ncId: string): Promise<void> {
     return this.store.unregisterNanoContract(ncId);
   }
+
+  /**
+   * Update nano contract registered address
+   * @param ncId Nano Contract ID.
+   * @param address New registered address
+   */
+  async updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void> {
+    return this.store.updateNanoContractRegisteredAddress(ncId, address);
+  }
 }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -1030,6 +1030,9 @@ export class Storage implements IStorage {
    * @param address New registered address
    */
   async updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void> {
+    if (!await this.isAddressMine(address)) {
+      throw new Error('Registered address must belong to the wallet.');
+    }
     return this.store.updateNanoContractRegisteredAddress(ncId, address);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -405,6 +405,7 @@ export interface IStore {
   getNanoContract(ncId: string): Promise<INcData | null>;
   registerNanoContract(ncId: string, ncValue: INcData): Promise<void>;
   unregisterNanoContract(ncId: string): Promise<void>;
+  updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void>;
 
   // Generic storage keys
   getItem(key: string): Promise<any>;
@@ -489,9 +490,11 @@ export interface IStorage {
 
   // Nano Contract methods
   isNanoContractRegistered(ncId: string): Promise<boolean>;
+  getRegisteredNanoContracts(): AsyncGenerator<INcData>;
   getNanoContract(ncId: string): Promise<INcData | null>;
   registerNanoContract(ncId: string, ncValue: INcData): Promise<void>;
   unregisterNanoContract(ncId: string): Promise<void>;
+  updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void>;
 }
 
 /**
@@ -591,6 +594,7 @@ export interface IKVNanoContractIndex extends IKVStoreIndex<void> {
   getNanoContract(ncId: string): Promise<INcData | null>;
   registerNanoContract(ncId: string, ncValue: INcData): Promise<void>;
   unregisterNanoContract(ncId: string): Promise<void>;
+  updateNanoContractRegisteredAddress(ncId: string, address: string): Promise<void>;
   clear(): Promise<void>;
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- Add methods in storages and default stores to update the address associated with a registered nano contract.
- Add `getRegisteredNanoContracts` to the `IStorage`.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
