### PR TITLE
refactor: split nano contract send method into create and mine/push

### DIFF
--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -30,24 +30,22 @@ import { parseScript } from '../utils/scripts';
 import { MethodArgInfo } from './types';
 
 /**
- * Sign a transaction, create a send transaction object, mine and push
+ * Sign a transaction and create a send transaction object
  *
  * @param tx Transaction to sign and send
  * @param pin Pin to decrypt data
  * @param storage Wallet storage object
  */
-export const signAndPushNCTransaction = async (tx: NanoContract, pin: string, storage: IStorage): Promise<Transaction> => {
+export const signAndCreateSendTransaction = async (tx: NanoContract, pin: string, storage: IStorage): Promise<SendTransaction> => {
   await transactionUtils.signTransaction(tx, storage, pin);
   tx.prepareToSend();
 
-  // Create send transaction object
-  const sendTransaction = new SendTransaction({
+  // Create and return a send transaction object
+  return new SendTransaction({
     storage,
     transaction: tx,
     pin,
   });
-
-  return sendTransaction.runFromMining();
 }
 
 /**

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -36,7 +36,7 @@ import { MethodArgInfo } from './types';
  * @param pin Pin to decrypt data
  * @param storage Wallet storage object
  */
-export const signAndCreateSendTransaction = async (tx: NanoContract, pin: string, storage: IStorage): Promise<SendTransaction> => {
+export const prepareNanoSendTransaction = async (tx: NanoContract, pin: string, storage: IStorage): Promise<SendTransaction> => {
   await transactionUtils.signTransaction(tx, storage, pin);
   tx.prepareToSend();
 

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -42,7 +42,7 @@ import txApi from '../api/txApi';
 import { MemoryStore, Storage } from '../storage';
 import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../utils/address';
 import NanoContractTransactionBuilder from '../nano_contracts/builder';
-import { signAndCreateSendTransaction } from '../nano_contracts/utils';
+import { prepareNanoSendTransaction } from '../nano_contracts/utils';
 
 const ERROR_MESSAGE_PIN_REQUIRED = 'Pin is required.';
 
@@ -2759,7 +2759,7 @@ class HathorWallet extends EventEmitter {
       .setArgs(data.args);
 
     const nc = await builder.build();
-    return signAndCreateSendTransaction(nc, pin, this.storage);
+    return prepareNanoSendTransaction(nc, pin, this.storage);
   }
 
   /**

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -42,7 +42,7 @@ import txApi from '../api/txApi';
 import { MemoryStore, Storage } from '../storage';
 import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../utils/address';
 import NanoContractTransactionBuilder from '../nano_contracts/builder';
-import { signAndPushNCTransaction } from '../nano_contracts/utils';
+import { signAndCreateSendTransaction } from '../nano_contracts/utils';
 
 const ERROR_MESSAGE_PIN_REQUIRED = 'Pin is required.';
 
@@ -2711,8 +2711,29 @@ class HathorWallet extends EventEmitter {
    * @returns {Promise<NanoContract>}
    */
   async createAndSendNanoContractTransaction(method, address, data, options = {}) {
+    const sendTransaction = await this.createNanoContractTransaction(method, address, data, options);
+    return sendTransaction.runFromMining();
+  }
+
+  /**
+   * Create a nano contract transaction and return the SendTransaction object
+   *
+   * @param {string} method Method of nano contract to have the transaction created
+   * @param {string} address Address that will be used to sign the nano contract transaction
+   * @param [data]
+   * @param {string | null} [data.blueprintId] ID of the blueprint to create the nano contract. Required if method is initialize
+   * @param {string | null} [data.ncId] ID of the nano contract to execute method. Required if method is not initialize
+   * @param {NanoContractAction[]} [data.actions] List of actions to execute in the nano contract transaction
+   * @param {any[]} [data.args] List of arguments for the method to be executed in the transaction
+   * @param [options]
+   * @param {string} [options.pinCode] PIN to decrypt the private key.
+   *                                   Optional but required if not set in this
+   *
+   * @returns {Promise<SendTransaction>}
+   */
+  async createNanoContractTransaction(method, address, data, options = {}) {
     if (await this.storage.isReadonly()) {
-      throw new WalletFromXPubGuard('createAndSendNanoContractTransaction');
+      throw new WalletFromXPubGuard('createNanoContractTransaction');
     }
     const newOptions = Object.assign({ pinCode: null }, options);
     const pin = newOptions.pinCode || this.pinCode;
@@ -2738,7 +2759,7 @@ class HathorWallet extends EventEmitter {
       .setArgs(data.args);
 
     const nc = await builder.build();
-    return signAndPushNCTransaction(nc, pin, this.storage);
+    return signAndCreateSendTransaction(nc, pin, this.storage);
   }
 
   /**


### PR DESCRIPTION
### Motivation

The desktop wallet has a flow for sending tx that it expects the `SendTransaction` object because internally we handle the states of mine/push with the error handling and UI feedback for the user.

### Acceptance Criteria
- Transform the create and send nano contract method into two, (i) build tx and create `SendTransaction` object and (ii) create, mine, and push.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
