### PR TITLE
chore: upgrades `mock-socket`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "jest": "29.7.0",
         "jest-html-reporter": "3.10.2",
         "jest-localstorage-mock": "2.4.26",
-        "mock-socket": "8.1.1",
+        "mock-socket": "9.3.1",
         "typescript": "4.9.5"
       },
       "engines": {
@@ -9233,15 +9233,12 @@
       }
     },
     "node_modules/mock-socket": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-8.1.1.tgz",
-      "integrity": "sha512-ValJ4+1d9hfoNgR4pFv+g1TaGRLFTSM1EMWi3g+aN6pxPzvag0WIZCwaFKZIGfBhonx3Q0IeUVmXRPw1YoIyhA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.3.1.tgz",
+      "integrity": "sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==",
       "dev": true,
-      "dependencies": {
-        "url-parse": "^1.4.4"
-      },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 8"
       }
     },
     "node_modules/module-error": {
@@ -10135,12 +10132,6 @@
         }
       ]
     },
-    "node_modules/querystringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10274,12 +10265,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.1",
@@ -11431,16 +11416,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-      "dev": true,
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "jest": "29.7.0",
     "jest-html-reporter": "3.10.2",
     "jest-localstorage-mock": "2.4.26",
-    "mock-socket": "8.1.1",
+    "mock-socket": "9.3.1",
     "typescript": "4.9.5"
   },
   "repository": {


### PR DESCRIPTION
### Acceptance Criteria
- Upgrades `mock-socket` from `8.1.1` to `9.3.1`

### Notes
The [changelogs](https://github.com/thoov/mock-socket/blob/master/CHANGELOG.md) only offer data about version 9. The [v9 release](https://github.com/thoov/mock-socket/releases/tag/9.0.0) itself only mentions a deprecation of NodeJs older than 12, so there are probably no breaking changes here.


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
