### PR TITLE
feat: add new nano contract type contractId

### DIFF
--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -67,6 +67,26 @@ test('Bytes', () => {
   const deserialized = deserializer.deserializeFromType(serialized, 'bytes');
 
   expect(value.equals(deserialized)).toBe(true);
+
+  const serializedVertex = serializer.serializeFromType(value, 'VertexId');
+  const deserializedVertex = deserializer.deserializeFromType(serialized, 'VertexId');
+
+  expect(value.equals(deserializedVertex)).toBe(true);
+
+  const serializedToken = serializer.serializeFromType(value, 'TokenUid');
+  const deserializedToken = deserializer.deserializeFromType(serialized, 'TokenUid');
+
+  expect(value.equals(deserializedToken)).toBe(true);
+
+  const serializedScript = serializer.serializeFromType(value, 'TxOutputScript');
+  const deserializedScript = deserializer.deserializeFromType(serialized, 'TxOutputScript');
+
+  expect(value.equals(deserializedScript)).toBe(true);
+
+  const serializedContract = serializer.serializeFromType(value, 'ContractId');
+  const deserializedContract = deserializer.deserializeFromType(serialized, 'ContractId');
+
+  expect(value.equals(deserializedContract)).toBe(true);
 });
 
 test('Float', () => {

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -69,22 +69,22 @@ test('Bytes', () => {
   expect(value.equals(deserialized)).toBe(true);
 
   const serializedVertex = serializer.serializeFromType(value, 'VertexId');
-  const deserializedVertex = deserializer.deserializeFromType(serialized, 'VertexId');
+  const deserializedVertex = deserializer.deserializeFromType(serializedVertex, 'VertexId');
 
   expect(value.equals(deserializedVertex)).toBe(true);
 
   const serializedToken = serializer.serializeFromType(value, 'TokenUid');
-  const deserializedToken = deserializer.deserializeFromType(serialized, 'TokenUid');
+  const deserializedToken = deserializer.deserializeFromType(serializedToken, 'TokenUid');
 
   expect(value.equals(deserializedToken)).toBe(true);
 
   const serializedScript = serializer.serializeFromType(value, 'TxOutputScript');
-  const deserializedScript = deserializer.deserializeFromType(serialized, 'TxOutputScript');
+  const deserializedScript = deserializer.deserializeFromType(serializedScript, 'TxOutputScript');
 
   expect(value.equals(deserializedScript)).toBe(true);
 
   const serializedContract = serializer.serializeFromType(value, 'ContractId');
-  const deserializedContract = deserializer.deserializeFromType(serialized, 'ContractId');
+  const deserializedContract = deserializer.deserializeFromType(serializedContract, 'ContractId');
 
   expect(value.equals(deserializedContract)).toBe(true);
 });

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -46,6 +46,7 @@ class Deserializer {
       case 'bytes':
       case 'TxOutputScript':
       case 'TokenUid':
+      case 'ContractId':
       case 'VertexId':
         return this.toBytes(value);
       case 'Address':

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -57,6 +57,7 @@ class Serializer {
       case 'bytes':
       case 'Address':
       case 'VertexId':
+      case 'ContractId':
       case 'TxOutputScript':
       case 'TokenUid':
         return this.fromBytes(value as Buffer);

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -186,6 +186,7 @@ export const validateAndUpdateBlueprintMethodArgs = async (
       case 'bytes':
       case 'TxOutputScript':
       case 'TokenUid':
+      case 'ContractId':
       case 'VertexId':
         // Bytes arguments are sent in hexadecimal
         try {


### PR DESCRIPTION
### Acceptance Criteria
- Add new nano contract type `ContractId` as `bytes` in the Serializer and Deserializer
- Add tests for all contract types that are handled as bytes.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
