### PR TITLE
feat: update nano hathor core URL for blueprint info endpoint

### DIFF
--- a/src/api/nano.ts
+++ b/src/api/nano.ts
@@ -112,7 +112,7 @@ const ncApi = {
     const data = { blueprint_id: id };
     const axiosInstance = await createRequestInstance();
     try {
-      const response = await axiosInstance.get(`nano_contract/blueprint`, { params: data });
+      const response = await axiosInstance.get(`nano_contract/blueprint/info`, { params: data });
       const responseData = response.data;
       if (response.status === 200) {
         return responseData;


### PR DESCRIPTION
### Context

When I was creating a new API in the hathor core to get the blueprint source code, I had a discussion with @msbrogli about the best path for it. We ended up deciding to use `/blueprint/source` and, to keep consistency, we changed `/blueprint` (which returned the blueprint information) to `/blueprint/info`.

We decided to do it now that we don't have many clients using it and we can quickly update the lib and wallets with this new version. 

### Acceptance Criteria
- Update blueprint information endpoint URL from hathor core

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
