### PR TITLE
feat: handle nano custom types in the parser and builder classes

### DIFF
--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 
   fullnode:
     image:
-      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:experimental-nano-sdk-v1.1}
+      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:experimental-nano-sdk-new-types}
     command: [
       "run_node",
       "--listen", "tcp:40404",

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -103,8 +103,39 @@ describe('full cycle of bet nano contract', () => {
       { name: 'date_last_bet', type: 'Timestamp', parsed: dateLastBet },
     ]);
 
-    // Bet 100 to address 2
+    // First validate some bet arguments error handling
     const address2 = await wallet.getAddressAtIndex(2);
+
+    // Address must be a string
+    await expect(wallet.createAndSendNanoContractTransaction('bet', address2, {
+      ncId: tx1.hash,
+      args: [1234, '1x0'],
+      actions: [
+        {
+          type: 'deposit',
+          token: NATIVE_TOKEN_UID,
+          amount: 100,
+          changeAddress: address0,
+        },
+      ],
+    })).rejects.toThrow(NanoContractTransactionError);
+
+    // Invalid address
+    await expect(wallet.createAndSendNanoContractTransaction('bet', address2, {
+      ncId: tx1.hash,
+      args: ['1234', '1x0'],
+      actions: [
+        {
+          type: 'deposit',
+          token: NATIVE_TOKEN_UID,
+          amount: 100,
+          changeAddress: address0,
+        },
+      ],
+    })).rejects.toThrow(NanoContractTransactionError);
+
+
+    // Bet 100 to address 2
     const txBet = await wallet.createAndSendNanoContractTransaction('bet', address2, {
       ncId: tx1.hash,
       args: [address2, '1x0'],
@@ -349,6 +380,14 @@ describe('full cycle of bet nano contract', () => {
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         blueprintId,
         args: [bufferToHex(oracleData), NATIVE_TOKEN_UID],
+      })
+    ).rejects.toThrow(NanoContractTransactionError);
+
+    // Args as null
+    await expect(
+      hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
+        blueprintId,
+        args: null,
       })
     ).rejects.toThrow(NanoContractTransactionError);
 

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -107,33 +107,36 @@ describe('full cycle of bet nano contract', () => {
     const address2 = await wallet.getAddressAtIndex(2);
 
     // Address must be a string
-    await expect(wallet.createAndSendNanoContractTransaction('bet', address2, {
-      ncId: tx1.hash,
-      args: [1234, '1x0'],
-      actions: [
-        {
-          type: 'deposit',
-          token: NATIVE_TOKEN_UID,
-          amount: 100,
-          changeAddress: address0,
-        },
-      ],
-    })).rejects.toThrow(NanoContractTransactionError);
+    await expect(
+      wallet.createAndSendNanoContractTransaction('bet', address2, {
+        ncId: tx1.hash,
+        args: [1234, '1x0'],
+        actions: [
+          {
+            type: 'deposit',
+            token: NATIVE_TOKEN_UID,
+            amount: 100,
+            changeAddress: address0,
+          },
+        ],
+      })
+    ).rejects.toThrow(NanoContractTransactionError);
 
     // Invalid address
-    await expect(wallet.createAndSendNanoContractTransaction('bet', address2, {
-      ncId: tx1.hash,
-      args: ['1234', '1x0'],
-      actions: [
-        {
-          type: 'deposit',
-          token: NATIVE_TOKEN_UID,
-          amount: 100,
-          changeAddress: address0,
-        },
-      ],
-    })).rejects.toThrow(NanoContractTransactionError);
-
+    await expect(
+      wallet.createAndSendNanoContractTransaction('bet', address2, {
+        ncId: tx1.hash,
+        args: ['1234', '1x0'],
+        actions: [
+          {
+            type: 'deposit',
+            token: NATIVE_TOKEN_UID,
+            amount: 100,
+            changeAddress: address0,
+          },
+        ],
+      })
+    ).rejects.toThrow(NanoContractTransactionError);
 
     // Bet 100 to address 2
     const txBet = await wallet.createAndSendNanoContractTransaction('bet', address2, {

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -91,23 +91,23 @@ describe('full cycle of bet nano contract', () => {
       blueprintId,
       NANO_CONTRACTS_INITIALIZE_METHOD,
       tx1Data.tx.nc_pubkey,
+      network,
       tx1Data.tx.nc_args
     );
     tx1Parser.parseAddress(network);
     await tx1Parser.parseArguments();
     expect(tx1Parser.address.base58).toBe(address0);
     expect(tx1Parser.parsedArgs).toStrictEqual([
-      { name: 'oracle_script', type: 'bytes', parsed: oracleData },
-      { name: 'token_uid', type: 'bytes', parsed: Buffer.from([NATIVE_TOKEN_UID]) },
-      { name: 'date_last_offer', type: 'int', parsed: dateLastBet },
+      { name: 'oracle_script', type: 'TxOutputScript', parsed: oracleData },
+      { name: 'token_uid', type: 'TokenUid', parsed: Buffer.from([NATIVE_TOKEN_UID]) },
+      { name: 'date_last_bet', type: 'Timestamp', parsed: dateLastBet },
     ]);
 
     // Bet 100 to address 2
     const address2 = await wallet.getAddressAtIndex(2);
-    const address2Obj = new Address(address2, { network });
     const txBet = await wallet.createAndSendNanoContractTransaction('bet', address2, {
       ncId: tx1.hash,
-      args: [bufferToHex(address2Obj.decode()), '1x0'],
+      args: [address2, '1x0'],
       actions: [
         {
           type: 'deposit',
@@ -125,13 +125,14 @@ describe('full cycle of bet nano contract', () => {
       blueprintId,
       'bet',
       txBetData.tx.nc_pubkey,
+      network,
       txBetData.tx.nc_args
     );
     txBetParser.parseAddress(network);
     await txBetParser.parseArguments();
     expect(txBetParser.address.base58).toBe(address2);
     expect(txBetParser.parsedArgs).toStrictEqual([
-      { name: 'address', type: 'bytes', parsed: address2Obj.decode() },
+      { name: 'address', type: 'Address', parsed: address2 },
       { name: 'score', type: 'str', parsed: '1x0' },
     ]);
 
@@ -144,10 +145,9 @@ describe('full cycle of bet nano contract', () => {
 
     // Bet 200 to address 3
     const address3 = await wallet.getAddressAtIndex(3);
-    const address3Obj = new Address(address3, { network });
     const txBet2 = await wallet.createAndSendNanoContractTransaction('bet', address3, {
       ncId: tx1.hash,
-      args: [bufferToHex(address3Obj.decode()), '2x0'],
+      args: [address3, '2x0'],
       actions: [
         {
           type: 'deposit',
@@ -164,13 +164,14 @@ describe('full cycle of bet nano contract', () => {
       blueprintId,
       'bet',
       txBet2Data.tx.nc_pubkey,
+      network,
       txBet2Data.tx.nc_args
     );
     txBet2Parser.parseAddress(network);
     await txBet2Parser.parseArguments();
     expect(txBet2Parser.address.base58).toBe(address3);
     expect(txBet2Parser.parsedArgs).toStrictEqual([
-      { name: 'address', type: 'bytes', parsed: address3Obj.decode() },
+      { name: 'address', type: 'Address', parsed: address3 },
       { name: 'score', type: 'str', parsed: '2x0' },
     ]);
 
@@ -188,7 +189,7 @@ describe('full cycle of bet nano contract', () => {
       'total',
       'final_result',
       'oracle_script',
-      'date_last_offer',
+      'date_last_bet',
       `address_details.a'${address2}'`,
       `withdrawals.a'${address2}'`,
       `address_details.a'${address3}'`,
@@ -207,7 +208,7 @@ describe('full cycle of bet nano contract', () => {
     const outputScriptBuffer1 = outputScript.createScript();
 
     expect(ncState.fields.token_uid.value).toBe(NATIVE_TOKEN_UID);
-    expect(ncState.fields.date_last_offer.value).toBe(dateLastBet);
+    expect(ncState.fields.date_last_bet.value).toBe(dateLastBet);
     expect(ncState.fields.oracle_script.value).toBe(bufferToHex(outputScriptBuffer1));
     expect(ncState.fields.final_result.value).toBeNull();
     expect(ncState.fields.total.value).toBe(300);
@@ -234,6 +235,7 @@ describe('full cycle of bet nano contract', () => {
       blueprintId,
       'set_result',
       txSetResultData.tx.nc_pubkey,
+      network,
       txSetResultData.tx.nc_args
     );
     txSetResultParser.parseAddress(network);
@@ -269,6 +271,7 @@ describe('full cycle of bet nano contract', () => {
       blueprintId,
       'set_result',
       txWithdrawalData.tx.nc_pubkey,
+      network,
       txWithdrawalData.tx.nc_args
     );
     txWithdrawalParser.parseAddress(network);
@@ -282,14 +285,14 @@ describe('full cycle of bet nano contract', () => {
       'total',
       'final_result',
       'oracle_script',
-      'date_last_offer',
+      'date_last_bet',
       `address_details.a'${address2}'`,
       `withdrawals.a'${address2}'`,
       `address_details.a'${address3}'`,
       `withdrawals.a'${address3}'`,
     ]);
     expect(ncState2.fields.token_uid.value).toBe(NATIVE_TOKEN_UID);
-    expect(ncState2.fields.date_last_offer.value).toBe(dateLastBet);
+    expect(ncState2.fields.date_last_bet.value).toBe(dateLastBet);
     expect(ncState2.fields.oracle_script.value).toBe(bufferToHex(outputScriptBuffer1));
     expect(ncState2.fields.final_result.value).toBe('1x0');
     expect(ncState2.fields.total.value).toBe(300);
@@ -381,10 +384,9 @@ describe('full cycle of bet nano contract', () => {
 
     // Missing ncId for bet
     const address2 = await hWallet.getAddressAtIndex(2);
-    const address2Obj = new Address(address2, { network });
     await expect(
       hWallet.createAndSendNanoContractTransaction('bet', address2, {
-        args: [bufferToHex(address2Obj.decode()), '1x0'],
+        args: [address2, '1x0'],
         actions: [
           {
             type: 'deposit',
@@ -399,7 +401,7 @@ describe('full cycle of bet nano contract', () => {
     await expect(
       hWallet.createAndSendNanoContractTransaction('bet', address2, {
         ncId: '1234',
-        args: [bufferToHex(address2Obj.decode()), '1x0'],
+        args: [address2, '1x0'],
         actions: [
           {
             type: 'deposit',
@@ -414,7 +416,7 @@ describe('full cycle of bet nano contract', () => {
     await expect(
       hWallet.createAndSendNanoContractTransaction('bet', address2, {
         ncId: fundsTx.hash,
-        args: [bufferToHex(address2Obj.decode()), '1x0'],
+        args: [address2, '1x0'],
         actions: [
           {
             type: 'deposit',

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -47,6 +47,17 @@ test('Int', () => {
   expect(value).toBe(deserialized);
 });
 
+test('Amount', () => {
+  const serializer = new Serializer();
+  const deserializer = new Deserializer();
+
+  const value = 300;
+  const serialized = serializer.serializeFromType(value, 'Amount');
+  const deserialized = deserializer.deserializeFromType(serialized, 'Amount');
+
+  expect(value).toBe(deserialized);
+});
+
 test('Bytes', () => {
   const serializer = new Serializer();
   const deserializer = new Deserializer();

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -190,5 +190,8 @@ test('Address', () => {
 
   const deserialized = deserializer.deserializeFromType(addressBuffer, 'Address');
 
-  expect(deserialized).toBe(address);
+  const wrongNetworkAddress = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
+  const wrongNetworkAddressBuffer = new Address(wrongNetworkAddress).decode();
+
+  expect(() => deserializer.deserializeFromType(wrongNetworkAddressBuffer, 'Address')).toThrow();
 });

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -7,6 +7,8 @@
 
 import Serializer from '../../src/nano_contracts/serializer';
 import Deserializer from '../../src/nano_contracts/deserializer';
+import Address from '../../src/models/address';
+import Network from '../../src/models/network';
 
 test('Bool', () => {
   const serializer = new Serializer();
@@ -177,4 +179,16 @@ test('Signed', () => {
   );
 
   expect(valueBoolTrue).toBe(deserializedBoolTrue);
+});
+
+test('Address', () => {
+  const network = new Network('testnet');
+  const deserializer = new Deserializer(network);
+
+  const address = 'WfthPUEecMNRs6eZ2m2EQBpVH6tbqQxYuU';
+  const addressBuffer = new Address(address).decode();
+
+  const deserialized = deserializer.deserializeFromType(addressBuffer, 'Address');
+
+  expect(deserialized).toBe(address);
 });

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -189,6 +189,7 @@ test('Address', () => {
   const addressBuffer = new Address(address).decode();
 
   const deserialized = deserializer.deserializeFromType(addressBuffer, 'Address');
+  expect(deserialized).toBe(address);
 
   const wrongNetworkAddress = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
   const wrongNetworkAddressBuffer = new Address(wrongNetworkAddress).decode();

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -23,9 +23,10 @@ import {
   NanoContractAction,
   MethodArgInfo,
   NanoContractArgumentApiInputType,
+  NanoContractArgumentType,
 } from './types';
 import ncApi from '../api/nano';
-import { validateBlueprintMethodArgs } from './utils';
+import { validateAndUpdateBlueprintMethodArgs } from './utils';
 
 class NanoContractTransactionBuilder {
   blueprintId: string | null | undefined;
@@ -39,7 +40,7 @@ class NanoContractTransactionBuilder {
 
   caller: Buffer | null;
 
-  args: NanoContractArgumentApiInputType[] | null;
+  args: NanoContractArgumentType[] | null;
 
   transaction: NanoContract | null;
 
@@ -299,7 +300,7 @@ class NanoContractTransactionBuilder {
     }
 
     // Validate if the arguments match the expected method arguments
-    await validateBlueprintMethodArgs(this.blueprintId, this.method, this.args);
+    await validateAndUpdateBlueprintMethodArgs(this.blueprintId, this.method, this.args);
 
     // Transform actions into inputs and outputs
     let inputs: Input[] = [];

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -9,6 +9,7 @@ import { bufferToHex, unpackToFloat, unpackToInt } from '../utils/buffer';
 import helpersUtils from '../utils/helpers';
 import Network from '../models/network';
 import { NanoContractArgumentType } from './types';
+import { OutputValueType } from '../types';
 
 class Deserializer {
   network: Network;
@@ -51,8 +52,9 @@ class Deserializer {
         return this.toAddress(value);
       case 'int':
       case 'Timestamp':
-      case 'Amount':
         return this.toInt(value);
+      case 'Amount':
+        return this.toAmount(value);
       case 'float':
         return this.toFloat(value);
       case 'bool':
@@ -98,6 +100,18 @@ class Deserializer {
    */
   toInt(value: Buffer): number {
     return unpackToInt(4, true, value)[0];
+  }
+
+  /**
+   * Deserialize amount value
+   *
+   * @param {value} Value to deserialize
+   *
+   * @memberof Deserializer
+   * @inner
+   */
+  toAmount(value: Buffer): OutputValueType {
+    return this.toInt(value);
   }
 
   /**

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -214,7 +214,9 @@ class Deserializer {
     const address = helpersUtils.encodeAddress(addressBytes, this.network);
     const decoded = address.decode();
     if (decoded[0] !== value[0]) {
-      throw new Error(`Asked to deserialize an address with version byte ${value[0]} but the network from the deserializer object has version byte ${decoded[0]}.`);
+      throw new Error(
+        `Asked to deserialize an address with version byte ${value[0]} but the network from the deserializer object has version byte ${decoded[0]}.`
+      );
     }
     return address.base58;
   }

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -211,7 +211,12 @@ class Deserializer {
   toAddress(value: Buffer): string {
     // First we get the 20 bytes of the address without the version byte and checksum
     const addressBytes = value.slice(1, 21);
-    return helpersUtils.encodeAddress(addressBytes, this.network).base58;
+    const address = helpersUtils.encodeAddress(addressBytes, this.network);
+    const decoded = address.decode();
+    if (decoded[0] !== value[0]) {
+      throw new Error(`Asked to deserialize an address with version byte ${value[0]} but the network from the deserializer object has version byte ${decoded[0]}.`);
+    }
+    return address.base58;
   }
 }
 

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { bufferToHex, hexToBuffer, unpackToFloat, unpackToInt } from '../utils/buffer';
+import { bufferToHex, unpackToFloat, unpackToInt } from '../utils/buffer';
 import helpersUtils from '../utils/helpers';
 import Network from '../models/network';
 import { NanoContractArgumentType } from './types';

--- a/src/nano_contracts/parser.ts
+++ b/src/nano_contracts/parser.ts
@@ -30,7 +30,13 @@ class NanoContractTransactionParser {
 
   parsedArgs: NanoContractParsedArgument[] | null;
 
-  constructor(blueprintId: string, method: string, publicKey: string, network: Network, args: string | null) {
+  constructor(
+    blueprintId: string,
+    method: string,
+    publicKey: string,
+    network: Network,
+    args: string | null
+  ) {
     this.blueprintId = blueprintId;
     this.method = method;
     this.publicKey = publicKey;

--- a/src/nano_contracts/parser.ts
+++ b/src/nano_contracts/parser.ts
@@ -22,17 +22,20 @@ class NanoContractTransactionParser {
 
   publicKey: string;
 
+  network: Network;
+
   address: Address | null;
 
   args: string | null;
 
   parsedArgs: NanoContractParsedArgument[] | null;
 
-  constructor(blueprintId: string, method: string, publicKey: string, args: string | null) {
+  constructor(blueprintId: string, method: string, publicKey: string, network: Network, args: string | null) {
     this.blueprintId = blueprintId;
     this.method = method;
     this.publicKey = publicKey;
     this.args = args;
+    this.network = network;
     this.address = null;
     this.parsedArgs = null;
   }
@@ -43,8 +46,8 @@ class NanoContractTransactionParser {
    * @memberof NanoContractTransactionParser
    * @inner
    */
-  parseAddress(network: Network) {
-    this.address = getAddressFromPubkey(this.publicKey, network);
+  parseAddress() {
+    this.address = getAddressFromPubkey(this.publicKey, this.network);
   }
 
   /**
@@ -59,7 +62,7 @@ class NanoContractTransactionParser {
       return;
     }
 
-    const deserializer = new Deserializer();
+    const deserializer = new Deserializer(this.network);
     // Get the blueprint data from full node
     const blueprintInformation = await ncApi.getBlueprintInformation(this.blueprintId);
     if (!has(blueprintInformation, `public_methods.${this.method}`)) {

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -7,6 +7,7 @@
 
 import { hexToBuffer, intToBytes, floatToBytes, signedIntToBytes } from '../utils/buffer';
 import { NanoContractArgumentType } from './types';
+import { OutputValueType } from '../types';
 
 // Number of bytes used to serialize the size of the value
 const SERIALIZATION_SIZE_LEN = 2;
@@ -60,9 +61,10 @@ class Serializer {
       case 'TokenUid':
         return this.fromBytes(value as Buffer);
       case 'int':
-      case 'Amount':
       case 'Timestamp':
         return this.fromInt(value as number);
+      case 'Amount':
+        return this.fromAmount(value as OutputValueType);
       case 'float':
         return this.fromFloat(value as number);
       case 'bool':
@@ -106,6 +108,21 @@ class Serializer {
    */
   fromInt(value: number): Buffer {
     return signedIntToBytes(value, 4);
+  }
+
+  /**
+   * Serialize amount value
+   *
+   * @param {value} Value to serialize
+   *
+   * @memberof Serializer
+   * @inner
+   */
+  fromAmount(value: OutputValueType): Buffer {
+    // For now, this method is the same as fromInt
+    // but we are making it clear that it should be handled
+    // as an OutputValueType when we refactor it
+    return this.fromInt(value);
   }
 
   /**

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -54,8 +54,14 @@ class Serializer {
       case 'str':
         return this.fromString(value as string);
       case 'bytes':
+      case 'Address':
+      case 'VertexId':
+      case 'TxOutputScript':
+      case 'TokenUid':
         return this.fromBytes(value as Buffer);
       case 'int':
+      case 'Amount':
+      case 'Timestamp':
         return this.fromInt(value as number);
       case 'float':
         return this.fromFloat(value as number);

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -11,7 +11,7 @@ export enum NanoContractActionType {
   WITHDRAWAL = 'withdrawal',
 }
 
-export type NanoContractArgumentApiInputType = string | number | boolean | null;
+export type NanoContractArgumentApiInputType = string | number | OutputValueType | boolean | null;
 export type NanoContractArgumentType = NanoContractArgumentApiInputType | Buffer;
 
 export interface NanoContractAction {

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -22,7 +22,7 @@ import { NanoContractTransactionError, OracleParseError, WalletFromXPubGuard } f
 import { OutputType } from '../wallet/types';
 import { IHistoryTx, IStorage } from '../types';
 import { parseScript } from '../utils/scripts';
-import { MethodArgInfo } from './types';
+import { MethodArgInfo, NanoContractArgumentType } from './types';
 import { NANO_CONTRACTS_VERSION, NANO_CONTRACTS_INITIALIZE_METHOD } from '../constants';
 
 /**
@@ -121,6 +121,9 @@ export const getOracleInputData = async (
 
 /**
  * Validate if nano contracts arguments match the expected ones from the blueprint method
+ * It also converts arguments that come from clients in a different type than the expected,
+ * e.g., bytes come as hexadecimal strings and address (bytes) come as base58 string.
+ * We convert them to the expected type and update the original array of arguments
  *
  * @param blueprintId Blueprint ID
  * @param method Method name
@@ -131,7 +134,7 @@ export const getOracleInputData = async (
  * @throws NanoContractTransactionError in case the arguments are not valid
  * @throws NanoRequest404Error in case the blueprint ID does not exist on the full node
  */
-export const validateBlueprintMethodArgs = async (blueprintId, method, args): Promise<void> => {
+export const validateAndUpdateBlueprintMethodArgs = async (blueprintId: string, method: string, args: NanoContractArgumentType[] | null): Promise<void> => {
   // Get the blueprint data from full node
   const blueprintInformation = await ncApi.getBlueprintInformation(blueprintId);
 
@@ -144,8 +147,9 @@ export const validateBlueprintMethodArgs = async (blueprintId, method, args): Pr
     throw new NanoContractTransactionError(`Blueprint does not have method ${method}.`);
   }
 
-  // Args may come as undefined
-  const argsLen = args ? args.length : 0;
+  // Args may come as undefined or null
+  args = args ?? [];
+  const argsLen = args.length;
   if (argsLen !== methodArgs.length) {
     throw new NanoContractTransactionError(
       `Method needs ${methodArgs.length} parameters but data has ${args.length}.`
@@ -154,6 +158,10 @@ export const validateBlueprintMethodArgs = async (blueprintId, method, args): Pr
 
   // Here we validate that the arguments sent in the data array of args has
   // the expected type for each parameter of the blueprint method
+  // Besides that, there are arguments that come from the clients in a different way
+  // that we expect, e.g. the bytes arguments come as hexadecimal, and the address
+  // arguments come as base58 strings, so we converts them and update the original
+  // array of arguments with the expected type
   for (const [index, arg] of methodArgs.entries()) {
     let typeToCheck = arg.type;
     if (typeToCheck.startsWith('SignedData')) {
@@ -163,19 +171,24 @@ export const validateBlueprintMethodArgs = async (blueprintId, method, args): Pr
     }
     switch (typeToCheck) {
       case 'bytes':
+      case 'TxOutputScript':
+      case 'TokenUid':
+      case 'VertexId':
         // Bytes arguments are sent in hexadecimal
         try {
           // eslint-disable-next-line no-param-reassign
-          args[index] = hexToBuffer(args[index]);
+          args[index] = hexToBuffer(args[index] as string);
         } catch {
           // Data sent is not a hex
           throw new NanoContractTransactionError(
-            `Invalid hexadecimal for argument number ${index + 1}.`
+            `Invalid hexadecimal for argument number ${index + 1} for type ${arg.type}.`
           );
         }
         break;
       case 'int':
       case 'float':
+      case 'Amount':
+      case 'Timestamp':
         if (typeof args[index] !== 'number') {
           throw new NanoContractTransactionError(
             `Expects argument number ${index + 1} type ${arg.type} but received type ${typeof args[index]}.`
@@ -186,6 +199,25 @@ export const validateBlueprintMethodArgs = async (blueprintId, method, args): Pr
         if (typeof args[index] !== 'string') {
           throw new NanoContractTransactionError(
             `Expects argument number ${index + 1} type ${arg.type} but received type ${typeof args[index]}.`
+          );
+        }
+        break;
+      case 'Address':
+        const argValue = args[index];
+        if (typeof argValue !== 'string') {
+          throw new NanoContractTransactionError(
+            `Expects argument number ${index + 1} type ${arg.type} but received type ${typeof argValue}.`
+          );
+        }
+
+        try {
+          const address = new Address(argValue as string);
+          address.validateAddress();
+          args[index] = address.decode();
+        } catch {
+          // Argument value is not a valid address
+          throw new NanoContractTransactionError(
+            `Argument ${argValue} is not a valid base58 address.`
           );
         }
         break;

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -152,7 +152,16 @@ export const validateAndUpdateBlueprintMethodArgs = async (
   }
 
   // Args may come as undefined or null
-  args = args ?? [];
+  if (args == null) {
+    if (methodArgs.length !== 0) {
+      throw new NanoContractTransactionError(
+        `Method needs ${methodArgs.length} parameters but no arguments were received.`
+      );
+    }
+
+    return;
+  }
+
   const argsLen = args.length;
   if (argsLen !== methodArgs.length) {
     throw new NanoContractTransactionError(
@@ -206,7 +215,9 @@ export const validateAndUpdateBlueprintMethodArgs = async (
           );
         }
         break;
-      case 'Address':
+      // Creating a block {} in the case below
+      // because we can't create a variable without it (linter - no-case-declarations)
+      case 'Address': {
         const argValue = args[index];
         if (typeof argValue !== 'string') {
           throw new NanoContractTransactionError(
@@ -217,6 +228,7 @@ export const validateAndUpdateBlueprintMethodArgs = async (
         try {
           const address = new Address(argValue as string);
           address.validateAddress();
+          // eslint-disable-next-line no-param-reassign
           args[index] = address.decode();
         } catch {
           // Argument value is not a valid address
@@ -225,6 +237,7 @@ export const validateAndUpdateBlueprintMethodArgs = async (
           );
         }
         break;
+      }
       default:
         // eslint-disable-next-line valid-typeof -- This rule is not suited for dynamic comparisons such as this one
         if (arg.type !== typeof args[index]) {

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -134,7 +134,11 @@ export const getOracleInputData = async (
  * @throws NanoContractTransactionError in case the arguments are not valid
  * @throws NanoRequest404Error in case the blueprint ID does not exist on the full node
  */
-export const validateAndUpdateBlueprintMethodArgs = async (blueprintId: string, method: string, args: NanoContractArgumentType[] | null): Promise<void> => {
+export const validateAndUpdateBlueprintMethodArgs = async (
+  blueprintId: string,
+  method: string,
+  args: NanoContractArgumentType[] | null
+): Promise<void> => {
   // Get the blueprint data from full node
   const blueprintInformation = await ncApi.getBlueprintInformation(blueprintId);
 


### PR DESCRIPTION
### Context

There are nano contract method arguments and attributes that have specific types and we can improve user usability of the clients when considering them. For example, an address is decoded in bytes but if we know that the argument is an address we can validate it better and expect in the clients a base58 string instead of a hexadecimal of the decoded address.

In this PR we will consider the new types as following:

bytes: `TxOutputScript`, `TokenUid`, `VertexId`, and `Address`
int: `Timestamp` and `Amount`

Even though there are no differences when serializing/deserializing a Timestamp/Amount from a normal integer, we can use this information to create the UI in a way that is more user friendly.

### Acceptance Criteria
- Consider new custom types when serializing/deserializing data for nano contract.
- Accept address as a base58 string in the nano contract builder.
- Use new nano hathor core experimental image to validate the integration tests

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
