### PR TITLE
refactor: create OutputValueType

### DIFF
--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -11,6 +11,7 @@ import HathorWallet from '../../../src/new/wallet';
 import { waitForTxReceived, waitForWalletReady, waitUntilNextTimestamp } from './wallet.helper';
 import { loggers } from '../utils/logger.util';
 import { delay } from '../utils/core.util';
+import { OutputValueType } from '../../../src/types';
 
 /**
  * @type {?GenesisWalletHelper}
@@ -59,14 +60,14 @@ export class GenesisWalletHelper {
    * Internal method to send HTR to another wallet's address.
    * @param {HathorWallet} destinationWallet Wallet object that we are sending the funds to
    * @param {string} address
-   * @param {number} value
+   * @param {OutputValueType} value
    * @param [options]
    * @param {number} [options.waitTimeout] Optional timeout for the websocket confirmation.
    *                                       Passing 0 here skips this waiting.
    * @returns {Promise<BaseTransactionResponse>}
    * @private
    */
-  async _injectFunds(destinationWallet, address, value, options = {}) {
+  async _injectFunds(destinationWallet, address, value: OutputValueType, options = {}) {
     try {
       const result = await this.hWallet.sendTransaction(address, value, {
         changeAddress: WALLET_CONSTANTS.genesis.addresses[0],
@@ -107,13 +108,13 @@ export class GenesisWalletHelper {
    * An easy way to send HTR to another wallet's address for testing.
    * @param {HathorWallet} destinationWallet Wallet object that we are sending the funds to
    * @param {string} address
-   * @param {number} value
+   * @param {OutputValueType} value
    * @param [options]
    * @param {number} [options.waitTimeout] Optional timeout for the websocket confirmation.
    *                                       Passing 0 here skips this waiting.
    * @returns {Promise<BaseTransactionResponse>}
    */
-  static async injectFunds(destinationWallet, address, value, options) {
+  static async injectFunds(destinationWallet, address, value: OutputValueType, options) {
     const instance = await GenesisWalletHelper.getSingleton();
     return instance._injectFunds(destinationWallet, address, value, options);
   }

--- a/__tests__/integration/helpers/wallet.helper.ts
+++ b/__tests__/integration/helpers/wallet.helper.ts
@@ -224,7 +224,7 @@ export async function stopAllWallets() {
  * @param {HathorWallet} hWallet
  * @param {string} name Name of the token
  * @param {string} symbol Symbol of the token
- * @param {number} amount Quantity of the token to be minted
+ * @param {OutputValueType} amount Quantity of the token to be minted
  * @param [options] Options parameters
  * @param {string} [options.address] address of the minted token
  * @param {string} [options.changeAddress] address of the change output

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { AddressScanPolicy, SCANNING_POLICY } from './types';
+import { AddressScanPolicy, OutputValueType, SCANNING_POLICY } from './types';
 
 /**
  * Constants defined for the Hathor Wallet
@@ -105,13 +105,13 @@ export const TOKEN_INFO_VERSION = 1;
 /**
  * Max value (inclusive) before having to use 8 bytes: 2147483648 ~= 2.14748e+09
  */
-export const MAX_OUTPUT_VALUE_32 = 2 ** 31 - 1;
+export const MAX_OUTPUT_VALUE_32: OutputValueType = 2 ** 31 - 1;
 
 /**
  * Max accepted value for an output
  * Because of a precision problem in javascript we don't handle all 8 bytes of value
  */
-export const MAX_OUTPUT_VALUE = 2 ** 43;
+export const MAX_OUTPUT_VALUE: OutputValueType = 2 ** 43;
 
 /**
  * Entropy for the new HD wallet words
@@ -133,13 +133,13 @@ export const TOKEN_AUTHORITY_MASK: number = 0b10000000;
  * Mask to check if it's mint UTXO (last bit indicates it)
  * For further information: https://gitlab.com/HathorNetwork/rfcs/blob/master/text/0004-tokens.md
  */
-export const TOKEN_MINT_MASK: number = 0b00000001;
+export const TOKEN_MINT_MASK: OutputValueType = 0b00000001;
 
 /**
  * Mask to check if it's melt UTXO (second to last bit indicates it)
  * For further information: https://gitlab.com/HathorNetwork/rfcs/blob/master/text/0004-tokens.md
  */
-export const TOKEN_MELT_MASK: number = 0b00000010;
+export const TOKEN_MELT_MASK: OutputValueType = 0b00000010;
 
 /**
  * Token data for an authority output of the first token in a transaction.

--- a/src/models/output.ts
+++ b/src/models/output.ts
@@ -28,6 +28,7 @@ import {
 } from '../utils/buffer';
 import { prettyValue } from '../utils/numbers';
 import { parseScript as utilsParseScript } from '../utils/scripts';
+import { OutputValueType } from '../types';
 
 type optionsType = {
   tokenData?: number | undefined;
@@ -43,7 +44,7 @@ export const MAXIMUM_SCRIPT_LENGTH: number = 256;
 
 class Output {
   // Output value as an integer
-  value: number;
+  value: OutputValueType;
 
   // tokenData of the output
   tokenData: number;
@@ -54,7 +55,7 @@ class Output {
   // Decoded output script
   decodedScript: P2PKH | P2SH | ScriptData | null;
 
-  constructor(value: number, script: Buffer, options: optionsType = {}) {
+  constructor(value: OutputValueType, script: Buffer, options: optionsType = {}) {
     const defaultOptions = {
       tokenData: 0,
     };

--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -29,7 +29,7 @@ import {
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
 } from '../constants';
-import { IDataInput, IDataOutput, IDataTx } from '../types';
+import { IDataInput, IDataOutput, IDataTx, OutputValueType } from '../types';
 
 /**
  * Extended version of the Input class with extra data
@@ -38,23 +38,23 @@ import { IDataInput, IDataOutput, IDataTx } from '../types';
 export class ProposalInput extends Input {
   token: string;
 
-  authorities: number;
+  authorities: OutputValueType;
 
-  value: number;
+  value: OutputValueType;
 
   address: string;
 
   constructor(
     hash: string,
     index: number,
-    value: number,
+    value: OutputValueType,
     address: string,
     {
       token = NATIVE_TOKEN_UID,
       authorities = 0,
     }: {
       token?: string;
-      authorities?: number;
+      authorities?: OutputValueType;
     } = {}
   ) {
     super(hash, index);
@@ -103,10 +103,10 @@ export class ProposalOutput extends Output {
 
   isChange: boolean;
 
-  authorities: number;
+  authorities: OutputValueType;
 
   constructor(
-    value: number,
+    value: OutputValueType,
     script: Buffer,
     {
       isChange = false,
@@ -115,7 +115,7 @@ export class ProposalOutput extends Output {
     }: {
       token?: string;
       isChange?: boolean;
-      authorities?: number;
+      authorities?: OutputValueType;
     } = {}
   ) {
     let tokenData = 0;
@@ -247,8 +247,8 @@ export class PartialTx {
    * @memberof PartialTx
    * @inner
    */
-  calculateTokenBalance(): Record<string, { inputs: number; outputs: number }> {
-    const tokenBalance: Record<string, { inputs: number; outputs: number }> = {};
+  calculateTokenBalance(): Record<string, { inputs: OutputValueType; outputs: OutputValueType }> {
+    const tokenBalance: Record<string, { inputs: OutputValueType; outputs: OutputValueType }> = {};
     for (const input of this.inputs) {
       if (!tokenBalance[input.token]) {
         tokenBalance[input.token] = { inputs: 0, outputs: 0 };
@@ -294,8 +294,8 @@ export class PartialTx {
    *
    * @param {string} txId The transaction id of the UTXO.
    * @param {number} index The index of the UTXO.
-   * @param {number} value Value of the UTXO.
-   * @param {number} authorities The authority information of the utxo.
+   * @param {OutputValueType} value Value of the UTXO.
+   * @param {OutputValueType} authorities The authority information of the utxo.
    * @param {string} address base58 address
    * @param {Object} [options]
    * @param {string} [options.token='00'] The token UID.
@@ -306,14 +306,14 @@ export class PartialTx {
   addInput(
     txId: string,
     index: number,
-    value: number,
+    value: OutputValueType,
     address: string,
     {
       token = NATIVE_TOKEN_UID,
       authorities = 0,
     }: {
       token?: string;
-      authorities?: number;
+      authorities?: OutputValueType;
     } = {}
   ) {
     this.inputs.push(new ProposalInput(txId, index, value, address, { token, authorities }));
@@ -322,9 +322,9 @@ export class PartialTx {
   /**
    * Add an output to the PartialTx.
    *
-   * @param {number} value The amount of tokens on the output.
+   * @param {OutputValueType} value The amount of tokens on the output.
    * @param {Buffer} script The output script.
-   * @param {number} authorities The authority information of the output.
+   * @param {OutputValueType} authorities The authority information of the output.
    * @param {Object} [options]
    * @param {string} [options.token='00'] The token UID.
    * @param {boolean|null} [options.isChange=false] isChange If this is a change output.
@@ -333,7 +333,7 @@ export class PartialTx {
    * @inner
    */
   addOutput(
-    value: number,
+    value: OutputValueType,
     script: Buffer,
     {
       token = NATIVE_TOKEN_UID,
@@ -342,7 +342,7 @@ export class PartialTx {
     }: {
       token?: string;
       isChange?: boolean;
-      authorities?: number;
+      authorities?: OutputValueType;
     } = {}
   ) {
     this.outputs.push(new ProposalOutput(value, script, { token, authorities, isChange }));

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -34,6 +34,7 @@ import Input from './input';
 import Output from './output';
 import Network from './network';
 import { MaximumNumberInputsError, MaximumNumberOutputsError } from '../errors';
+import { OutputValueType } from '../types';
 
 enum txType {
   BLOCK = 'Block',
@@ -318,7 +319,7 @@ class Transaction {
    * @memberof Transaction
    * @inner
    */
-  getOutputsSum(): number {
+  getOutputsSum(): OutputValueType {
     let sumOutputs = 0;
     for (const output of this.outputs) {
       if (output.isAuthority()) {

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { OutputValueType } from '../types';
+
 /**
  * An output object enriched by the wallet's history methods
  */
 export type HistoryTransactionOutput = {
-  value: number;
+  value: OutputValueType;
   token_data: number;
   script: string;
   decoded: {
@@ -26,7 +28,7 @@ export type HistoryTransactionOutput = {
  * An input object enriched by the wallet's history methods
  */
 export type HistoryTransactionInput = {
-  value: number;
+  value: OutputValueType;
   token_data: number;
   script: string;
   decoded: {
@@ -69,8 +71,8 @@ export interface Balance {
 }
 
 export interface TokenBalance {
-  unlocked: number;
-  locked: number;
+  unlocked: OutputValueType;
+  locked: OutputValueType;
 }
 
 export interface AuthorityBalance {
@@ -79,8 +81,8 @@ export interface AuthorityBalance {
 }
 
 export interface Authority {
-  mint: number;
-  melt: number;
+  mint: OutputValueType;
+  melt: OutputValueType;
 }
 
 /**

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { IHistoryTx } from '../types';
+import { IHistoryTx, OutputValueType } from '../types';
 
 export enum NanoContractActionType {
   DEPOSIT = 'deposit',
@@ -17,7 +17,7 @@ export type NanoContractArgumentType = NanoContractArgumentApiInputType | Buffer
 export interface NanoContractAction {
   type: NanoContractActionType.DEPOSIT | NanoContractActionType.WITHDRAWAL;
   token: string;
-  amount: number;
+  amount: OutputValueType;
   // For withdrawal is required, which is address to send the output
   // For deposit is optional, and it's the address to filter the utxos
   address: string | null;

--- a/src/new/sendTransaction.ts
+++ b/src/new/sendTransaction.ts
@@ -24,6 +24,7 @@ import {
   IUtxoSelectionOptions,
   isDataOutputCreateToken,
   WalletType,
+  OutputValueType,
 } from '../types';
 import Transaction from '../models/transaction';
 import { bestUtxoSelection } from '../utils/utxo';
@@ -47,7 +48,7 @@ export function isDataOutput(output: ISendOutput): output is ISendDataOutput {
 export interface ISendTokenOutput {
   type: OutputType.P2PKH | OutputType.P2SH;
   address: string;
-  value: number;
+  value: OutputValueType;
   token: string;
   timelock?: number | null;
 }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -985,7 +985,7 @@ class HathorWallet extends EventEmitter {
    * @property {string} tokenId
    * @property {string} address
    * @property {string} value
-   * @property {number} authorities
+   * @property {OutputValueType} authorities
    * @property {number|null} timelock
    * @property {number|null} heightlock
    * @property {boolean} locked
@@ -1030,7 +1030,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} [options.token='00'] - Search for UTXOs of this token UID.
    * @param {string|null} [options.filter_address=null] - Address to filter the utxos.
    *
-   * @return {Promise<{utxos: Utxo[], changeAmount: number}>} Utxos and change information.
+   * @return {Promise<{utxos: Utxo[], changeAmount: OutputValueType}>} Utxos and change information.
    */
   async getUtxosForAmount(amount, options = {}) {
     const newOptions = {
@@ -1065,7 +1065,7 @@ class HathorWallet extends EventEmitter {
    * Prepare all required data to consolidate utxos.
    *
    * @typedef {Object} PrepareConsolidateUtxosDataResult
-   * @property {{ address: string, value: number }[]} outputs - Destiny of the consolidated utxos
+   * @property {{ address: string, value: OutputValueType }[]} outputs - Destiny of the consolidated utxos
    * @property {{ hash: string, index: number }[]} inputs - Inputs for the consolidation transaction
    * @property {{ uid: string, name: string, symbol: string }} token - HTR or custom token
    * @property {{ address: string, amount: number, tx_id: string, locked: boolean, index: number }[]} utxos - Array of utxos that will be consolidated
@@ -1164,7 +1164,7 @@ class HathorWallet extends EventEmitter {
    * @property {number} timestamp
    * @property {boolean} is_voided
    * @property {{
-   *   value: number,
+   *   value: OutputValueType,
    *   token_data: number,
    *   script: string,
    *   decoded: { type: string, address: string, timelock: number|null },
@@ -1173,7 +1173,7 @@ class HathorWallet extends EventEmitter {
    *   index: number
    * }[]} inputs
    * @property {{
-   *   value: number,
+   *   value: OutputValueType,
    *   token_data: number,
    *   script: string,
    *   decoded: { type: string, address: string, timelock: number|null },
@@ -1322,7 +1322,7 @@ class HathorWallet extends EventEmitter {
    *
    * @param {{
    *   address: string,
-   *   value: number,
+   *   value: OutputValueType,
    *   timelock?: number,
    *   token: string
    * }[]} outputs Array of proposed outputs
@@ -1528,7 +1528,7 @@ class HathorWallet extends EventEmitter {
    *
    * @param {string} name Name of the token
    * @param {string} symbol Symbol of the token
-   * @param {number} amount Quantity of the token to be minted
+   * @param {OutputValueType} amount Quantity of the token to be minted
    * @param [options] Options parameters
    * @param {string} [options.address] address of the minted token,
    * @param {string} [options.changeAddress] address of the change output,
@@ -1644,7 +1644,7 @@ class HathorWallet extends EventEmitter {
    *
    * @param {string} name Name of the token
    * @param {string} symbol Symbol of the token
-   * @param {number} amount Quantity of the token to be minted
+   * @param {OutputValueType} amount Quantity of the token to be minted
    * @param [options] Options parameters
    * @param {string} [options.address] address of the minted token
    * @param {string} [options.changeAddress] address of the change output
@@ -1681,7 +1681,7 @@ class HathorWallet extends EventEmitter {
    *   txId: string,
    *   index: number,
    *   address: string,
-   *   authorities: number
+   *   authorities: OutputValueType
    * }[]>} Promise that resolves with an Array of objects with properties of the authority output.
    *       The "authorities" field actually contains the output value with the authority masks.
    *       Returns an empty array in case there are no tx_outupts for this type.
@@ -1713,7 +1713,7 @@ class HathorWallet extends EventEmitter {
    *   txId: string,
    *   index: number,
    *   address: string,
-   *   authorities: number
+   *   authorities: OutputValueType
    * }[]>} Promise that resolves with an Array of objects with properties of the authority output.
    *       The "authorities" field actually contains the output value with the authority masks.
    *       Returns an empty array in case there are no tx_outupts for this type.
@@ -1738,7 +1738,7 @@ class HathorWallet extends EventEmitter {
    * Prepare mint transaction before mining
    *
    * @param {string} tokenUid UID of the token to mint
-   * @param {number} amount Quantity to mint
+   * @param {OutputValueType} amount Quantity to mint
    * @param {Object} options Options parameters
    *  {
    *   'address': destination address of the minted token
@@ -1821,7 +1821,7 @@ class HathorWallet extends EventEmitter {
    * Mint tokens
    *
    * @param {string} tokenUid UID of the token to mint
-   * @param {number} amount Quantity to mint
+   * @param {OutputValueType} amount Quantity to mint
    * @param [options] Options parameters
    * @param {string} [options.address] destination address of the minted token
    *                                   (if not sent we choose the next available address to use)
@@ -1853,7 +1853,7 @@ class HathorWallet extends EventEmitter {
    * Prepare melt transaction before mining
    *
    * @param {string} tokenUid UID of the token to melt
-   * @param {number} amount Quantity to melt
+   * @param {OutputValueType} amount Quantity to melt
    * @param {Object} options Options parameters
    *  {
    *   'address': address of the HTR deposit back
@@ -1933,7 +1933,7 @@ class HathorWallet extends EventEmitter {
    * Melt tokens
    *
    * @param {string} tokenUid UID of the token to melt
-   * @param {number} amount Quantity to melt
+   * @param {OutputValueType} amount Quantity to melt
    * @param [options] Options parameters
    * @param {string} [options.address]: address of the HTR deposit back
    * @param {string} [options.changeAddress] address of the change output
@@ -2130,7 +2130,7 @@ class HathorWallet extends EventEmitter {
    * @param {string} tokenUid UID of the token to delegate the authority
    * @param {"mint"|"melt"} type Type of the authority to search for: 'mint' or 'melt'
    *
-   * @return {{tx_id: string, index: number, address: string, authorities: number}[]}
+   * @return {{tx_id: string, index: number, address: string, authorities: OutputValueType}[]}
    *    Array of the authority outputs.
    * */
   async getAuthorityUtxos(tokenUid, type) {
@@ -2314,7 +2314,7 @@ class HathorWallet extends EventEmitter {
    *
    * @param {string} name Name of the token
    * @param {string} symbol Symbol of the token
-   * @param {number} amount Quantity of the token to be minted
+   * @param {OutputValueType} amount Quantity of the token to be minted
    * @param {string} data NFT data string using utf8 encoding
    * @param [options] Options parameters
    * @param {string} [options.address] address of the minted token,

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -35,6 +35,7 @@ import {
   INcData,
   EcdsaTxSign,
   ITxSignatureData,
+  OutputValueType,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import { processHistory, processUtxoUnlock } from '../utils/storage';
@@ -467,18 +468,18 @@ export class Storage implements IStorage {
   /**
    * Match the selected balance for the given authority and token.
    *
-   * @param {number} singleBalance The balance we want to match
+   * @param {OutputValueType} singleBalance The balance we want to match
    * @param {string} token The token uid
-   * @param {number} authorities The authorities we want to match
+   * @param {OutputValueType} authorities The authorities we want to match
    * @param {string} changeAddress change address to use
    * @param {boolean} chooseInputs If we can add new inputs to the transaction
    * @returns {Promise<{inputs: IDataInput[], outputs: IDataOutput[]}>} The inputs and outputs that match the balance
    * @internal
    */
   async matchBalanceSelection(
-    singleBalance: number,
+    singleBalance: OutputValueType,
     token: string,
-    authorities: number,
+    authorities: OutputValueType,
     changeAddress: string,
     chooseInputs: boolean
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
@@ -583,7 +584,7 @@ export class Storage implements IStorage {
    */
   async matchTokenBalance(
     token: string,
-    balance: Record<'funds' | 'mint' | 'melt', number>,
+    balance: Record<'funds' | 'mint' | 'melt', OutputValueType>,
     { changeAddress, skipAuthorities = true, chooseInputs = true }: IFillTxOptions = {}
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     const addressForChange = changeAddress || (await this.getCurrentAddress());

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ import Transaction from './models/transaction';
 import Input from './models/input';
 import FullNodeConnection from './new/connection';
 
+export type OutputValueType = number;
+
 export interface ITxSignatureData {
   ncCallerSignature: Buffer | null;
   inputSignatures: IInputSignature[];
@@ -80,8 +82,8 @@ export interface IBalance {
 }
 
 export interface ITokenBalance {
-  locked: number;
-  unlocked: number;
+  locked: OutputValueType;
+  unlocked: OutputValueType;
 }
 
 export interface IAuthoritiesBalance {
@@ -119,7 +121,7 @@ export enum TxHistoryProcessingStatus {
 }
 
 export interface IHistoryInput {
-  value: number;
+  value: OutputValueType;
   token_data: number;
   script: string;
   decoded: IHistoryOutputDecoded;
@@ -137,7 +139,7 @@ export interface IHistoryOutputDecoded {
 }
 
 export interface IHistoryOutput {
-  value: number;
+  value: OutputValueType;
   token_data: number;
   script: string;
   decoded: IHistoryOutputDecoded;
@@ -148,8 +150,8 @@ export interface IHistoryOutput {
 export interface IDataOutputData {
   type: 'data';
   token: string;
-  value: number;
-  authorities: number;
+  value: OutputValueType;
+  authorities: OutputValueType;
   data: string;
 }
 
@@ -160,8 +162,8 @@ export function isDataOutputData(output: IDataOutput): output is IDataOutputData
 export interface IDataOutputAddress {
   type: 'p2pkh' | 'p2sh';
   token: string;
-  value: number;
-  authorities: number;
+  value: OutputValueType;
+  authorities: OutputValueType;
   address: string;
   timelock: number | null;
 }
@@ -173,10 +175,10 @@ export function isDataOutputAddress(output: IDataOutput): output is IDataOutputA
 // This is for create token transactions, where we dont have a token uid yet
 export interface IDataOutputCreateToken {
   type: 'mint' | 'melt';
-  value: number;
+  value: OutputValueType;
   address: string;
   timelock: number | null;
-  authorities: number;
+  authorities: OutputValueType;
 }
 
 export function isDataOutputCreateToken(output: IDataOutput): output is IDataOutputCreateToken {
@@ -193,8 +195,8 @@ export type IDataOutput = (IDataOutputData | IDataOutputAddress | IDataOutputCre
 export interface IDataInput {
   txId: string;
   index: number;
-  value: number;
-  authorities: number;
+  value: OutputValueType;
+  authorities: OutputValueType;
   token: string;
   address: string;
   data?: string;
@@ -226,8 +228,8 @@ export interface IUtxo {
   index: number;
   token: string;
   address: string;
-  value: number;
-  authorities: number;
+  value: OutputValueType;
+  authorities: OutputValueType;
   timelock: number | null;
   type: number; // tx.version, is the value of the transaction version byte
   height: number | null; // only for block outputs
@@ -323,13 +325,13 @@ export interface IMultisigData {
 
 export interface IUtxoFilterOptions {
   token?: string; // default to HTR
-  authorities?: number; // default to 0 (funds)
+  authorities?: OutputValueType; // default to 0 (funds)
   max_utxos?: number; // default to unlimited
   filter_address?: string;
-  target_amount?: number;
-  max_amount?: number;
-  amount_smaller_than?: number;
-  amount_bigger_than?: number;
+  target_amount?: OutputValueType;
+  max_amount?: OutputValueType;
+  amount_smaller_than?: OutputValueType;
+  amount_bigger_than?: OutputValueType;
   only_available_utxos?: boolean;
   filter_method?: (utxo: IUtxo) => boolean;
   reward_lock?: number;
@@ -341,8 +343,8 @@ export interface IUtxoFilterOptions {
 export type UtxoSelectionAlgorithm = (
   storage: IStorage,
   token: string,
-  amount: number
-) => Promise<{ utxos: IUtxo[]; amount: number }>;
+  amount: OutputValueType
+) => Promise<{ utxos: IUtxo[]; amount: OutputValueType }>;
 
 export interface IUtxoSelectionOptions {
   token?: string;

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,6 +1,7 @@
 import buffer from 'buffer';
 import Long from 'long';
 import { ParseError } from '../errors';
+import { OutputValueType } from '../types';
 
 const isHexa = (value: string): boolean => {
   // test if value is string?
@@ -214,13 +215,13 @@ export const bufferToHex = (buff: Buffer): string => {
  *
  * @return Output value and rest of buffer after unpacking
  */
-export const bytesToOutputValue = (srcBuf: Buffer): [number, Buffer] => {
+export const bytesToOutputValue = (srcBuf: Buffer): [OutputValueType, Buffer] => {
   // Copies buffer locally, not to change the original parameter
   let buff = Buffer.from(srcBuf);
 
   const [highByte] = unpackToInt(1, true, buff);
-  let sign;
-  let value;
+  let sign: OutputValueType;
+  let value: OutputValueType;
   if (highByte < 0) {
     // 8 bytes
     sign = -1;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -21,6 +21,7 @@ import {
   IDataTx,
   IStorage,
   ITokenData,
+  OutputValueType,
   UtxoSelectionAlgorithm,
 } from '../types';
 import { getAddressType } from './address';
@@ -258,7 +259,7 @@ const tokens = {
   /**
    * Calculate deposit value for the given token mint amount
    *
-   * @param {number} mintAmount Amount of tokens being minted
+   * @param {OutputValueType} mintAmount Amount of tokens being minted
    * @param {number} [depositPercent=TOKEN_DEPOSIT_PERCENTAGE] token deposit percentage.
    *
    * @return {number}
@@ -266,22 +267,25 @@ const tokens = {
    * @inner
    *
    */
-  getDepositAmount(mintAmount: number, depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE): number {
+  getDepositAmount(
+    mintAmount: OutputValueType,
+    depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE
+  ): OutputValueType {
     return Math.ceil(depositPercent * mintAmount);
   },
 
   /**
    * Get the HTR value of the fee to add a data script output
-   * @returns {number} The fee to have a data script output
+   * @returns {OutputValueType} The fee to have a data script output
    */
-  getDataScriptOutputFee(): number {
+  getDataScriptOutputFee(): OutputValueType {
     return 1;
   },
 
   /**
    * Calculate withdraw value for the given token melt amount
    *
-   * @param {number} meltAmount Amount of tokens being melted
+   * @param {OutputValueType} meltAmount Amount of tokens being melted
    * @param {number} [depositPercent=TOKEN_DEPOSIT_PERCENTAGE] token deposit percentage.
    *
    * @return {number}
@@ -289,7 +293,10 @@ const tokens = {
    * @inner
    *
    */
-  getWithdrawAmount(meltAmount: number, depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE): number {
+  getWithdrawAmount(
+    meltAmount: OutputValueType,
+    depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE
+  ): OutputValueType {
     return Math.floor(depositPercent * meltAmount);
   },
 
@@ -313,7 +320,7 @@ const tokens = {
    */
   async prepareMintTxData(
     address: string,
-    amount: number,
+    amount: OutputValueType,
     storage: IStorage,
     {
       token = null,
@@ -435,7 +442,7 @@ const tokens = {
    * @param {string} token Token to melt
    * @param {IDataInput} authorityMeltInput Input with authority to melt
    * @param {string} address Address to send the melted HTR tokens
-   * @param {number} amount The amount of tokens to melt
+   * @param {OutputValueType} amount The amount of tokens to melt
    * @param {IStorage} storage The storage object
    * @param {Object} [options={}] Options to create the melt transaction
    * @param {boolean} [options.createAnotherMelt=true] If should create another melt authority
@@ -450,7 +457,7 @@ const tokens = {
     token: string,
     authorityMeltInput: IDataInput, // Authority melt
     address: string,
-    amount: number,
+    amount: OutputValueType,
     storage: IStorage,
     {
       createAnotherMelt = true,
@@ -608,7 +615,7 @@ const tokens = {
    * @param {string} address Address to create the token
    * @param {string} name Name of the token being created
    * @param {string} symbol Symbol of the token being created
-   * @param {number} mintAmount Amount of tokens to mint
+   * @param {OutputValueType} mintAmount Amount of tokens to mint
    * @param {IStorage} storage Storage to get necessary data
    * @param {Object} [options={}] options to create the token
    * @param {string|null} [options.changeAddress=null] Address to send the change
@@ -624,7 +631,7 @@ const tokens = {
     address: string,
     name: string,
     symbol: string,
-    mintAmount: number,
+    mintAmount: OutputValueType,
     storage: IStorage,
     {
       changeAddress = null,

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -38,6 +38,7 @@ import {
   IUtxoId,
   IInputSignature,
   ITxSignatureData,
+  OutputValueType,
 } from '../types';
 import Address from '../models/address';
 import P2PKH from '../models/p2pkh';
@@ -247,7 +248,10 @@ const transaction = {
    * @memberof transaction
    * @inner
    */
-  selectUtxos(utxos: Utxo[], totalAmount: number): { utxos: Utxo[]; changeAmount: number } {
+  selectUtxos(
+    utxos: Utxo[],
+    totalAmount: OutputValueType
+  ): { utxos: Utxo[]; changeAmount: OutputValueType } {
     if (totalAmount <= 0) {
       throw new UtxoError('Total amount must be a positive integer.');
     }
@@ -413,7 +417,7 @@ const transaction = {
   async calculateTxBalanceToFillTx(
     token: string,
     tx: IDataTx
-  ): Promise<Record<'funds' | 'mint' | 'melt', number>> {
+  ): Promise<Record<'funds' | 'mint' | 'melt', OutputValueType>> {
     const balance = { funds: 0, mint: 0, melt: 0 };
     for (const output of tx.outputs) {
       if (isDataOutputCreateToken(output)) {
@@ -609,9 +613,9 @@ const transaction = {
    * Calculate the authorities data for an output
    *
    * @param output History output
-   * @returns {number} Authorities from output
+   * @returns {OutputValueType} Authorities from output
    */
-  authoritiesFromOutput(output: Pick<IHistoryOutput, 'token_data' | 'value'>): number {
+  authoritiesFromOutput(output: Pick<IHistoryOutput, 'token_data' | 'value'>): OutputValueType {
     let authorities = 0;
     if (this.isMint(output)) {
       authorities |= TOKEN_MINT_MASK;

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -5,7 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IStorage, IUtxo, IUtxoFilterOptions, UtxoSelectionAlgorithm } from '../types';
+import {
+  IStorage,
+  IUtxo,
+  IUtxoFilterOptions,
+  OutputValueType,
+  UtxoSelectionAlgorithm,
+} from '../types';
 
 export enum UtxoSelection {
   FAST = 'fast',
@@ -36,14 +42,14 @@ export function getAlgorithmFromEnum(algorithm: UtxoSelection): UtxoSelectionAlg
  *
  * @param {IStorage} storage The wallet storage to select the utxos
  * @param {string} token The token uid to select the utxos
- * @param {number} amount The target amount of tokens required
- * @returns {Promise<{ utxos: IUtxo[], utxosAmount: number}>
+ * @param {OutputValueType} amount The target amount of tokens required
+ * @returns {Promise<{ utxos: IUtxo[], utxosAmount: OutputValueType}>
  */
 export async function fastUtxoSelection(
   storage: IStorage,
   token: string,
-  amount: number
-): Promise<{ utxos: IUtxo[]; amount: number }> {
+  amount: OutputValueType
+): Promise<{ utxos: IUtxo[]; amount: OutputValueType }> {
   const utxos: IUtxo[] = [];
   let utxosAmount = 0;
 
@@ -80,14 +86,14 @@ export async function fastUtxoSelection(
  *
  * @param {IStorage} storage The wallet storage to select the utxos
  * @param {string} token The token uid to select the utxos
- * @param {number} amount The target amount of tokens required
- * @returns {Promise<{ utxos: IUtxo[], utxosAmount: number}>
+ * @param {OutputValueType} amount The target amount of tokens required
+ * @returns {Promise<{ utxos: IUtxo[], utxosAmount: OutputValueType}>
  */
 export async function bestUtxoSelection(
   storage: IStorage,
   token: string,
-  amount: number
-): Promise<{ utxos: IUtxo[]; amount: number }> {
+  amount: OutputValueType
+): Promise<{ utxos: IUtxo[]; amount: OutputValueType }> {
   const utxos: IUtxo[] = [];
   let utxosAmount = 0;
   let selectedUtxo: IUtxo | null = null;

--- a/src/wallet/partialTxProposal.ts
+++ b/src/wallet/partialTxProposal.ts
@@ -19,7 +19,7 @@ import dateFormatter from '../utils/date';
 
 import { OutputType, Utxo } from './types';
 import { Balance } from '../models/types';
-import { IStorage } from '../types';
+import { IStorage, OutputValueType } from '../types';
 
 class PartialTxProposal {
   public partialTx: PartialTx;
@@ -63,7 +63,7 @@ class PartialTxProposal {
    * Add inputs sending the amount of tokens specified, may add a change output.
    *
    * @param {string} token UID of token that is being sent
-   * @param {number} value Quantity of tokens being sent
+   * @param {OutputValueType} value Quantity of tokens being sent
    * @param {Object} [options]
    * @param {Utxo[]|null} [options.utxos=[]] utxos to add to the partial transaction.
    * @param {string|null} [options.changeAddress=null] If we add change, use this address instead of getting a new one from the wallet.
@@ -71,7 +71,7 @@ class PartialTxProposal {
    */
   async addSend(
     token: string,
-    value: number,
+    value: OutputValueType,
     {
       utxos = [],
       changeAddress = null,
@@ -129,7 +129,7 @@ class PartialTxProposal {
    * Add outputs receiving the amount of tokens specified.
    *
    * @param {string} token UID of token that is being sent
-   * @param {number} value Quantity of tokens being sent
+   * @param {OutputValueType} value Quantity of tokens being sent
    * @param {Object} [options]
    * @param {number|null} [options.timelock=null] UNIX timestamp of the timelock.
    * @param {string|null} [options.address=null] Output address to receive the tokens.
@@ -137,7 +137,7 @@ class PartialTxProposal {
    */
   async addReceive(
     token: string,
-    value: number,
+    value: OutputValueType,
     { timelock = null, address = null }: { timelock?: number | null; address?: string | null } = {}
   ) {
     this.resetSignatures();
@@ -152,17 +152,17 @@ class PartialTxProposal {
    *
    * @param {string} hash Transaction hash
    * @param {number} index UTXO index on the outputs of the transaction.
-   * @param {number} value UTXO value.
+   * @param {OutputValueType} value UTXO value.
    * @param {Object} [options]
    * @param {string} [options.token='00'] Token UID in hex format.
-   * @param {number} [options.authorities=0] Authority information of the UTXO.
+   * @param {OutputValueType} [options.authorities=0] Authority information of the UTXO.
    * @param {string|null} [options.address=null] Address that owns the UTXO.
    * @param {boolean} [options.markAsSelected=true] Mark the utxo with `selected_as_input`.
    */
   addInput(
     hash: string,
     index: number,
-    value: number,
+    value: OutputValueType,
     address: string,
     {
       token = NATIVE_TOKEN_UID,
@@ -170,7 +170,7 @@ class PartialTxProposal {
       markAsSelected = true,
     }: {
       token?: string;
-      authorities?: number;
+      authorities?: OutputValueType;
       markAsSelected?: boolean;
     } = {}
   ) {
@@ -187,24 +187,24 @@ class PartialTxProposal {
    * Add an output to the partial data.
    *
    * @param {string} token UID of token that is being sent.
-   * @param {number} value Quantity of tokens being sent.
+   * @param {OutputValueType} value Quantity of tokens being sent.
    * @param {string} address Create the output script for this address.
    * @param {Object} [options]
    * @param {number|null} [options.timelock=null] UNIX timestamp of the timelock.
    * @param {boolean} [options.isChange=false] If the output should be considered as change.
-   * @param {number} [options.authorities=0] Authority information of the Output.
+   * @param {OutputValueType} [options.authorities=0] Authority information of the Output.
    *
    * @throws AddressError
    */
   addOutput(
     token: string,
-    value: number,
+    value: OutputValueType,
     address: string,
     {
       timelock = null,
       isChange = false,
       authorities = 0,
-    }: { timelock?: number | null; isChange?: boolean; authorities?: number } = {}
+    }: { timelock?: number | null; isChange?: boolean; authorities?: OutputValueType } = {}
   ) {
     this.resetSignatures();
 

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -11,6 +11,7 @@ import CreateTokenTransaction from '../models/create_token_transaction';
 import SendTransactionWalletService from './sendTransactionWalletService';
 import Input from '../models/input';
 import Output from '../models/output';
+import { OutputValueType } from '../types';
 
 export interface GetAddressesObject {
   address: string; // Address in base58
@@ -33,8 +34,8 @@ export interface TokenInfo {
 }
 
 export interface Balance {
-  unlocked: number; // Available amount
-  locked: number; // Locked amount
+  unlocked: OutputValueType; // Available amount
+  locked: OutputValueType; // Locked amount
 }
 
 export interface AuthoritiesBalance {
@@ -49,7 +50,7 @@ export interface Authority {
 
 export interface GetHistoryObject {
   txId: string; // Transaction ID
-  balance: number; // Balance of this tx in this wallet (can be negative)
+  balance: OutputValueType; // Balance of this tx in this wallet (can be negative)
   timestamp: number; // Transaction timestamp
   voided: boolean; // If transaction is voided
   version: number; // Transaction version
@@ -109,7 +110,7 @@ export interface TokenDetailsAuthoritiesObject {
 
 export interface TokenDetailsObject {
   tokenInfo: TokenInfo;
-  totalSupply: number;
+  totalSupply: OutputValueType;
   totalTransactions: number;
   authorities: TokenDetailsAuthoritiesObject;
 }
@@ -135,7 +136,7 @@ export interface TxProposalInputs {
 
 export interface TxProposalOutputs {
   address: string; // output address
-  value: number; // output value
+  value: OutputValueType; // output value
   token: string; // output token
   timelock: number | null; // output timelock
 }
@@ -176,8 +177,8 @@ export interface Utxo {
   index: number; // output index
   tokenId: string; // output token
   address: string; // output address
-  value: number; // output value
-  authorities: number; // 0 for no authority, 1 for mint authority and 2 for melt authority
+  value: OutputValueType; // output value
+  authorities: OutputValueType; // 0 for no authority, 1 for mint authority and 2 for melt authority
   timelock: number | null; // output timelock
   heightlock: number | null; // output heightlock
   locked: boolean; // if output is locked
@@ -188,7 +189,7 @@ export interface AuthorityTxOutput {
   txId: string; // output transaction id
   index: number; // output index
   address: string; // output address
-  authorities: number; // output authorities
+  authorities: OutputValueType; // output authorities
 }
 
 export interface AuthTokenResponseData {
@@ -198,7 +199,7 @@ export interface AuthTokenResponseData {
 
 export interface OutputRequestObj {
   address: string; // output address
-  value: number; // output value
+  value: OutputValueType; // output value
   token: string; // output token
   timelock?: number | null; // output timelock
 }
@@ -211,7 +212,7 @@ export interface DataScriptOutputRequestObj {
 // This is the output object to be used in the SendTransactionWalletService class
 export interface OutputSendTransaction {
   type: string; // output type (in this case will be 'data')
-  value: number; // output value. Optional because we add fixed value of 1 to the output.
+  value: OutputValueType; // output value. Optional because we add fixed value of 1 to the output.
   token: string; // output token. Optional because we add fixed value of HTR token to the output.
   address?: string; // output address. required for p2pkh or p2sh
   timelock?: number | null; // output timelock
@@ -243,7 +244,7 @@ export interface WalletAddressMap {
 }
 
 export interface TokenAmountMap {
-  [token: string]: number; // For each token we have the amount
+  [token: string]: OutputValueType; // For each token we have the amount
 }
 
 export interface TransactionFullObject {
@@ -287,7 +288,7 @@ export interface IHathorWallet {
   ): Promise<Transaction>;
   sendTransaction(
     address: string,
-    value: number,
+    value: OutputValueType,
     options: { token?: string; changeAddress?: string }
   ): Promise<Transaction>;
   stop(params?: IStopWalletParams): void;
@@ -299,21 +300,26 @@ export interface IHathorWallet {
   prepareCreateNewToken(
     name: string,
     symbol: string,
-    amount: number,
+    amount: OutputValueType,
     options
   ): Promise<CreateTokenTransaction>;
-  createNewToken(name: string, symbol: string, amount: number, options): Promise<Transaction>;
+  createNewToken(
+    name: string,
+    symbol: string,
+    amount: OutputValueType,
+    options
+  ): Promise<Transaction>;
   createNFT(
     name: string,
     symbol: string,
-    amount: number,
+    amount: OutputValueType,
     data: string,
     options
   ): Promise<Transaction>;
-  prepareMintTokensData(token: string, amount: number, options): Promise<Transaction>;
-  mintTokens(token: string, amount: number, options): Promise<Transaction>;
-  prepareMeltTokensData(token: string, amount: number, options): Promise<Transaction>;
-  meltTokens(token: string, amount: number, options): Promise<Transaction>;
+  prepareMintTokensData(token: string, amount: OutputValueType, options): Promise<Transaction>;
+  mintTokens(token: string, amount: OutputValueType, options): Promise<Transaction>;
+  prepareMeltTokensData(token: string, amount: OutputValueType, options): Promise<Transaction>;
+  meltTokens(token: string, amount: OutputValueType, options): Promise<Transaction>;
   prepareDelegateAuthorityData(
     token: string,
     type: string,
@@ -339,7 +345,7 @@ export interface IHathorWallet {
     options: DestroyAuthorityOptions
   ): Promise<Transaction>;
   getFullHistory(): TransactionFullObject[];
-  getTxBalance(tx: WsTransaction, optionsParams): Promise<{ [tokenId: string]: number }>;
+  getTxBalance(tx: WsTransaction, optionsParams): Promise<{ [tokenId: string]: OutputValueType }>;
   onConnectionChangedState(newState: ConnectionState): void;
   getTokenDetails(tokenId: string): Promise<TokenDetailsObject>;
   getVersionData(): Promise<FullNodeVersionData>;
@@ -371,7 +377,7 @@ export interface DecodedOutput {
 }
 
 export interface TxOutput {
-  value: number;
+  value: OutputValueType;
   script: string;
   token: string;
   decoded: DecodedOutput;
@@ -386,7 +392,7 @@ export interface TxInput {
   // eslint-disable-next-line camelcase
   tx_id: string;
   index: number;
-  value: number;
+  value: OutputValueType;
   // eslint-disable-next-line camelcase
   token_data: number;
   script: string;
@@ -480,7 +486,7 @@ export interface FullNodeDecodedInput {
   type: string;
   address: string;
   timelock?: number | null;
-  value: number;
+  value: OutputValueType;
   token_data: number;
 }
 
@@ -488,12 +494,12 @@ export interface FullNodeDecodedOutput {
   type: string;
   address?: string;
   timelock?: number | null;
-  value: number;
+  value: OutputValueType;
   token_data?: number;
 }
 
 export interface FullNodeInput {
-  value: number;
+  value: OutputValueType;
   token_data: number;
   script: string;
   decoded: FullNodeDecodedInput;
@@ -504,7 +510,7 @@ export interface FullNodeInput {
 }
 
 export interface FullNodeOutput {
-  value: number;
+  value: OutputValueType;
   token_data: number;
   script: string;
   decoded: FullNodeDecodedOutput;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -70,7 +70,7 @@ import {
   UninitializedWalletError,
 } from '../errors';
 import { ErrorMessages } from '../errorMessages';
-import { IStorage, IWalletAccessData } from '../types';
+import { IStorage, IWalletAccessData, OutputValueType } from '../types';
 
 // Time in milliseconds berween each polling to check wallet status
 // if it ended loading and became ready
@@ -575,7 +575,10 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    *
    * @return {Object} Object with each token and it's balance in this tx for this wallet
    * */
-  async getTxBalance(tx: WsTransaction, optionsParam = {}): Promise<{ [tokenId: string]: number }> {
+  async getTxBalance(
+    tx: WsTransaction,
+    optionsParam = {}
+  ): Promise<{ [tokenId: string]: OutputValueType }> {
     const options = { includeAuthorities: false, ...optionsParam };
 
     const addresses: string[] = [];
@@ -590,7 +593,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       nextAddress = await generator.next();
     }
 
-    const balance = {};
+    const balance: { [tokenId: string]: OutputValueType } = {};
     for (const txout of tx.outputs) {
       if (transaction.isAuthorityOutput(txout)) {
         if (options.includeAuthorities) {
@@ -819,17 +822,17 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async getUtxos(
     options: {
       tokenId?: string;
-      authority?: number;
+      authority?: OutputValueType;
       addresses?: string[];
-      totalAmount?: number;
+      totalAmount?: OutputValueType;
       count?: number;
     } = {}
-  ): Promise<{ utxos: Utxo[]; changeAmount: number }> {
+  ): Promise<{ utxos: Utxo[]; changeAmount: OutputValueType }> {
     type optionsType = {
       tokenId: string;
-      authority: number | null;
+      authority: OutputValueType | null;
       addresses: string[] | null;
-      totalAmount: number | null;
+      totalAmount: OutputValueType | null;
       count: number;
       ignoreLocked: true;
       skipSpent: true;
@@ -1002,7 +1005,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async sendTransaction(
     address: string,
-    value: number,
+    value: OutputValueType,
     options: { token?: string; changeAddress?: string; pinCode?: string } = {}
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
@@ -1222,7 +1225,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async prepareCreateNewToken(
     name: string,
     symbol: string,
-    amount: number,
+    amount: OutputValueType,
     options = {}
   ): Promise<CreateTokenTransaction> {
     this.failIfWalletNotReady();
@@ -1407,7 +1410,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async _getAuthorityTxOutput(options: {
     tokenId: string;
-    authority: number;
+    authority: OutputValueType;
     skipSpent: boolean;
     maxOutputs?: number;
   }): Promise<AuthorityTxOutput[]> {
@@ -1486,7 +1489,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async createNewToken(
     name: string,
     symbol: string,
-    amount: number,
+    amount: OutputValueType,
     options = {}
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
@@ -1500,7 +1503,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async prepareMintTokensData(token: string, amount: number, options = {}): Promise<Transaction> {
+  async prepareMintTokensData(
+    token: string,
+    amount: OutputValueType,
+    options = {}
+  ): Promise<Transaction> {
     this.failIfWalletNotReady();
     type optionsType = {
       address: string | null;
@@ -1637,7 +1644,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async mintTokens(token: string, amount: number, options = {}): Promise<Transaction> {
+  async mintTokens(token: string, amount: OutputValueType, options = {}): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareMintTokensData(token, amount, options);
     return this.handleSendPreparedTransaction(tx);
@@ -1664,7 +1671,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async prepareMeltTokensData(token: string, amount: number, options = {}): Promise<Transaction> {
+  async prepareMeltTokensData(
+    token: string,
+    amount: OutputValueType,
+    options = {}
+  ): Promise<Transaction> {
     this.failIfWalletNotReady();
     type optionsType = {
       address: string | null;
@@ -1802,7 +1813,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @memberof HathorWalletServiceWallet
    * @inner
    */
-  async meltTokens(token: string, amount: number, options = {}): Promise<Transaction> {
+  async meltTokens(token: string, amount: OutputValueType, options = {}): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareMeltTokensData(token, amount, options);
     return this.handleSendPreparedTransaction(tx);
@@ -1826,8 +1837,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
 
-    let authority: number;
-    let mask: number;
+    let authority: OutputValueType;
+    let mask: OutputValueType;
     if (type === 'mint') {
       authority = 1;
       mask = TOKEN_MINT_MASK;
@@ -1933,7 +1944,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
 
-    let authority: number;
+    let authority: OutputValueType;
     if (type === 'mint') {
       authority = 1;
     } else if (type === 'melt') {
@@ -2009,7 +2020,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async createNFT(
     name: string,
     symbol: string,
-    amount: number,
+    amount: OutputValueType,
     data: string,
     options = {}
   ): Promise<Transaction> {


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-wallet-lib/pull/730

### Motivation

See https://github.com/HathorNetwork/internal-issues/issues/363.

To add support for greater output values, the output value type must be changed from `number` to `bigint`. In preparation for that, this PR performs an extremely simple refactor by introducing a type alias `type OutputValueType: number`, and changing all related places to use it. Then, we can change the type alias to `bigint`, reducing the size of the final conversion PR.

### Acceptance Criteria

- All instances of variables/parameters such as `value`, `authorities`, `balance`, and `amount` that are related/come from an output value are changed from type `number` to `OutputValueType`.
- No behavior should change.


### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
