### PR TITLE
fix: updateTokensData retry mechanism

### DIFF
--- a/__tests__/utils/storage.test.js
+++ b/__tests__/utils/storage.test.js
@@ -5,8 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
 import { MemoryStore, Storage } from '../../src/storage';
-import { scanPolicyStartAddresses, checkScanningPolicy } from '../../src/utils/storage';
+import {
+  scanPolicyStartAddresses,
+  checkScanningPolicy,
+  _updateTokensData,
+} from '../../src/utils/storage';
 
 describe('scanning policy methods', () => {
   it('start addresses', async () => {
@@ -41,5 +47,282 @@ describe('scanning policy methods', () => {
 
     policyMock.mockReturnValue(Promise.resolve('invalid-policy'));
     await expect(checkScanningPolicy(storage)).resolves.toEqual(null);
+  });
+});
+
+describe('_updateTokensData', () => {
+  let axiosMock;
+  const updateTokenApiUrl = 'thin_wallet/token';
+  const sampleTokensAPIOutput = {
+    balance: {
+      authorities: {
+        melt: {
+          locked: 0,
+          unlocked: 0,
+        },
+        mint: {
+          locked: 0,
+          unlocked: 0,
+        },
+      },
+      tokens: {
+        locked: 0,
+        unlocked: 0,
+      },
+    },
+    name: '',
+    numTransactions: 0,
+    symbol: '',
+    uid: '',
+  };
+
+  /**
+   * Helper function to iterate the `getAllTokens` generator function and output an array of tokens
+   * @param storage
+   * @returns {Promise<*[]>}
+   */
+  async function getAllTokensArray(storage) {
+    const results = [];
+    for await (const value of storage.getAllTokens()) {
+      results.push(value);
+    }
+    return results;
+  }
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(axios);
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+  });
+
+  it('should handle empty tokens parameter', async () => {
+    // Setup
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    axiosMock.onGet(updateTokenApiUrl).reply(200);
+
+    // Execute
+    const result = await _updateTokensData(storage, new Set());
+
+    // Verify
+    expect(result).toStrictEqual(undefined); // Method has void return
+    expect(await getAllTokensArray(storage)).toHaveLength(0); // No tokens added
+    expect(axiosMock.history.get).toHaveLength(0); // No API calls made
+  });
+
+  it('should handle a single token parameter', async () => {
+    // Setup
+    const mockToken = {
+      uid: 'mock-token',
+      name: 'Mock Token 1',
+      symbol: 'MT1',
+    };
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    axiosMock.onGet(updateTokenApiUrl).reply(200, {
+      success: true,
+      name: mockToken.name,
+      symbol: mockToken.symbol,
+    });
+
+    // Execute
+    const tokensSet = new Set();
+    tokensSet.add(mockToken.uid);
+    await _updateTokensData(storage, tokensSet);
+
+    // Verify
+    expect(await getAllTokensArray(storage)).toHaveLength(1);
+    expect(axiosMock.history.get).toHaveLength(1);
+    expect(await storage.getToken(mockToken.uid)).toStrictEqual({
+      ...sampleTokensAPIOutput,
+      name: mockToken.name,
+      symbol: mockToken.symbol,
+      uid: mockToken.uid,
+    });
+  });
+
+  it('should retry fetching a token', async () => {
+    // Setup
+    const mockToken = {
+      uid: 'mock-token',
+      name: 'Mock Token 1',
+      symbol: 'MT1',
+    };
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    // The method should try 1 time and retry 5 times before throwing
+    axiosMock
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(200, {
+        success: true,
+        name: mockToken.name,
+        symbol: mockToken.symbol,
+      });
+
+    // Execute
+    const tokensSet = new Set();
+    tokensSet.add('mock-token');
+    jest.useFakeTimers();
+    const promiseObj = _updateTokensData(storage, tokensSet);
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await expect(promiseObj).resolves.toEqual(undefined); // A void resolution, but with no failure
+
+    // Verify
+    expect(await getAllTokensArray(storage)).toHaveLength(1);
+    expect(axiosMock.history.get).toHaveLength(6);
+    expect(await storage.getToken(mockToken.uid)).toStrictEqual({
+      ...sampleTokensAPIOutput,
+      name: mockToken.name,
+      symbol: mockToken.symbol,
+      uid: mockToken.uid,
+    });
+  });
+
+  it('should fail if there were too many retries', async () => {
+    // Setup
+    const mockToken = {
+      uid: 'mock-token',
+      name: 'Mock Token 1',
+      symbol: 'MT1',
+    };
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    // The method should try 1 time and retry 5 times before throwing
+    axiosMock
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(200, {
+        success: true,
+        name: mockToken.name,
+        symbol: mockToken.symbol,
+      });
+
+    // Execute
+    const tokensSet = new Set();
+    tokensSet.add('mock-token');
+    jest.useFakeTimers();
+    const promiseObj = _updateTokensData(storage, tokensSet).catch(
+      err => `Catched error: ${err.message}`
+    );
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await jest.advanceTimersToNextTimerAsync();
+    await expect(promiseObj).resolves.toEqual(
+      `Catched error: Too many attempts at fetchTokenData for ${mockToken.uid}`
+    );
+
+    // Verify
+    expect(await getAllTokensArray(storage)).toHaveLength(0);
+    expect(axiosMock.history.get).toHaveLength(6);
+    expect(await storage.getToken(mockToken.uid)).toEqual(null);
+  });
+
+  it('should delay with exponential backoffs', async () => {
+    // Setup
+    const mockToken = {
+      uid: 'mock-token',
+      name: 'Mock Token 1',
+      symbol: 'MT1',
+    };
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    // The method should try 1 time and retry 5 times before throwing
+    axiosMock
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(500)
+      .onGet(updateTokenApiUrl)
+      .replyOnce(200, {
+        success: true,
+        name: mockToken.name,
+        symbol: mockToken.symbol,
+      });
+
+    // Execute
+    const tokensSet = new Set();
+    tokensSet.add('mock-token');
+    jest.useFakeTimers();
+    let beforeTime;
+    let afterTime;
+    const promiseObj = _updateTokensData(storage, tokensSet).catch(
+      err => `Catched error: ${err.message}`
+    );
+    beforeTime = jest.now();
+    await jest.advanceTimersToNextTimerAsync();
+    afterTime = jest.now();
+    expect(afterTime - beforeTime).toEqual(500);
+
+    beforeTime = jest.now();
+    await jest.advanceTimersToNextTimerAsync();
+    afterTime = jest.now();
+    expect(afterTime - beforeTime).toEqual(1000);
+
+    beforeTime = jest.now();
+    await jest.advanceTimersToNextTimerAsync();
+    afterTime = jest.now();
+    expect(afterTime - beforeTime).toEqual(2000);
+
+    beforeTime = jest.now();
+    await jest.advanceTimersToNextTimerAsync();
+    afterTime = jest.now();
+    expect(afterTime - beforeTime).toEqual(4000);
+
+    beforeTime = jest.now();
+    await jest.advanceTimersToNextTimerAsync();
+    afterTime = jest.now();
+    expect(afterTime - beforeTime).toEqual(8000);
+
+    beforeTime = jest.now();
+    await jest.advanceTimersToNextTimerAsync();
+    afterTime = jest.now();
+    expect(afterTime - beforeTime).toEqual(16000);
+
+    await expect(promiseObj).resolves.toEqual(
+      `Catched error: Too many attempts at fetchTokenData for ${mockToken.uid}`
+    );
+
+    // Verify
+    expect(axiosMock.history.get).toHaveLength(6);
   });
 });

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -393,7 +393,7 @@ export async function processHistory(
  * @param {Set<string>} tokens - set of tokens to fetch and save.
  * @returns {Promise<void>}
  */
-async function updateTokensData(storage: IStorage, tokens: Set<string>): Promise<void> {
+export async function _updateTokensData(storage: IStorage, tokens: Set<string>): Promise<void> {
   async function fetchTokenData(uid: string): Promise<
     | {
         success: true;
@@ -422,8 +422,8 @@ async function updateTokensData(storage: IStorage, tokens: Set<string>): Promise
               name: string;
               symbol: string;
             }
-          | { success: false; message: string } = await new Promise(resolve => {
-          return walletApi.getGeneralTokenInfo(uid, resolve);
+          | { success: false; message: string } = await new Promise((resolve, reject) => {
+          walletApi.getGeneralTokenInfo(uid, resolve).catch(err => reject(err));
         });
         return result;
       } catch (err: unknown) {
@@ -490,7 +490,7 @@ async function updateWalletMetadataFromProcessedTxData(
   // Update token config
   // Up until now we have updated the tokens metadata, but the token config may be missing
   // So we will check if we have each token found, if not we will fetch the token config from the api.
-  await updateTokensData(storage, tokens);
+  await _updateTokensData(storage, tokens);
 }
 
 /**


### PR DESCRIPTION
### Motivation
The linting made on https://github.com/HathorNetwork/hathor-wallet-lib/pull/682 accused that a single line inside the `utils/storage.ts` was not being tested and this broke the CI in the PR.

Upon investigation, this proved to be an actual bug on the `updateTokensData` method that would require a full test suite and changes to the utils to fix it.

The impact of this bug on applications running prior to NodeJS 16 was to exhibit a warning indicating that an _Unhandled Exception_ happened whenever the `[GET] 'thin_wallet/token'` fullnode endpoint failed. Starting with NodeJS 16 this started throwing an unhandled error that may crash applications that do not handle this properly [at the global level](https://nodejs.org/api/process.html#event-unhandledrejection).

### Acceptance Criteria
- Fixes the `updateTokensData` retry mechanism not working properly
- Adds a test suite to ensure its correctness

### Notes
The `updateTokensData` had to be exported for the tests to be able to assess its results. It was otherwise only available through `processHistory` -> `updateWalletMetadataFromProcessedTxData` -> `updateTokensData`, which would make the unit test inviable.

The `_` prefix was also added to the method name, to indicate it should not be used by other lib modules.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
