### PR TITLE
chore: upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -44,8 +44,8 @@ jobs:
 
       - name: Upload debug transaction logs
         if: always()
-        # https://github.com/actions/upload-artifact/releases/tag/v3.1.2
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        # https://github.com/actions/upload-artifact/releases/tag/v4.3.6
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a
         with:
           name: test-transacion-logs
           path: tmp
@@ -71,8 +71,8 @@ jobs:
 
       - name: Upload logs to GitHub
         if: failure()
-        # https://github.com/actions/upload-artifact/releases/tag/v3.1.2
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+        # https://github.com/actions/upload-artifact/releases/tag/v4.3.6
+        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a
         with:
           name: logs.tgz
           path: ./docker-logs.tgz


### PR DESCRIPTION
### Acceptance Criteria
- Upgrade upload-artifact to v4 which uses node20


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
