### PR TITLE
feat: implement bigint support

### DIFF
--- a/__tests__/utils/bigint.test.js.ts
+++ b/__tests__/utils/bigint.test.js.ts
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { z } from 'zod';
+import { bigIntCoercibleSchema, JSONBigInt, parseJsonBigInt } from '../../src/utils/bigint';
+
+const obj = {
+  a: 123,
+  b: 123.456,
+  c: 'testing',
+  d: null,
+  e: true,
+  f: [123, 123.456, 'testing', null],
+  g: {
+    a: 123,
+    b: 123.456,
+    c: 'testing',
+    d: null,
+    e: true,
+    f: [123, 123.456, 'testing', null],
+  },
+};
+const nativeJson = JSON.stringify(obj);
+
+const bigIntJson = '{"large":12345678901234567890,"small":123}';
+const bigIntObj = { large: 12345678901234567890n, small: 123 };
+const bigIntCoercedObj = { large: 12345678901234567890n, small: 123n };
+
+const objSchema = z.object({
+  a: z.number(),
+  b: z.number(),
+  c: z.string(),
+  d: z.null(),
+  e: z.boolean(),
+  f: z.tuple([z.number(), z.number(), z.string(), z.null()]),
+  g: z.object({
+    a: z.number(),
+    b: z.number(),
+    c: z.string(),
+    d: z.null(),
+    e: z.boolean(),
+    f: z.tuple([z.number(), z.number(), z.string(), z.null()]),
+  }),
+});
+
+const bigIntObjSchema = z.object({
+  large: bigIntCoercibleSchema,
+  small: bigIntCoercibleSchema,
+});
+
+describe('test JSONBigInt', () => {
+  test('should parse numbers', () => {
+    expect(JSONBigInt.parse('123')).toStrictEqual(123);
+    expect(JSONBigInt.parse('123.456')).toStrictEqual(123.456);
+    expect(JSONBigInt.parse('1.0')).toStrictEqual(1);
+    expect(JSONBigInt.parse('1.000000000000')).toStrictEqual(1);
+
+    if (!JSONBigInt.isAvailable()) {
+      return;
+    }
+
+    expect(JSONBigInt.parse('12345678901234567890')).toStrictEqual(12345678901234567890n);
+    expect(JSONBigInt.parse('12345678901234567890.000')).toStrictEqual(12345678901234567890n);
+
+    expect(() => JSONBigInt.parse('12345678901234567890.1')).toThrow(
+      Error('large float will lose precision! in "12345678901234567890.1"')
+    );
+    expect(() => JSONBigInt.parse('1e2')).toThrow(
+      Error('exponential notation is not supported in "1e2"')
+    );
+    expect(() => JSONBigInt.parse('1E2')).toThrow(
+      Error('exponential notation is not supported in "1E2"')
+    );
+  });
+
+  test('should parse normal JSON', () => {
+    expect(JSONBigInt.parse(nativeJson)).toStrictEqual(obj);
+  });
+
+  test('should stringify normal JSON', () => {
+    expect(JSONBigInt.stringify(obj)).toStrictEqual(nativeJson);
+  });
+
+  test('should parse bigint', () => {
+    if (!JSONBigInt.isAvailable()) {
+      return;
+    }
+    expect(JSONBigInt.parse(bigIntJson)).toStrictEqual(bigIntObj);
+  });
+
+  test('should stringify bigint', () => {
+    if (!JSONBigInt.isAvailable()) {
+      return;
+    }
+    expect(JSONBigInt.stringify(bigIntObj)).toStrictEqual(bigIntJson);
+  });
+});
+
+describe('test parseJsonBigInt', () => {
+  test('should parse normal JSON', () => {
+    expect(parseJsonBigInt(nativeJson, objSchema)).toStrictEqual(obj);
+  });
+
+  test('should parse object with small and large bigints', () => {
+    if (!JSONBigInt.isAvailable()) {
+      return;
+    }
+    expect(parseJsonBigInt(bigIntJson, bigIntObjSchema)).toStrictEqual(bigIntCoercedObj);
+  });
+});

--- a/__tests__/utils/buffer.test.ts
+++ b/__tests__/utils/buffer.test.ts
@@ -1,12 +1,20 @@
+import buffer from 'buffer';
 import {
+  bigIntToBytes,
   bufferToHex,
+  bytesToOutputValue,
   floatToBytes,
   hexToBuffer,
   intToBytes,
   signedIntToBytes,
+  unpackToBigInt,
   unpackToFloat,
   unpackToInt,
 } from '../../src/utils/buffer';
+import Output from '../../src/models/output';
+import { MAX_OUTPUT_VALUE, MAX_OUTPUT_VALUE_32 } from '../../src/constants';
+import Address from '../../src/models/address';
+import P2PKH from '../../src/models/p2pkh';
 
 test('Buffer to hex', () => {
   const hexString =
@@ -41,14 +49,96 @@ test('Signed int to bytes', () => {
   const number3 = 70000;
   const buf3 = signedIntToBytes(number3, 4);
   expect(unpackToInt(4, true, buf3)[0]).toBe(number3);
+});
 
-  const number4 = 2 ** 33;
-  const buf4 = signedIntToBytes(number4, 8);
-  expect(unpackToInt(8, true, buf4)[0]).toBe(number4);
+test('bigint to bytes', () => {
+  // it only supports either 4 ou 8 bytes
+  expect(() => bigIntToBytes(0n, 2)).toThrow();
+
+  expect(bigIntToBytes(0n, 4)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 0]));
+  expect(bigIntToBytes(1n, 4)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 1]));
+  expect(bigIntToBytes(2n ** 31n - 1n, 4)).toStrictEqual(
+    buffer.Buffer.from([0x7f, 0xff, 0xff, 0xff])
+  );
+  expect(() => bigIntToBytes(2n ** 31n, 4)).toThrow();
+  expect(bigIntToBytes(-(2n ** 31n), 4)).toStrictEqual(
+    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00])
+  );
+  expect(() => bigIntToBytes(-(2n ** 31n) - 1n, 4)).toThrow();
+
+  expect(bigIntToBytes(0n, 8)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]));
+  expect(bigIntToBytes(1n, 8)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 0, 0, 0, 0, 1]));
+  expect(bigIntToBytes(2n ** 31n - 1n, 8)).toStrictEqual(
+    buffer.Buffer.from([0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff])
+  );
+  expect(bigIntToBytes(2n ** 31n, 8)).toStrictEqual(
+    buffer.Buffer.from([0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00])
+  );
+  expect(bigIntToBytes(-(2n ** 31n), 8)).toStrictEqual(
+    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x80, 0x00, 0x00, 0x00])
+  );
+  expect(bigIntToBytes(-(2n ** 31n) - 1n, 8)).toStrictEqual(
+    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff])
+  );
+
+  expect(bigIntToBytes(2n ** 63n - 1n, 8)).toStrictEqual(
+    buffer.Buffer.from([0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+  );
+  expect(() => bigIntToBytes(2n ** 63n, 8)).toThrow();
+  expect(bigIntToBytes(-(2n ** 63n), 8)).toStrictEqual(
+    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+  );
+  expect(() => bigIntToBytes(-(2n ** 63n) - 1n, 4)).toThrow();
+});
+
+test('unpack to bigint', () => {
+  // it only supports 8 bytes
+  expect(() => unpackToBigInt(4, true, buffer.Buffer.from([]))).toThrow();
+
+  expect(unpackToBigInt(8, true, bigIntToBytes(0n, 8))[0]).toStrictEqual(0n);
+  expect(unpackToBigInt(8, true, bigIntToBytes(1n, 8))[0]).toStrictEqual(1n);
+  expect(unpackToBigInt(8, true, bigIntToBytes(2n ** 31n - 1n, 8))[0]).toStrictEqual(
+    2n ** 31n - 1n
+  );
+  expect(unpackToBigInt(8, true, bigIntToBytes(2n ** 31n, 8))[0]).toStrictEqual(2n ** 31n);
+  expect(unpackToBigInt(8, true, bigIntToBytes(-(2n ** 31n), 8))[0]).toStrictEqual(-(2n ** 31n));
+  expect(unpackToBigInt(8, true, bigIntToBytes(-(2n ** 31n) - 1n, 8))[0]).toStrictEqual(
+    -(2n ** 31n) - 1n
+  );
+  expect(unpackToBigInt(8, true, bigIntToBytes(2n ** 63n - 1n, 8))[0]).toStrictEqual(
+    2n ** 63n - 1n
+  );
+  expect(unpackToBigInt(8, true, bigIntToBytes(-(2n ** 63n), 8))[0]).toStrictEqual(-(2n ** 63n));
 });
 
 test('Float to bytes', () => {
   const number = 10.5;
-  const buffer = floatToBytes(number, 8);
-  expect(unpackToFloat(buffer)[0]).toBe(number);
+  const buf = floatToBytes(number, 8);
+  expect(unpackToFloat(buf)[0]).toBe(number);
+});
+
+test('bytes to output value', () => {
+  const address = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo');
+  const p2pkh = new P2PKH(address);
+  const p2pkhScript = p2pkh.createScript();
+
+  // Value smaller than 32 bytes max
+  const o3 = new Output(MAX_OUTPUT_VALUE_32 - 1, p2pkhScript);
+  expect(bytesToOutputValue(o3.valueToBytes())[0]).toStrictEqual(MAX_OUTPUT_VALUE_32 - 1);
+
+  // Value equal to 32 bytes max
+  const o4 = new Output(MAX_OUTPUT_VALUE_32, p2pkhScript);
+  expect(bytesToOutputValue(o4.valueToBytes())[0]).toStrictEqual(MAX_OUTPUT_VALUE_32);
+
+  // Value greater than 32 bytes max
+  const o5 = new Output(MAX_OUTPUT_VALUE_32 + 1, p2pkhScript);
+  expect(bytesToOutputValue(o5.valueToBytes())[0]).toStrictEqual(MAX_OUTPUT_VALUE_32 + 1);
+
+  // Value smaller than max
+  const o6 = new Output(MAX_OUTPUT_VALUE - 1, p2pkhScript);
+  expect(bytesToOutputValue(o6.valueToBytes())[0]).toStrictEqual(MAX_OUTPUT_VALUE - 1);
+
+  // Value equal to max
+  const o7 = new Output(MAX_OUTPUT_VALUE, p2pkhScript);
+  expect(bytesToOutputValue(o7.valueToBytes())[0]).toStrictEqual(MAX_OUTPUT_VALUE);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,11 @@
         "crypto-js": "4.2.0",
         "isomorphic-ws": "5.0.0",
         "level": "8.0.1",
+        "level-transcoder": "1.0.1",
         "lodash": "4.17.21",
-        "long": "5.2.3",
         "queue-microtask": "1.2.3",
-        "ws": "8.17.1"
+        "ws": "8.17.1",
+        "zod": "3.23.8"
       },
       "devDependencies": {
         "@babel/cli": "7.24.7",
@@ -9101,12 +9102,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -11023,6 +11018,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,11 @@
     "crypto-js": "4.2.0",
     "isomorphic-ws": "5.0.0",
     "level": "8.0.1",
+    "level-transcoder": "1.0.1",
     "lodash": "4.17.21",
-    "long": "5.2.3",
     "queue-microtask": "1.2.3",
-    "ws": "8.17.1"
+    "ws": "8.17.1",
+    "zod": "3.23.8"
   },
   "scripts": {
     "test": "jest --env=node --forceExit",

--- a/src/api/schemas/txApi.ts
+++ b/src/api/schemas/txApi.ts
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { z } from 'zod';
+
+export const transactionSchema = z.discriminatedUnion('success', [
+  z
+    .object({
+      success: z.literal(true),
+      tx: z
+        .object({
+          hash: z.string(),
+          nonce: z.string(),
+          timestamp: z.number(),
+          version: z.number(),
+          weight: z.number(),
+          signal_bits: z.number(),
+          parents: z.string().array(),
+          nc_id: z.string().nullish(),
+          nc_method: z.string().nullish(),
+          nc_pubkey: z.string().nullish(),
+          nc_args: z.string().nullish(),
+          nc_blueprint_id: z.string().nullish(),
+          inputs: z
+            .object({
+              value: z.number(),
+              token_data: z.number(),
+              script: z.string(),
+              decoded: z
+                .object({
+                  type: z.string(),
+                  address: z.string(),
+                  timelock: z.number().nullish(),
+                  value: z.number(),
+                  token_data: z.number(),
+                })
+                .passthrough(),
+              tx_id: z.string(),
+              index: z.number(),
+              token: z.string().nullish(),
+              spent_by: z.string().nullish(),
+            })
+            .passthrough()
+            .array(),
+          outputs: z
+            .object({
+              value: z.number(),
+              token_data: z.number(),
+              script: z.string(),
+              decoded: z
+                .object({
+                  type: z.string(),
+                  address: z.string().optional(),
+                  timelock: z.number().nullish(),
+                  value: z.number(),
+                  token_data: z.number().optional(),
+                })
+                .passthrough(),
+              token: z.string().nullish(),
+              spent_by: z.string().nullish(),
+            })
+            .passthrough()
+            .array(),
+          tokens: z
+            .object({
+              uid: z.string(),
+              name: z.string().nullable(),
+              symbol: z.string().nullable(),
+            })
+            .passthrough()
+            .array(),
+          token_name: z.string().nullish(),
+          token_symbol: z.string().nullish(),
+          raw: z.string(),
+        })
+        .passthrough(),
+      meta: z
+        .object({
+          hash: z.string(),
+          spent_outputs: z.tuple([z.number(), z.string().array()]).array(),
+          received_by: z.string().array(),
+          children: z.string().array(),
+          conflict_with: z.string().array(),
+          voided_by: z.string().array(),
+          twins: z.string().array(),
+          accumulated_weight: z.number(),
+          score: z.number(),
+          height: z.number(),
+          min_height: z.number(),
+          feature_activation_bit_counts: z.number().array().nullable(),
+          first_block: z.string().nullish(),
+          validation: z.string().nullish(),
+          first_block_height: z.number().nullish(),
+        })
+        .passthrough(),
+      spent_outputs: z.record(z.coerce.number(), z.string()),
+    })
+    .passthrough(),
+  z.object({ success: z.literal(false), message: z.string().nullish() }).passthrough(),
+]);
+
+export type TransactionSchema = z.infer<typeof transactionSchema>;

--- a/src/api/schemas/wallet.ts
+++ b/src/api/schemas/wallet.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { z } from 'zod';
+import { IHistoryTxSchema } from '../../schemas';
+
+export const addressHistorySchema = z.discriminatedUnion('success', [
+  z
+    .object({
+      success: z.literal(true),
+      history: IHistoryTxSchema.array(),
+      has_more: z.boolean(),
+      first_hash: z.string().nullish(),
+      first_address: z.string().nullish(),
+    })
+    .passthrough(),
+  z.object({ success: z.literal(false), message: z.string() }).passthrough(),
+]);
+
+export type AddressHistorySchema = z.infer<typeof addressHistorySchema>;
+
+export const mintMeltUtxoSchema = z
+  .object({
+    tx_id: z.string(),
+    index: z.number(),
+  })
+  .passthrough();
+
+export const generalTokenInfoSchema = z.discriminatedUnion('success', [
+  z
+    .object({
+      success: z.literal(true),
+      name: z.string(),
+      symbol: z.string(),
+      mint: mintMeltUtxoSchema.array(),
+      melt: mintMeltUtxoSchema.array(),
+      total: z.number(),
+      transactions_count: z.number(),
+    })
+    .passthrough(),
+  z.object({ success: z.literal(false), message: z.string() }).passthrough(),
+]);
+
+export type GeneralTokenInfoSchema = z.infer<typeof generalTokenInfoSchema>;

--- a/src/api/txApi.ts
+++ b/src/api/txApi.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { AxiosResponse } from 'axios';
 import { createRequestInstance } from './axiosInstance';
+import { transformJsonBigIntResponse } from '../utils/bigint';
+import { TransactionSchema, transactionSchema } from './schemas/txApi';
 
 /**
  * Api calls for transaction
@@ -24,9 +27,12 @@ const txApi = {
    * @memberof ApiTransaction
    * @inner
    */
-  getTransactionBase(data, resolve) {
+  getTransactionBase(data, resolve, schema?) {
     return createRequestInstance(resolve)
-      .get(`transaction`, { params: data })
+      .get(`transaction`, {
+        params: data,
+        transformResponse: res => (schema ? transformJsonBigIntResponse(res, schema) : res),
+      })
       .then(
         res => {
           resolve(res.data);
@@ -72,9 +78,9 @@ const txApi = {
    * @memberof ApiTransaction
    * @inner
    */
-  getTransaction(id, resolve) {
+  getTransaction(id, resolve): Promise<void | AxiosResponse<TransactionSchema>> {
     const data = { id };
-    return this.getTransactionBase(data, resolve);
+    return this.getTransactionBase(data, resolve, transactionSchema);
   },
 
   /**

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -5,8 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { AxiosResponse } from 'axios';
 import { createRequestInstance } from './axiosInstance';
 import { SEND_TOKENS_TIMEOUT } from '../constants';
+import { transformJsonBigIntResponse } from '../utils/bigint';
+import {
+  AddressHistorySchema,
+  addressHistorySchema,
+  GeneralTokenInfoSchema,
+  generalTokenInfoSchema,
+} from './schemas/wallet';
 
 /**
  * Api calls for wallet
@@ -26,14 +34,17 @@ const walletApi = {
    * @memberof ApiWallet
    * @inner
    */
-  getAddressHistory(addresses, hash, resolve) {
+  getAddressHistory(addresses, hash, resolve): Promise<void | AxiosResponse<AddressHistorySchema>> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = { addresses, paginate: true };
     if (hash) {
       data.hash = hash;
     }
     return createRequestInstance(resolve)
-      .get('thin_wallet/address_history', { params: data })
+      .get('thin_wallet/address_history', {
+        params: data,
+        transformResponse: res => transformJsonBigIntResponse(res, addressHistorySchema),
+      })
       .then(
         res => {
           resolve(res.data);
@@ -65,13 +76,16 @@ const walletApi = {
    * @memberof ApiWallet
    * @inner
    */
-  getAddressHistoryForAwait(addresses, hash) {
+  getAddressHistoryForAwait(addresses, hash): Promise<AxiosResponse<AddressHistorySchema>> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = { addresses, paginate: true };
     if (hash) {
       data.hash = hash;
     }
-    return createRequestInstance().get('thin_wallet/address_history', { params: data });
+    return createRequestInstance().get('thin_wallet/address_history', {
+      params: data,
+      transformResponse: res => transformJsonBigIntResponse(res, addressHistorySchema),
+    });
   },
 
   /**
@@ -85,13 +99,15 @@ const walletApi = {
    * @memberof ApiWallet
    * @inner
    */
-  getAddressHistoryForAwaitPOST(addresses, hash) {
+  getAddressHistoryForAwaitPOST(addresses, hash): Promise<AxiosResponse<AddressHistorySchema>> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const data: any = { addresses, paginate: true };
     if (hash) {
       data.hash = hash;
     }
-    return createRequestInstance().post('thin_wallet/address_history', data);
+    return createRequestInstance().post('thin_wallet/address_history', data, {
+      transformResponse: res => transformJsonBigIntResponse(res, addressHistorySchema),
+    });
   },
 
   /**
@@ -128,10 +144,13 @@ const walletApi = {
    * @memberof ApiWallet
    * @inner
    */
-  getGeneralTokenInfo(uid, resolve) {
+  getGeneralTokenInfo(uid, resolve): Promise<void | AxiosResponse<GeneralTokenInfoSchema>> {
     const data = { id: uid };
     return createRequestInstance(resolve)
-      .get('thin_wallet/token', { params: data })
+      .get('thin_wallet/token', {
+        params: data,
+        transformResponse: res => transformJsonBigIntResponse(res, generalTokenInfoSchema),
+      })
       .then(
         res => {
           resolve(res.data);

--- a/src/models/output.ts
+++ b/src/models/output.ts
@@ -24,7 +24,7 @@ import {
   unpackLen,
   unpackToInt,
   intToBytes,
-  signedIntToBytes,
+  bigIntToBytes,
 } from '../utils/buffer';
 import { prettyValue } from '../utils/numbers';
 import { parseScript as utilsParseScript } from '../utils/scripts';
@@ -96,9 +96,9 @@ class Output {
       throw new OutputValueError(`Maximum value is ${prettyValue(MAX_OUTPUT_VALUE)}`);
     }
     if (this.value > MAX_OUTPUT_VALUE_32) {
-      return signedIntToBytes(-this.value, 8);
+      return bigIntToBytes(BigInt(-this.value), 8);
     }
-    return signedIntToBytes(this.value, 4);
+    return bigIntToBytes(BigInt(this.value), 4);
   }
 
   /**

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -49,6 +49,7 @@ import { MemoryStore, Storage } from '../storage';
 import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../utils/address';
 import NanoContractTransactionBuilder from '../nano_contracts/builder';
 import { prepareNanoSendTransaction } from '../nano_contracts/utils';
+import { IHistoryTxSchema } from '../schemas';
 import GLL from '../sync/gll';
 
 /**
@@ -1322,7 +1323,12 @@ class HathorWallet extends EventEmitter {
   }
 
   async onNewTx(wsData) {
-    const newTx = wsData.history;
+    const parseResult = IHistoryTxSchema.safeParse(wsData.history);
+    if (!parseResult.success) {
+      this.logger.error(parseResult.error);
+      return;
+    }
+    const newTx = parseResult.data;
     const storageTx = await this.storage.getTx(newTx.tx_id);
     const isNewTx = storageTx === null;
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { z } from 'zod';
+import {
+  IAddressMetadataAsRecord,
+  IAuthoritiesBalance,
+  IBalance,
+  IHistoryInput,
+  IHistoryOutput,
+  IHistoryOutputDecoded,
+  IHistoryTx,
+  ILockedUtxo,
+  ITokenBalance,
+  ITokenMetadata,
+  IUtxo,
+  TxHistoryProcessingStatus,
+} from './types';
+import { ZodSchema } from './utils/bigint';
+
+export const ITokenBalanceSchema: ZodSchema<ITokenBalance> = z
+  .object({
+    locked: z.number(),
+    unlocked: z.number(),
+  })
+  .passthrough();
+
+export const IAuthoritiesBalanceSchema: ZodSchema<IAuthoritiesBalance> = z
+  .object({
+    mint: ITokenBalanceSchema,
+    melt: ITokenBalanceSchema,
+  })
+  .passthrough();
+
+export const IBalanceSchema: ZodSchema<IBalance> = z
+  .object({
+    tokens: ITokenBalanceSchema,
+    authorities: IAuthoritiesBalanceSchema,
+  })
+  .passthrough();
+
+export const IAddressMetadataAsRecordSchema: ZodSchema<IAddressMetadataAsRecord> = z
+  .object({
+    numTransactions: z.number(),
+    balance: z.record(IBalanceSchema),
+  })
+  .passthrough();
+
+export const ITokenMetadataSchema: ZodSchema<ITokenMetadata> = z
+  .object({
+    numTransactions: z.number(),
+    balance: IBalanceSchema,
+  })
+  .passthrough();
+
+export const IHistoryOutputDecodedSchema: ZodSchema<IHistoryOutputDecoded> = z
+  .object({
+    type: z.string().optional(),
+    address: z.string().optional(),
+    timelock: z.number().nullish(),
+    data: z.string().optional(),
+  })
+  .passthrough();
+
+export const IHistoryInputSchema: ZodSchema<IHistoryInput> = z
+  .object({
+    value: z.number(),
+    token_data: z.number(),
+    script: z.string(),
+    decoded: IHistoryOutputDecodedSchema,
+    token: z.string(),
+    tx_id: z.string(),
+    index: z.number(),
+  })
+  .passthrough();
+
+export const IHistoryOutputSchema: ZodSchema<IHistoryOutput> = z
+  .object({
+    value: z.number(),
+    token_data: z.number(),
+    script: z.string(),
+    decoded: IHistoryOutputDecodedSchema,
+    token: z.string(),
+    spent_by: z.string().nullable(),
+    selected_as_input: z.boolean().optional(),
+  })
+  .passthrough();
+
+export const IHistoryTxSchema: ZodSchema<IHistoryTx> = z
+  .object({
+    tx_id: z.string(),
+    signalBits: z.number().optional(),
+    version: z.number(),
+    weight: z.number(),
+    timestamp: z.number(),
+    is_voided: z.boolean(),
+    nonce: z.number().optional(),
+    inputs: IHistoryInputSchema.array(),
+    outputs: IHistoryOutputSchema.array(),
+    parents: z.string().array(),
+    token_name: z.string().optional(),
+    token_symbol: z.string().optional(),
+    tokens: z.string().array().optional(),
+    height: z.number().optional(),
+    processingStatus: z.nativeEnum(TxHistoryProcessingStatus).optional(),
+    nc_id: z.string().optional(),
+    nc_blueprint_id: z.string().optional(),
+    nc_method: z.string().optional(),
+    nc_args: z.string().optional(),
+    nc_pubkey: z.string().optional(),
+    first_block: z.string().nullish(),
+  })
+  .passthrough();
+
+export const IUtxoSchema: ZodSchema<IUtxo> = z
+  .object({
+    txId: z.string(),
+    index: z.number(),
+    token: z.string(),
+    address: z.string(),
+    value: z.number(),
+    authorities: z.number(),
+    timelock: z.number().nullable(),
+    type: z.number(),
+    height: z.number().nullable(),
+  })
+  .passthrough();
+
+export const ILockedUtxoSchema: ZodSchema<ILockedUtxo> = z
+  .object({
+    tx: IHistoryTxSchema,
+    index: z.number(),
+  })
+  .passthrough();

--- a/src/storage/leveldb/address_index.ts
+++ b/src/storage/leveldb/address_index.ts
@@ -18,6 +18,8 @@ import {
 } from '../../types';
 import { errorCodeOrNull, KEY_NOT_FOUND_CODE } from './errors';
 import { checkLevelDbVersion } from './utils';
+import { jsonBigIntEncoding } from '../../utils/bigint';
+import { IAddressMetadataAsRecordSchema } from '../../schemas';
 
 export const ADDRESS_PREFIX = 'address';
 export const INDEX_PREFIX = 'index';
@@ -85,7 +87,7 @@ export default class LevelAddressIndex implements IKVAddressIndex {
     this.addressesDB = db.sublevel<string, IAddressInfo>(ADDRESS_PREFIX, { valueEncoding: 'json' });
     this.addressesIndexDB = db.sublevel(INDEX_PREFIX);
     this.addressesMetaDB = db.sublevel<string, IAddressMetadataAsRecord>(ADDRESS_META_PREFIX, {
-      valueEncoding: 'json',
+      valueEncoding: jsonBigIntEncoding(IAddressMetadataAsRecordSchema),
     });
     this.isValidated = false;
     this.size = 0;

--- a/src/storage/leveldb/history_index.ts
+++ b/src/storage/leveldb/history_index.ts
@@ -11,6 +11,8 @@ import { AbstractSublevel } from 'abstract-level';
 import { IKVHistoryIndex, IHistoryTx, HistoryIndexValidateResponse } from '../../types';
 import { errorCodeOrNull, KEY_NOT_FOUND_CODE } from './errors';
 import { checkLevelDbVersion } from './utils';
+import { jsonBigIntEncoding } from '../../utils/bigint';
+import { IHistoryTxSchema } from '../../schemas';
 
 export const HISTORY_PREFIX = 'history';
 export const TS_HISTORY_PREFIX = 'ts_history';
@@ -52,10 +54,9 @@ export default class LevelHistoryIndex implements IKVHistoryIndex {
   constructor(dbpath: string) {
     this.dbpath = path.join(dbpath, 'history');
     const db = new Level(this.dbpath);
-    this.historyDB = db.sublevel<string, IHistoryTx>(HISTORY_PREFIX, { valueEncoding: 'json' });
-    this.tsHistoryDB = db.sublevel<string, IHistoryTx>(TS_HISTORY_PREFIX, {
-      valueEncoding: 'json',
-    });
+    const valueEncoding = jsonBigIntEncoding(IHistoryTxSchema);
+    this.historyDB = db.sublevel<string, IHistoryTx>(HISTORY_PREFIX, { valueEncoding });
+    this.tsHistoryDB = db.sublevel<string, IHistoryTx>(TS_HISTORY_PREFIX, { valueEncoding });
     this.isValidated = false;
     this.size = 0;
   }

--- a/src/storage/leveldb/token_index.ts
+++ b/src/storage/leveldb/token_index.ts
@@ -11,6 +11,8 @@ import { AbstractSublevel } from 'abstract-level';
 import { IKVTokenIndex, ITokenData, ITokenMetadata } from '../../types';
 import { errorCodeOrNull, KEY_NOT_FOUND_CODE } from './errors';
 import { checkLevelDbVersion } from './utils';
+import { jsonBigIntEncoding } from '../../utils/bigint';
+import { ITokenMetadataSchema } from '../../schemas';
 
 export const TOKEN_PREFIX = 'token';
 export const META_PREFIX = 'meta';
@@ -46,7 +48,9 @@ export default class LevelTokenIndex implements IKVTokenIndex {
     this.dbpath = path.join(dbpath, 'tokens');
     const db = new Level(this.dbpath);
     this.tokenDB = db.sublevel<string, ITokenData>(TOKEN_PREFIX, { valueEncoding: 'json' });
-    this.metadataDB = db.sublevel<string, ITokenMetadata>(META_PREFIX, { valueEncoding: 'json' });
+    this.metadataDB = db.sublevel<string, ITokenMetadata>(META_PREFIX, {
+      valueEncoding: jsonBigIntEncoding(ITokenMetadataSchema),
+    });
     this.registeredDB = db.sublevel<string, ITokenData>(REGISTER_PREFIX, { valueEncoding: 'json' });
   }
 

--- a/src/storage/leveldb/utxo_index.ts
+++ b/src/storage/leveldb/utxo_index.ts
@@ -14,6 +14,8 @@ import { NATIVE_TOKEN_UID } from '../../constants';
 import { errorCodeOrNull, KEY_NOT_FOUND_CODE } from './errors';
 import transactionUtils from '../../utils/transaction';
 import { checkLevelDbVersion } from './utils';
+import { jsonBigIntEncoding } from '../../utils/bigint';
+import { ILockedUtxoSchema, IUtxoSchema } from '../../schemas';
 
 export const UTXO_PREFIX = 'utxo';
 export const TOKEN_ADDRESS_UTXO_PREFIX = 'token:address:utxo';
@@ -88,13 +90,16 @@ export default class LevelUtxoIndex implements IKVUtxoIndex {
   constructor(dbpath: string) {
     this.dbpath = path.join(dbpath, 'utxos');
     const db = new Level(this.dbpath);
-    this.utxoDB = db.sublevel<string, IUtxo>(UTXO_PREFIX, { valueEncoding: 'json' });
-    this.tokenUtxoDB = db.sublevel<string, IUtxo>(TOKEN_UTXO_PREFIX, { valueEncoding: 'json' });
+    const utxoEncoding = jsonBigIntEncoding(IUtxoSchema);
+    this.utxoDB = db.sublevel<string, IUtxo>(UTXO_PREFIX, { valueEncoding: utxoEncoding });
+    this.tokenUtxoDB = db.sublevel<string, IUtxo>(TOKEN_UTXO_PREFIX, {
+      valueEncoding: utxoEncoding,
+    });
     this.tokenAddressUtxoDB = db.sublevel<string, IUtxo>(TOKEN_ADDRESS_UTXO_PREFIX, {
-      valueEncoding: 'json',
+      valueEncoding: utxoEncoding,
     });
     this.lockedUtxoDB = db.sublevel<string, ILockedUtxo>(LOCKED_UTXO_PREFIX, {
-      valueEncoding: 'json',
+      valueEncoding: jsonBigIntEncoding(ILockedUtxoSchema),
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,7 +129,7 @@ export interface IHistoryTx {
   nc_method?: string; // For nano contract
   nc_args?: string; // For nano contract. Args in hex
   nc_pubkey?: string; // For nano contract. Pubkey in hex
-  first_block?: string;
+  first_block?: string | null;
 }
 
 export enum TxHistoryProcessingStatus {

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { IEncoding } from 'level-transcoder';
+import { z } from 'zod';
+import { getDefaultLogger } from '../types';
+
+/**
+ * An object equivalent to the native global JSON, providing `parse()` and `stringify()` functions with compatible signatures, except
+ * for the `reviver` and `replacer` parameters that are not supported to prevent accidental override of the custom BigInt behavior.
+ *
+ * If the JSON string to be parsed contains large integers that would lose precision with the `number` type, they're parsed as `bigint`s,
+ * and analogously for `stringify`. The `any` type is allowed as it conforms to the original signatures.
+ */
+export const JSONBigInt = {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  parse(text: string): any {
+    function bigIntReviver(_key: string, value: any, context: { source: string }): any {
+      if (!Number.isInteger(value)) {
+        // No special handling needed for non-integer values.
+        return value;
+      }
+
+      let { source } = context;
+      if (source.includes('e') || source.includes('E')) {
+        // We explicitly prohibit JSONs with exponential notation (such as 10e2) as they cannot be parsed to BigInt.
+        throw Error(`exponential notation is not supported in "${text}"`);
+      }
+
+      if (source.includes('.')) {
+        // If value is an integer and contains a '.', it must be like '123.0', so we extract the integer part only.
+        let zeroes: string;
+        [source, zeroes] = source.split('.');
+
+        if (zeroes.split('').some(char => char !== '0')) {
+          // This case shouldn't happen but we'll prohibit it to be safe. For example, if the source is
+          // '12345678901234567890.1', JS will parse it as an integer with loss of precision, `12345678901234567000`.
+          throw Error(`large float will lose precision! in "${text}"`);
+        }
+      }
+
+      const bigIntValue = BigInt(source);
+      if (bigIntValue !== BigInt(value)) {
+        // If the parsed value is an integer and its BigInt representation is a different value,
+        // it means we lost precision, so we return the BigInt.
+        return bigIntValue;
+      }
+
+      // No special handling needed.
+      return value;
+    }
+
+    // @ts-expect-error TypeScript hasn't been updated with the `context` argument from Node v22.
+    return JSON.parse(text, this.isAvailable() ? bigIntReviver : undefined);
+  },
+
+  stringify(value: any, space?: string | number): string {
+    function bigIntReplacer(_key: string, value_: any): any {
+      // If the value is a BigInt, we simply return its string representation.
+      // @ts-expect-error TypeScript hasn't been updated with the `rawJSON` function from Node v22.
+      return typeof value_ === 'bigint' ? JSON.rawJSON(value_.toString()) : value_;
+    }
+
+    return JSON.stringify(value, this.isAvailable() ? bigIntReplacer : undefined, space);
+  },
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+
+  /**
+   * Utility function for checking if JSONBigInt is available. We shouldn't allow it to be used if it's not available,
+   * however we temporarily keep Node v20 in our CI, so we have to allow it for tests.
+   * After QA is done to test Node v22 and we remove v20 from CI, we may remove this function.
+   */
+  isAvailable(): boolean {
+    const major = process.versions.node.split('.')[0];
+    return Number(major) >= 22;
+  },
+};
+
+/**
+ * A utility Zod schema for `bigint` properties that can be instantiated from a coercible type, that is, a `number`, `string`, or `bigint` itself.
+ */
+export const bigIntCoercibleSchema = z
+  .bigint()
+  .or(z.number())
+  .or(z.string())
+  .pipe(z.coerce.bigint());
+
+/**
+ * A type alias for a Zod schema with `unknown` input and generic output.
+ */
+export type ZodSchema<T> = z.ZodSchema<T, z.ZodTypeDef, unknown>;
+
+/**
+ * Parse some `unknown` data with a Zod schema. If parsing fails, it logs the error and throws.
+ */
+export function parseSchema<T>(data: unknown, schema: ZodSchema<T>): T {
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    const logger = getDefaultLogger();
+    logger.error(`error: ${result.error.message}\ncaused by input: ${data}`);
+    throw result.error;
+  }
+
+  return result.data;
+}
+
+/**
+ * Parse some JSON string with a Zod schema.
+ *
+ * If the JSON string contains large integers that would lose precision with the `number` type, they're parsed as `bigint`s.
+ * This means that `z.bigint()` properties would fail for small integers, as they would be parsed as `number`s.
+ * To mitigate this, use the `bigIntCoercibleSchema` utility, which will coerce the property to a `bigint` output.
+ *
+ * If parsing fails, it logs the error and throws.
+ */
+export function parseJsonBigInt<T>(text: string, schema: ZodSchema<T>): T {
+  const jsonSchema = z
+    .string()
+    .transform((str, ctx) => {
+      try {
+        return JSONBigInt.parse(str);
+      } catch (e) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Could not parse with JSONBigInt. Error: ${e}`,
+        });
+        return z.NEVER;
+      }
+    })
+    .pipe(schema);
+
+  return parseSchema(text, jsonSchema);
+}
+
+/**
+ * A custom JSON encoding for LevelDB with support for `bigint` properties, powered by Zod schemas.
+ *
+ * If the resulting JSON contains large integers that would lose precision with the `number` type, they're parsed as `bigint`s.
+ * This means that `z.bigint()` properties would fail for small integers, as they would be parsed as `number`s.
+ * To mitigate this, use the `bigIntCoercibleSchema` utility, which will coerce the property to a `bigint` output.
+ */
+export function jsonBigIntEncoding<T>(schema: ZodSchema<T>): IEncoding<T, string, T> {
+  return {
+    name: 'json_bigint',
+    format: 'utf8',
+    encode(data: T): string {
+      return JSONBigInt.stringify(data);
+    },
+    decode(text: string): T {
+      return parseJsonBigInt(text, schema);
+    },
+  };
+}
+
+/**
+ * A utility function to be used with `transformResponse` in Axios requests with support for `bigint` properties, powered by Zod schemas.
+ *
+ * If the JSON string contains large integers that would lose precision with the `number` type, they're parsed as `bigint`s.
+ * This means that `z.bigint()` properties would fail for small integers, as they would be parsed as `number`s.
+ * To mitigate this, use the `bigIntCoercibleSchema` utility, which will coerce the property to a `bigint` output.
+ */
+export function transformJsonBigIntResponse<T>(data: unknown, schema: ZodSchema<T>): T {
+  return typeof data === 'string' ? parseJsonBigInt(data, schema) : parseSchema(data, schema);
+}

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,5 +1,4 @@
 import buffer from 'buffer';
-import Long from 'long';
 import { ParseError } from '../errors';
 import { OutputValueType } from '../types';
 
@@ -43,7 +42,7 @@ export function intToBytes(value: number, bytes: number): Buffer {
  * @inner
  */
 export function signedIntToBytes(value: number, bytes: number): Buffer {
-  let arr = new ArrayBuffer(bytes);
+  const arr = new ArrayBuffer(bytes);
   const view = new DataView(arr);
   if (bytes === 1) {
     // byteOffset = 0
@@ -53,10 +52,34 @@ export function signedIntToBytes(value: number, bytes: number): Buffer {
     view.setInt16(0, value, false);
   } else if (bytes === 4) {
     view.setInt32(0, value, false);
-  } else if (bytes === 8) {
-    // In case of 8 bytes I need to handle the int with a Long lib
-    const long = Long.fromNumber(value, false);
-    arr = new Uint8Array(long.toBytesBE()).buffer;
+  }
+  return buffer.Buffer.from(arr);
+}
+
+/**
+ * Transform a signed `bigint` to bytes (4 or 8 bytes).
+ *
+ * @param {bigint} value BigInt to be transformed to bytes
+ * @param {number} bytes How many bytes this number uses
+ */
+export function bigIntToBytes(value: bigint, bytes: 4 | 8): Buffer {
+  const arr = new ArrayBuffer(bytes);
+  const view = new DataView(arr);
+  switch (bytes) {
+    case 4:
+      if (value < -(2n ** 31n) || 2n ** 31n - 1n < value) {
+        throw new Error(`value too large for 4 bytes: ${value}`);
+      }
+      view.setInt32(0, Number(value), false);
+      break;
+    case 8:
+      if (value < -(2n ** 63n) || 2n ** 63n - 1n < value) {
+        throw new Error(`value too large for 8 bytes: ${value}`);
+      }
+      view.setBigInt64(0, value, false);
+      break;
+    default:
+      throw new Error(`invalid bytes size: ${bytes}`);
   }
   return buffer.Buffer.from(arr);
 }
@@ -149,20 +172,32 @@ export const unpackToInt = (n: number, signed: boolean, buff: Buffer): [number, 
     } else {
       retInt = slicedBuff.readUInt32BE(0);
     }
-  } else if (n === 8) {
-    // We have only signed ints here
-    // readBigInt64BE exists only in node versions > 8
-    // the else block is used for versions <= 8 and usage in web browsers
-    if (slicedBuff.readBigInt64BE) {
-      retInt = Number(slicedBuff.readBigInt64BE());
-    } else {
-      retInt = slicedBuff.readIntBE(0, 8);
-    }
   } else {
     throw new ParseError('Invalid value for n.');
   }
 
   return [retInt, buff.slice(n)];
+};
+
+/**
+ * Unpacks a `bigint` from a buffer, used for 64-bit integers.
+ *
+ * @param {8} n The size of the number in bytes, should always be 8
+ * @param {boolean} signed If the number is signed
+ * @param {Buffer} buff The buffer to unpack
+ *
+ * @return {[bigint, Buffer]} The unpacked `bigint` followed by the rest of the buffer
+ */
+export const unpackToBigInt = (n: 8, signed: boolean, buff: Buffer): [bigint, Buffer] => {
+  validateLenToUnpack(n, buff);
+  const [buf, rest] = [buff.subarray(0, n), buff.subarray(n)];
+
+  if (n !== 8) {
+    throw new Error(`invalid bytes size: ${n}`);
+  }
+
+  const value = signed ? buf.readBigInt64BE(0) : buf.readBigUInt64BE(0);
+  return [value, rest];
 };
 
 /**
@@ -225,7 +260,9 @@ export const bytesToOutputValue = (srcBuf: Buffer): [OutputValueType, Buffer] =>
   if (highByte < 0) {
     // 8 bytes
     sign = -1;
-    [value, buff] = unpackToInt(8, true, buff);
+    let bigintValue: bigint;
+    [bigintValue, buff] = unpackToBigInt(8, true, buff);
+    value = Number(bigintValue);
   } else {
     // 4 bytes
     sign = 1;

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseWebSocket, { WsOptions } from './base';
+import { JSONBigInt } from '../utils/bigint';
 
 /**
  * Handles websocket connections and message transmission
@@ -32,7 +33,7 @@ class GenericWebSocket extends BaseWebSocket {
    * @param {Object} evt Event that has data (evt.data) sent in the websocket
    */
   onMessage(evt) {
-    const message = JSON.parse(evt.data);
+    const message = JSONBigInt.parse(evt.data);
     const _type = this.splitMessageType ? message.type.split(':')[0] : message.type;
     if (_type === 'pong') {
       this.onPong();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es2018",
+    "target": "es2020",
     "module": "commonjs",
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
Depends on https://github.com/HathorNetwork/hathor-wallet-lib/pull/797

### Motivation

See https://github.com/HathorNetwork/internal-issues/issues/363.

This PR adds the necessary structures to support bigint fields, however it does _not_ yet change the `OutputValueType` to `bigint`.

### Acceptance Criteria

- Implement `bigIntToBytes()` and remove `signedIntToBytes()` support for 8 bytes.
- Implement `unpackToBigInt()` and remove `unpackToInt()` support for 8 bytes.
- Update `bytesToOutputValue()` to use `unpackToBigInt()`.
- Dependencies:
  - Added `zod`.
  - `level-transcoder` was added explicitly but was already an indirect dependency.
  - Removed `long`.
- Create `api/txApi` and `api/wallet` Zod schemas, updating requests to use `transformJsonBigIntResponse()`.
- Update `Output.valueToBytes()` to use `bigIntToBytes()` instead of `signedIntToBytes()`.
- Create Zod schemas for some necessary interfaces.
- Use Zod parsing in WS history txs.
- Update LevelDB sublevels to use `jsonBigIntEncoding()` where necessary.
- Implement `utils/bigint.ts`.
- Change WS handler to use `JSONBigInt.parse()` instead of `JSON.parse()`.
- Change TS target to `es2020` instead of `es2018`, adding support for `bigint`.


### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
