### PR TITLE
feat: move the history sort to the pre-process method

### DIFF
--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -11,7 +11,7 @@ import helpers from '../utils/helpers';
 import BaseConnection, { ConnectionParams } from '../connection';
 import { ConnectionState } from '../wallet/types';
 import { handleSubscribeAddress, handleWsDashboard } from '../utils/connection';
-import { IStorage, ILogger } from '../types';
+import { IStorage, ILogger, getDefaultLogger } from '../types';
 
 const STREAM_ABORT_TIMEOUT = 10000; // 10s
 
@@ -66,7 +66,10 @@ class WalletConnection extends BaseConnection {
       connectionTimeout?: number;
       wsURL: string;
       logger: ILogger;
-    } = { wsURL: helpers.getWSServerURL(this.currentServer), logger: options.logger };
+    } = {
+      wsURL: helpers.getWSServerURL(this.currentServer),
+      logger: options.logger || getDefaultLogger(),
+    };
 
     if (options.connectionTimeout) {
       wsOptions.connectionTimeout = options.connectionTimeout;

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -88,7 +88,7 @@ export default class LevelDBStore implements IStore {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async preProcess(): Promise<void> {
+  async preProcessHistory(): Promise<void> {
     // This is a noop since there are no pre-processing operations to do.
   }
 

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -87,6 +87,11 @@ export default class LevelDBStore implements IStore {
     await this.nanoContractIndex.validate();
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  async preProcess(): Promise<void> {
+    // This is a noop since there are no pre-processing operations to do.
+  }
+
   async *addressIter(): AsyncGenerator<IAddressInfo> {
     for await (const info of this.addressIndex.addressIter()) {
       yield info;

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -188,6 +188,13 @@ export class MemoryStore implements IStore {
     // This is a noop since the memory store always starts clean.
   }
 
+  /**
+   * Prepare the store for history processing.
+   */
+  async preProcess(): Promise<void> {
+    this.historyTs.sort();
+  }
+
   /** ADDRESSES */
 
   /**
@@ -407,14 +414,12 @@ export class MemoryStore implements IStore {
     // Protect ordering list from updates on the same transaction
     // We can check the historyTs but it's O(n) and this check is O(1).
     if (!this.history.has(tx.tx_id)) {
-      // Add transaction to the ordering list and sort it
+      // Add transaction to the ordering list
       // Wallets expect to show users the transactions in order of descending timestamp
       // This is so wallets can show the most recent transactions to users
-      // XXX: If this becomes a performance bottleneck we can either allow wallets to skip ordering
-      // or have the ordering be done during history processing so that
-      // we don't have to sort the list every time we add a new transaction
+      // The historyTs should be sorted to ensure the history order but this is not
+      // done here due to the performance bottleneck it creates on big wallets.
       this.historyTs.push(getOrderingKey(tx));
-      this.historyTs.sort();
     }
 
     this.history.set(tx.tx_id, tx);

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -191,7 +191,7 @@ export class MemoryStore implements IStore {
   /**
    * Prepare the store for history processing.
    */
-  async preProcess(): Promise<void> {
+  async preProcessHistory(): Promise<void> {
     this.historyTs.sort();
   }
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -40,7 +40,7 @@ import {
   getDefaultLogger,
 } from '../types';
 import transactionUtils from '../utils/transaction';
-import { processHistory, processUtxoUnlock } from '../utils/storage';
+import { processHistory as processHistoryUtil, processUtxoUnlock } from '../utils/storage';
 import config, { Config } from '../config';
 import { decryptData, checkPassword } from '../utils/crypto';
 import FullNodeConnection from '../new/connection';
@@ -355,7 +355,7 @@ export class Storage implements IStorage {
    */
   async processHistory(): Promise<void> {
     await this.store.preProcessHistory();
-    await processHistory(this, { rewardLock: this.version?.reward_spend_min_blocks });
+    await processHistoryUtil(this, { rewardLock: this.version?.reward_spend_min_blocks });
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -354,6 +354,7 @@ export class Storage implements IStorage {
    * @returns {Promise<void>}
    */
   async processHistory(): Promise<void> {
+    await this.store.preProcess();
     await processHistory(this, { rewardLock: this.version?.reward_spend_min_blocks });
   }
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -354,7 +354,7 @@ export class Storage implements IStorage {
    * @returns {Promise<void>}
    */
   async processHistory(): Promise<void> {
-    await this.store.preProcess();
+    await this.store.preProcessHistory();
     await processHistory(this, { rewardLock: this.version?.reward_spend_min_blocks });
   }
 

--- a/src/sync/stream.ts
+++ b/src/sync/stream.ts
@@ -420,7 +420,7 @@ function buildListener(manager: StreamManager, resolve: () => void) {
       manager.logger.error(`Stream error: ${wsData.errmsg}`);
       manager.abortWithError(wsData.errmsg);
     } else {
-      manager.logger.error(`Unknown event type ${wsData}`);
+      manager.logger.error(`Unknown event type ${JSON.stringify(wsData)}`);
     }
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,7 +394,7 @@ export interface ApiVersion {
 
 export interface IStore {
   validate(): Promise<void>;
-  preProcess(): Promise<void>;
+  preProcessHistory(): Promise<void>;
   // Address methods
   addressIter(): AsyncGenerator<IAddressInfo>;
   getAddress(base58: string): Promise<IAddressInfo | null>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -394,6 +394,7 @@ export interface ApiVersion {
 
 export interface IStore {
   validate(): Promise<void>;
+  preProcess(): Promise<void>;
   // Address methods
   addressIter(): AsyncGenerator<IAddressInfo>;
   getAddress(base58: string): Promise<IAddressInfo | null>;


### PR DESCRIPTION
### Acceptance Criteria
- Move the history sorting to before the processing

### Impact

It was tested loading a wallet with almost 400k transactions, the load time went from 40 minutes using the normal stream to 1 and a half minute.
This is because this change is only really impactful on wallets with over 20k transactions where each sorting becomes slow enough to impact the sync prrocess.

### Other changes

- Fix Websocket logger argument being undefined.
- When logging an unknown stream message, show the contents

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
