### PR TITLE
feat: Workflow to sync release into master

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,162 @@
+name: Sync Release with Master
+
+# Triggered when a new version is released publicly
+on:
+  workflow_dispatch:
+  release:
+    types: [ released ]
+
+jobs:
+  create-sync-pull-request:
+    name: Create release sync PR
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      ORG_NAME: HathorNetwork
+      PROJECT_NUMBER: 15
+      COLUMN_NAME: "In Progress (WIP)"
+
+    steps:
+      - name: Checkout
+        id: checkout
+        # https://github.com/actions/checkout/releases/tag/v4.1.6
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+
+      - name: Create Pull Request
+        id: create_pull
+        run: |
+          # The assignee will be the user that manually published the release
+          PR_URL=$(gh pr create \
+            --title "chore: [${{ github.ref_name }}] Merge release into master" \
+            --body "Automated PR to merge `release` branch into `master` based on release event." \
+            --base "master" \
+            --head "release" \
+            --assignee "@me")
+
+          # Store value in step output
+          echo "PR_URL=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Associate PR with project
+        env:
+          PR_URL: ${{ steps.create_pull.outputs.PR_URL }}
+        run: |
+          gh project item-add $PROJECT_NUMBER \
+            --owner $ORG_NAME \
+            --url "$PR_URL" \
+
+      - name: Fetch project and column data
+        id: proj_columns
+        env:
+          PR_URL: ${{ steps.create_pull.outputs.PR_URL }}
+        # There is no direct command to move a card inside a project. Here we start gathering id data about the project
+        # to do this operation through the API
+        run: |
+          QUERY="
+          query {
+            organization(login: \"$ORG_NAME\") {
+              projectV2(number: $PROJECT_NUMBER) {
+                id
+                field(name: \"Status\") {
+                  __typename
+                  ...on ProjectV2SingleSelectField {
+                    id
+                    options {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+          "
+          PROJ_RESPONSE=$(gh api graphql -f query="$QUERY")
+
+          # Parse json response and fetch necessary data identifiers from it
+          PROJ_DATA=$(echo "$PROJ_RESPONSE" | jq -r --arg column_name "$COLUMN_NAME" '
+            .data.organization.projectV2.id as $projectId |
+            .data.organization.projectV2.field.id as $fieldId |
+            .data.organization.projectV2.field.options[] |
+            select(.name == $column_name) |
+            {
+              projectId: $projectId,
+              fieldId: $fieldId,
+              optionId: .id
+            }')
+          PROJECT_ID=$(echo "$PROJ_DATA" | jq -r '.projectId')
+          FIELD_ID=$(echo "$PROJ_DATA" | jq -r '.fieldId')
+          OPTION_ID=$(echo "$PROJ_DATA" | jq -r '.optionId')
+
+          # Store values in step output
+          echo "PROJECT_ID=$PROJECT_ID" >> "$GITHUB_OUTPUT"
+          echo "FIELD_ID=$FIELD_ID" >> "$GITHUB_OUTPUT"
+          echo "OPTION_ID=$OPTION_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch PR card Id
+        id: proj_cardId
+        env:
+          PR_URL: ${{ steps.create_pull.outputs.PR_URL }}
+        run: |
+          QUERY="
+            query {
+              organization(login: \"$ORG_NAME\") {
+                projectV2(number: $PROJECT_NUMBER) {
+                  items(first: 10) {
+                    nodes {
+                      id
+                      content {
+                        ... on PullRequest {
+                          id
+                          title
+                          number
+                          repository {
+                            owner {
+                              login
+                            }
+                            name
+                          }
+                          url
+                        }
+                      }
+                    }
+                  }
+                }
+             }
+            }"
+          PROJ_RESPONSE=$(gh api graphql -f query="$QUERY")
+
+          CARD_ID=$(echo "$PROJ_RESPONSE" | jq -r --arg pr_url "$PR_URL" '
+            .data.organization.projectV2.items.nodes[]
+            | select(.content.url == $pr_url)
+            | .id')
+
+          # Store value in step output
+          echo "CARD_ID=$CARD_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Move card to correct column
+        id: mutateCard
+        env:
+          PROJECT_ID: ${{ steps.proj_columns.outputs.PROJECT_ID }}
+          FIELD_ID: ${{ steps.proj_columns.outputs.FIELD_ID }}
+          OPTION_ID: ${{ steps.proj_columns.outputs.OPTION_ID }}
+          CARD_ID: ${{ steps.proj_cardId.outputs.CARD_ID }}
+        run: |
+          QUERY="
+          mutation {
+            updateProjectV2ItemFieldValue(
+              input: {
+                projectId: \"$PROJECT_ID\",
+                itemId: \"$CARD_ID\",
+                fieldId: \"$FIELD_ID\",
+                value: {
+                  singleSelectOptionId: \"$OPTION_ID\"
+                }
+              }
+            ) {
+              projectV2Item {
+                id
+              }
+            }
+          }
+          "
+          PROJ_RESPONSE=$(gh api graphql -f query="$QUERY")

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -102,7 +102,7 @@ jobs:
           # The github repository contains the owner organization too: we need to get only the last part of it
           REPO_NAME=$(basename ${{ github.repository }})
 
-          # Executing graphql query
+          # Executing graphql query to fetch the Id of the card that links the PR to the Project
           QUERY="
             query {
               repository(owner: \"$ORG_NAME\", name: \"$REPO_NAME\") {

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -14,7 +14,7 @@ jobs:
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       ORG_NAME: HathorNetwork
       PROJECT_NUMBER: 15
-      COLUMN_NAME: "In Progress (WIP)"
+      COLUMN_NAME: "In Progress (Done)"
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -33,8 +33,12 @@ jobs:
             --head "release" \
             --assignee "@me")
 
-          # Store value in step output
+          # Obtaining the PR number from its URL
+          PR_NUMBER=$(echo $PR_URL | grep -oP '/pull/\K\d+')
+
+          # Store values in step output
           echo "PR_URL=$PR_URL" >> "$GITHUB_OUTPUT"
+          echo "PR_NUMBER=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Associate PR with project
         env:
@@ -46,8 +50,6 @@ jobs:
 
       - name: Fetch project and column data
         id: proj_columns
-        env:
-          PR_URL: ${{ steps.create_pull.outputs.PR_URL }}
         # There is no direct command to move a card inside a project. Here we start gathering id data about the project
         # to do this operation through the API
         run: |
@@ -95,40 +97,33 @@ jobs:
       - name: Fetch PR card Id
         id: proj_cardId
         env:
-          PR_URL: ${{ steps.create_pull.outputs.PR_URL }}
+          PR_NUMBER: ${{ steps.create_pull.outputs.PR_NUMBER }}
         run: |
+          # The github repository contains the owner organization too: we need to get only the last part of it
+          REPO_NAME=$(basename ${{ github.repository }})
+
+          # Executing graphql query
           QUERY="
             query {
-              organization(login: \"$ORG_NAME\") {
-                projectV2(number: $PROJECT_NUMBER) {
-                  items(first: 10) {
-                    nodes {
-                      id
-                      content {
-                        ... on PullRequest {
-                          id
-                          title
-                          number
-                          repository {
-                            owner {
-                              login
-                            }
-                            name
-                          }
-                          url
-                        }
+              repository(owner: \"$ORG_NAME\", name: \"$REPO_NAME\") {
+                pullRequest(number: $PR_NUMBER) {
+                  id
+                  projectItems(first: 100) {
+                    ... on ProjectV2ItemConnection {
+                      nodes {
+                      ... on ProjectV2Item {
+                        id
                       }
                     }
                   }
                 }
-             }
-            }"
+              }
+            }
+          }"
           PROJ_RESPONSE=$(gh api graphql -f query="$QUERY")
 
-          CARD_ID=$(echo "$PROJ_RESPONSE" | jq -r --arg pr_url "$PR_URL" '
-            .data.organization.projectV2.items.nodes[]
-            | select(.content.url == $pr_url)
-            | .id')
+          # Fetching the id of the project card related to this PR
+          CARD_ID=$(echo "$PROJ_RESPONSE" | jq -r '.data.repository.pullRequest.projectItems.nodes[0].id')
 
           # Store value in step output
           echo "CARD_ID=$CARD_ID" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Motivation
We sometimes forgot to merge the contents of the `release` branch back into `master` after a successful release. This workflow aims to automate the creation of the PR for this.

### Security considerations
There is no simple command on the GitHub CLI to add a card to a specific column. To do this it's necessary to execute mutation queries directly to GitHub API, with `write` permissions for the entire project, which raise a flag about the width of the necessary permissions.

The available actions that could execute this are still in beta, or were made obsolete by the GitHub Projects v2. So it was decided to implement the queries and mutation directly inside the workflow.

### Future possibilities
To facilitate the use of this functionality in other repositories, we should implement a GitHub Action inside the HathorNetwork organization with this code.

### Additional tasks
To run this workflow it's necessary to create a new access token containing the following permissions:
- Organization: Read and Write to organization projects
- Repository: Read and Write to pull requests for this specific repository ( or a limited set of repositories that can reuse this functionality )

This token should be added to this repository secrets with the name `RELEASE_TOKEN`

## Acceptance Criteria
- When the `publish release` action is taken, a new PR should be created
- This new PR should be assigned to the person who triggered the release
- This new PR should be added to HathorNetwork's engineering kanban project board
- This PR should be moved to the "In Progress (WIP)" column

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
