### PR TITLE
fix: no-extraneous-dependencies rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
+        "abstract-level": "1.0.4",
         "axios": "1.7.2",
         "bitcore-lib": "8.25.10",
         "bitcore-mnemonic": "8.25.10",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "/lib"
   ],
   "dependencies": {
+    "abstract-level": "1.0.4",
     "axios": "1.7.2",
     "bitcore-lib": "8.25.10",
     "bitcore-mnemonic": "8.25.10",


### PR DESCRIPTION
The `abstract-level` dependency is used directly by six classes in `Storage -> LevelDB` file. To avoid this linting error, we should explicitly declare it in the `package.json` file

### Acceptance Criteria
- Fixes [no-extraneous-dependencies](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-extraneous-dependencies.md) rule


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
