### PR TITLE
chore: Upgrades `bitcore-lib`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "axios": "1.6.8",
-        "bitcore-lib": "8.25.10",
-        "bitcore-mnemonic": "8.25.10",
+        "bitcore-lib": "10.0.36",
+        "bitcore-mnemonic": "10.0.36",
         "buffer": "6.0.3",
         "crypto-js": "4.2.0",
         "isomorphic-ws": "5.0.0",
@@ -4392,9 +4392,14 @@
       ]
     },
     "node_modules/bech32": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.3.tgz",
-      "integrity": "sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+    },
+    "node_modules/bigi": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/bigi/-/bigi-1.4.2.tgz",
+      "integrity": "sha512-ddkU+dFIuEIW8lE7ZwdIAf2UPoM90eaprg5m3YXAVVTmKlqV/9BX4A2M8BOK2yOq6/VgZFVhK6QAxJebhlbhzw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -4406,12 +4411,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/bitcore-lib": {
-      "version": "8.25.10",
-      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-8.25.10.tgz",
-      "integrity": "sha512-MyHpSg7aFRHe359RA/gdkaQAal3NswYZTLEuu0tGX1RGWXAYN9i/24fsjPqVKj+z0ua+gzAT7aQs0KiKXWCgKA==",
+    "node_modules/bip-schnorr": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/bip-schnorr/-/bip-schnorr-0.6.4.tgz",
+      "integrity": "sha512-dNKw7Lea8B0wMIN4OjEmOk/Z5qUGqoPDY0P2QttLqGk1hmDPytLWW8PR5Pb6Vxy6CprcdEgfJpOjUu+ONQveyg==",
       "dependencies": {
-        "bech32": "=1.1.3",
+        "bigi": "^1.4.2",
+        "ecurve": "^1.0.6",
+        "js-sha256": "^0.9.0",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bitcore-lib": {
+      "version": "10.0.36",
+      "resolved": "https://registry.npmjs.org/bitcore-lib/-/bitcore-lib-10.0.36.tgz",
+      "integrity": "sha512-yGSiEubYzabCYZ5/qu9ji5P/kfLkXpBgm1lAblVO2ESuD9ep7aaG6TRd3K5ips4pWgW/uRQpbiErT6pw2Ke/AQ==",
+      "dependencies": {
+        "bech32": "=2.0.0",
+        "bip-schnorr": "=0.6.4",
         "bn.js": "=4.11.8",
         "bs58": "^4.0.1",
         "buffer-compare": "=1.1.1",
@@ -4420,21 +4441,16 @@
         "lodash": "^4.17.20"
       }
     },
-    "node_modules/bitcore-lib/node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/bitcore-mnemonic": {
-      "version": "8.25.10",
-      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-8.25.10.tgz",
-      "integrity": "sha512-FeXxO37BLV5JRvxPmVFB91zRHalavV8H4TdQGt1/hz0AkoPymIV68OkuB+TptpjeYgatcgKPoPvPhglJkTzFQQ==",
+      "version": "10.0.36",
+      "resolved": "https://registry.npmjs.org/bitcore-mnemonic/-/bitcore-mnemonic-10.0.36.tgz",
+      "integrity": "sha512-7paCdPrcB8TsfryQxiDU6FB79H4DDmhlQYMiU/EcflTAJezz5RDpy9qMv3p/FX1wfUd4jRk4UIrWzQAnv0UM8A==",
       "dependencies": {
-        "bitcore-lib": "^8.25.10",
+        "bitcore-lib": "^10.0.36",
         "unorm": "^1.4.1"
       },
       "peerDependencies": {
-        "bitcore-lib": "^8.20.1"
+        "bitcore-lib": "*"
       }
     },
     "node_modules/bn.js": {
@@ -5067,6 +5083,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ecurve": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
+      "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
+      "dependencies": {
+        "bigi": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -8934,6 +8959,11 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10160,6 +10190,14 @@
         }
       ]
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -10408,9 +10446,23 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "dependencies": {
     "axios": "1.6.8",
-    "bitcore-lib": "8.25.10",
-    "bitcore-mnemonic": "8.25.10",
+    "bitcore-lib": "10.0.36",
+    "bitcore-mnemonic": "10.0.36",
     "buffer": "6.0.3",
     "crypto-js": "4.2.0",
     "isomorphic-ws": "5.0.0",


### PR DESCRIPTION
### Acceptance Criteria
- Upgrades `bitcore-lib` and `bitcore-mnemonic` from `8.25.10` to `10.0.36`

### Notes
Both the [release notes](https://github.com/bitpay/bitcore/releases), and the [changelog file](https://github.com/bitpay/bitcore/blob/master/CHANGELOG.md) do not have any information about the major upgrades 9 and 10.

There is no v9 tag, and the [v10 tag](https://github.com/bitpay/bitcore/releases/tag/v10.0.0) has no information about breaking changes. The only source of information to understand the changes are [the commits themselves](https://github.com/bitpay/bitcore/compare/v8.25.10...v10.0.36) and they indicate no breaking changes.

Tests sending transactions and validating addresses were executed on the Desktop Wallet to ensure the client applications worked correctly and passed with no issues.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
