### PR TITLE
feat: global load lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "level": "8.0.1",
         "lodash": "4.17.21",
         "long": "5.2.3",
+        "queue-promise": "^2.2.1",
         "ws": "8.17.1"
       },
       "devDependencies": {
@@ -9801,6 +9802,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-promise": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/queue-promise/-/queue-promise-2.2.1.tgz",
+      "integrity": "sha512-C3eyRwLF9m6dPV4MtqMVFX+Xmc7keZ9Ievm3jJ/wWM5t3uVbFnGsJXwpYzZ4LaIEcX9bss/mdaKzyrO6xheRuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.12.0"
+      }
     },
     "node_modules/react-is": {
       "version": "18.3.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "level": "8.0.1",
     "lodash": "4.17.21",
     "long": "5.2.3",
+    "queue-promise": "^2.2.1",
     "ws": "8.17.1"
   },
   "scripts": {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -387,7 +387,7 @@ export class OracleParseError extends Error {
   errorCode: string = ErrorMessages.NANO_ORACLE_PARSE_ERROR;
 }
 
-export class GllTaskError extends Error {
+export class GlobalLoadLockTaskError extends Error {
   taskId: string;
 
   innerError: Error;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -386,3 +386,15 @@ export class NanoContractTransactionParseError extends Error {
 export class OracleParseError extends Error {
   errorCode: string = ErrorMessages.NANO_ORACLE_PARSE_ERROR;
 }
+
+export class GllTaskError extends Error {
+  taskId: string;
+
+  innerError: Error;
+
+  constructor(taskId: string, innerError: Error) {
+    super(`${taskId} has failed with ${innerError}`);
+    this.taskId = taskId;
+    this.innerError = innerError;
+  }
+}

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2860,13 +2860,7 @@ class HathorWallet extends EventEmitter {
     }
     const syncMethod = getHistorySyncMethod(this.historySyncMode);
     await addTask(async () => {
-      await syncMethod(
-        startIndex,
-        count,
-        this.storage,
-        this.conn,
-        shouldProcessHistory
-      );
+      await syncMethod(startIndex, count, this.storage, this.conn, shouldProcessHistory);
     }, this.logger);
   }
 

--- a/src/sync/gll.ts
+++ b/src/sync/gll.ts
@@ -1,0 +1,67 @@
+import PQueue from 'queue-promise';
+import { ILogger } from '../types';
+
+let GLL = new PQueue({ concurrent: 2 });
+
+export function setConcurrency(value: number) {
+  GLL = new PQueue({ concurrent: value });
+}
+
+export function addTask(task: () => Promise<void>, logger: ILogger) {
+  const taskId = Math.random().toString(36).substring(2, 15);
+  const startTime = Date.now();
+  const promise = new Promise<void>((resolve, reject) => {
+    GLL.on('resolve', (data) => {
+      if (data === taskId) {
+        resolve();
+      }
+    });
+
+    GLL.on('reject', (data) => {
+      if (data.taskId === taskId) {
+        reject(data.error);
+      }
+    });
+  });
+
+  GLL.enqueue(async () => {
+    try {
+      logger.info(`Task waited on queue for ${(Date.now() - startTime)/1000}s`);
+      await task();
+      return taskId;
+    } catch(error) {
+      throw {
+        taskId,
+        error,
+      };
+    }
+  });
+
+  return promise;
+}
+
+// export async function gll() {
+//   const p1 = addTask(async () => {
+//     console.log('p1 started!');
+//     return new Promise(resolve => {
+//       setTimeout(resolve, 2000);
+//     });
+//   });
+
+//   const p2 = addTask(async () => {
+//     console.log('p2 started!');
+//     return new Promise(resolve => {
+//       setTimeout(resolve, 2000);
+//     });
+//   });
+
+//   const p3 = addTask(async () => {
+//     console.log('p3 started!');
+//     return new Promise(resolve => {
+//       setTimeout(resolve, 2000);
+//     });
+//   });
+
+//   await Promise.all([p1, p2, p3]);
+//   console.log('finished');
+// }

--- a/src/sync/gll.ts
+++ b/src/sync/gll.ts
@@ -1,16 +1,20 @@
 import PQueue from 'queue-promise';
 import { ILogger } from '../types';
-import { GllTaskError } from '../errors';
+import { GlobalLoadLockTaskError } from '../errors';
 
-let GLL = new PQueue({ concurrent: 5 });
+const MAX_CONCURRENT_LOAD_TASKS = 5;
 
-export function setConcurrency(value: number) {
-  GLL = new PQueue({ concurrent: value });
-}
+const GLL = new PQueue({ concurrent: MAX_CONCURRENT_LOAD_TASKS });
 
+/**
+ * Add task to the GLL and return a promise that will resolve or reject when the task resolves or rejects.
+ * @param task The task to execute.
+ * @param logger Logger instance to use.
+ */
 export function addTask(task: () => Promise<void>, logger: ILogger) {
   const taskId = Math.random().toString(36).substring(2, 15);
   const startTime = Date.now();
+  // This promise will resolve or reject when the task does, so the caller can know his task has ended.
   const promise = new Promise<void>((resolve, reject) => {
     GLL.on('resolve', data => {
       if (data === taskId) {
@@ -25,6 +29,10 @@ export function addTask(task: () => Promise<void>, logger: ILogger) {
     });
   });
 
+  /**
+   * Add the task to the queue and return or rejects with the taskId
+   * So the promise above can detect any issues and reject correctly.
+   */
   GLL.enqueue(async () => {
     try {
       logger.info(`Task waited on queue for ${(Date.now() - startTime) / 1000}s`);
@@ -32,9 +40,9 @@ export function addTask(task: () => Promise<void>, logger: ILogger) {
       return taskId;
     } catch (error: unknown) {
       if (error instanceof Error) {
-        throw new GllTaskError(taskId, error);
+        throw new GlobalLoadLockTaskError(taskId, error);
       }
-      throw new GllTaskError(taskId, new Error(`${error}`));
+      throw new GlobalLoadLockTaskError(taskId, new Error(`${error}`));
     }
   });
 

--- a/src/sync/gll.ts
+++ b/src/sync/gll.ts
@@ -1,5 +1,6 @@
 import PQueue from 'queue-promise';
 import { ILogger } from '../types';
+import { GllTaskError } from '../errors';
 
 let GLL = new PQueue({ concurrent: 5 });
 
@@ -11,29 +12,29 @@ export function addTask(task: () => Promise<void>, logger: ILogger) {
   const taskId = Math.random().toString(36).substring(2, 15);
   const startTime = Date.now();
   const promise = new Promise<void>((resolve, reject) => {
-    GLL.on('resolve', (data) => {
+    GLL.on('resolve', data => {
       if (data === taskId) {
         resolve();
       }
     });
 
-    GLL.on('reject', (data) => {
+    GLL.on('reject', data => {
       if (data.taskId === taskId) {
-        reject(data.error);
+        reject(data.innerError);
       }
     });
   });
 
   GLL.enqueue(async () => {
     try {
-      logger.info(`Task waited on queue for ${(Date.now() - startTime)/1000}s`);
+      logger.info(`Task waited on queue for ${(Date.now() - startTime) / 1000}s`);
       await task();
       return taskId;
-    } catch(error) {
-      throw {
-        taskId,
-        error,
-      };
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        throw new GllTaskError(taskId, error);
+      }
+      throw new GllTaskError(taskId, new Error(`${error}`));
     }
   });
 

--- a/src/sync/gll.ts
+++ b/src/sync/gll.ts
@@ -1,7 +1,7 @@
 import PQueue from 'queue-promise';
 import { ILogger } from '../types';
 
-let GLL = new PQueue({ concurrent: 2 });
+let GLL = new PQueue({ concurrent: 5 });
 
 export function setConcurrency(value: number) {
   GLL = new PQueue({ concurrent: value });
@@ -39,29 +39,3 @@ export function addTask(task: () => Promise<void>, logger: ILogger) {
 
   return promise;
 }
-
-// export async function gll() {
-//   const p1 = addTask(async () => {
-//     console.log('p1 started!');
-//     return new Promise(resolve => {
-//       setTimeout(resolve, 2000);
-//     });
-//   });
-
-//   const p2 = addTask(async () => {
-//     console.log('p2 started!');
-//     return new Promise(resolve => {
-//       setTimeout(resolve, 2000);
-//     });
-//   });
-
-//   const p3 = addTask(async () => {
-//     console.log('p3 started!');
-//     return new Promise(resolve => {
-//       setTimeout(resolve, 2000);
-//     });
-//   });
-
-//   await Promise.all([p1, p2, p3]);
-//   console.log('finished');
-// }


### PR DESCRIPTION
### Acceptance Criteria
- Create a global load lock (GLL).
- GLL should only allow 5 wallets to load concurrently at any time.
- Any wallets trying to sync the history should wait on the GLL for their turn.
- Log time wallets waited on GLL to start syncing.

### How

The GLL is an instance of a promise queue, meaning it runs the tasks on queue but only allow a number of concurrent runs.
For instance 5 concurrent tasks, meaning only 5 wallets can load at any given time.

The `syncHistory` method of the wallet now just uses the `addTask` to enqueue the actual history sync
```js
  async syncHistory(startIndex, count, shouldProcessHistory = false) {
    if (!(await getSupportedSyncMode(this.storage)).includes(this.historySyncMode)) {
      throw new Error('Trying to use an unsupported sync method for this wallet.');
    }
    const syncMethod = getHistorySyncMethod(this.historySyncMode);
    await addTask(async () => {
      await syncMethod(startIndex, count, this.storage, this.conn, shouldProcessHistory);
    }, this.logger);
  }
```

```js
wallet0.syncHistory(0, 20);
wallet1.syncHistory(0, 20);
wallet2.syncHistory(0, 20);
wallet3.syncHistory(0, 20);
wallet4.syncHistory(0, 20);
// This next one will only start when one of the previous finishes
wallet5.syncHistory(0, 20);
```

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
