### PR TITLE
Change listener to be used only once

### DIFF
--- a/src/sync/gll.ts
+++ b/src/sync/gll.ts
@@ -8,10 +8,20 @@ const MAX_CONCURRENT_LOAD_TASKS = 3;
 const GLL = new PQueue({ concurrent: MAX_CONCURRENT_LOAD_TASKS });
 const GLLEvents = new EventEmitter();
 
+/**
+ * PQueue will emit a `resolve` event when a task is resolved.
+ * The data will be the taskId since our tasks always resolve with the taskId.
+ * We then emit another event on GLLEvents specially for this taskId.
+ */
 GLL.on('resolve', data => {
   GLLEvents.emit(data, true);
 });
 
+/**
+ * PQueue will emit a `reject` event when a task is rejected.
+ * The data will be the taskId and the error since our tasks always reject with them.
+ * We then emit another event on GLLEvents specially for this taskId.
+ */
 GLL.on('reject', data => {
   GLLEvents.emit(data.taskId, false, data.innerError);
 });

--- a/src/sync/gll.ts
+++ b/src/sync/gll.ts
@@ -26,7 +26,7 @@ export function addTask(task: () => Promise<void>, logger: ILogger) {
   const startTime = Date.now();
   // This promise will resolve or reject when the task does, so the caller can know his task has ended.
   const promise = new Promise<void>((resolve, reject) => {
-   GLLEvents.once(taskId, (success, error) => {
+    GLLEvents.once(taskId, (success, error) => {
       if (success) {
         resolve();
       } else {


### PR DESCRIPTION
### Acceptance Criteria

- Create an event emitter that emits an event with the taskId as a name to avoid multiple listeners on the same event name
- Use once so listeners are cleaned automa

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
