### PR TITLE
feat: treat streaming edge cases

### DIFF
--- a/__tests__/stream.test.ts
+++ b/__tests__/stream.test.ts
@@ -138,6 +138,7 @@ async function startWalletFor(mode) {
     servers: ['http://localhost:8080/v1a'],
     logger: getDefaultLogger(),
   });
+  connection.capabilities = ['history-streaming'];
   if (connection.websocket === null) {
     throw new Error('Invalid websocket instance');
   }

--- a/__tests__/stream.test.ts
+++ b/__tests__/stream.test.ts
@@ -287,12 +287,12 @@ describe('Websocket stream history sync', () => {
     const wallet = await startWalletFor(HistorySyncMode.MANUAL_STREAM_WS);
     wallet.conn.on('stream', data => {
       // Any stream event should fail the test
-      fail(`Received a stream event: ${JSON.stringify(data)}`);
+      throw new Error(`Received a stream event: ${JSON.stringify(data)}`);
     });
     wallet.on('state', state => {
       // If the sync fails, fail the test
       if (state === HathorWallet.ERROR) {
-        fail('Wallet reached an error state');
+        throw new Error('Wallet reached an error state');
       }
     });
     try {
@@ -309,5 +309,9 @@ describe('Websocket stream history sync', () => {
       await wallet.stop({ cleanStorage: true, cleanAddresses: true });
       mockServer.stop();
     }
+
+    await expect(wallet.getAddressAtIndex(0)).resolves.toEqual(
+      'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN'
+    );
   }, 10000);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "level": "8.0.1",
         "lodash": "4.17.21",
         "long": "5.2.3",
+        "queue-microtask": "^1.2.3",
         "queue-promise": "^2.2.1",
         "ws": "8.17.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "level": "8.0.1",
         "lodash": "4.17.21",
         "long": "5.2.3",
-        "queue-microtask": "^1.2.3",
+        "queue-microtask": "1.2.3",
         "ws": "8.17.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "level": "8.0.1",
     "lodash": "4.17.21",
     "long": "5.2.3",
+    "queue-microtask": "^1.2.3",
     "queue-promise": "^2.2.1",
     "ws": "8.17.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "level": "8.0.1",
     "lodash": "4.17.21",
     "long": "5.2.3",
-    "queue-microtask": "^1.2.3",
+    "queue-microtask": "1.2.3",
     "ws": "8.17.1"
   },
   "scripts": {

--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -14,6 +14,7 @@ import { handleSubscribeAddress, handleWsDashboard } from '../utils/connection';
 import { IStorage, ILogger, getDefaultLogger } from '../types';
 
 const STREAM_ABORT_TIMEOUT = 10000; // 10s
+const CAPABILITIES_WAIT_TIMEOUT = 2000 // 2s
 
 /**
  * Event names for requesting stream from fullnode
@@ -133,7 +134,7 @@ class WalletConnection extends BaseConnection {
     if (this.capabilities === undefined) {
       // Wait 2s so the fullnode has some time to send the capabilities envent
       await new Promise<void>(resolve => {
-        setTimeout(resolve, 2000);
+        setTimeout(resolve, CAPABILITIES_WAIT_TIMEOUT);
       });
     }
   }

--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -127,10 +127,23 @@ class WalletConnection extends BaseConnection {
   }
 
   /**
+   * If the fullnode has not sent the capabilities yet wait a while.
+   */
+  async waitCapabilities() {
+    if (this.capabilities === undefined) {
+      // Wait 2s so the fullnode has some time to send the capabilities envent
+      await new Promise<void>(resolve => {
+        setTimeout(resolve, 2000);
+      });
+    }
+  }
+
+  /**
    * Check if the connected fullnode has the desired capability.
    * Will return false if the fullnode has not yet sent the capability list.
    */
-  hasCapability(flag: FullnodeCapability) {
+  async hasCapability(flag: FullnodeCapability) {
+    await this.waitCapabilities();
     if (!this.capabilities) {
       return false;
     }

--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -117,7 +117,7 @@ class WalletConnection extends BaseConnection {
   /**
    * Handle the capabilities event from the websocket.
    */
-  handleCapabilities(data: { type: string, capabilities: FullnodeCapability[]}) {
+  handleCapabilities(data: { type: string; capabilities: FullnodeCapability[] }) {
     this.logger.debug(`Fullnode has capabilities: ${JSON.stringify(data.capabilities)}`);
     const { capabilities } = data;
     if (!capabilities) {

--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -14,7 +14,7 @@ import { handleSubscribeAddress, handleWsDashboard } from '../utils/connection';
 import { IStorage, ILogger, getDefaultLogger } from '../types';
 
 const STREAM_ABORT_TIMEOUT = 10000; // 10s
-const CAPABILITIES_WAIT_TIMEOUT = 2000 // 2s
+const CAPABILITIES_WAIT_TIMEOUT = 2000; // 2s
 
 /**
  * Event names for requesting stream from fullnode

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1452,7 +1452,7 @@ class HathorWallet extends EventEmitter {
     if (info.network.indexOf(this.conn.network) >= 0) {
       this.storage.setApiVersion(info);
       await this.storage.saveNativeToken();
-      this.conn.start(); // XXX: maybe await?
+      this.conn.start();
     } else {
       this.setState(HathorWallet.CLOSED);
       throw new Error(`Wrong network. server=${info.network} expected=${this.conn.network}`);

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2862,14 +2862,17 @@ class HathorWallet extends EventEmitter {
       throw new Error('Trying to use an unsupported sync method for this wallet.');
     }
     let syncMode = this.historySyncMode;
-    if ([
-      HistorySyncMode.MANUAL_STREAM_WS,
-      HistorySyncMode.XPUB_STREAM_WS,
-    ].includes(this.historySyncMode)
-    && !(await this.conn.hasCapability('history-streaming'))) {
+    if (
+      [HistorySyncMode.MANUAL_STREAM_WS, HistorySyncMode.XPUB_STREAM_WS].includes(
+        this.historySyncMode
+      ) &&
+      !(await this.conn.hasCapability('history-streaming'))
+    ) {
       // History sync mode is streaming but fullnode is not streaming capable.
       // We revert to the http polling default.
-      this.logger.debug('Either fullnode does not support history-streaming or has not sent a capabilities event');
+      this.logger.debug(
+        'Either fullnode does not support history-streaming or has not sent a capabilities event'
+      );
       this.logger.debug('Falling back to http polling API');
       syncMode = HistorySyncMode.POLLING_HTTP_API;
     }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -2879,7 +2879,7 @@ class HathorWallet extends EventEmitter {
     const syncMethod = getHistorySyncMethod(syncMode);
     // This will add the task to the GLL queue and return a promise that
     // resolves when the task finishes executing
-    await addTask(async () => {
+    await GLL.add(async () => {
       await syncMethod(startIndex, count, this.storage, this.conn, shouldProcessHistory);
     });
   }

--- a/src/sync/stream.ts
+++ b/src/sync/stream.ts
@@ -427,12 +427,6 @@ export class StreamManager extends AbortController {
       throw new Error('No abort controller on connection');
     }
 
-    // The connection with the fullnode may have been lost during the time waiting to sync
-    if (signal.aborted) {
-      this.abort();
-      throw new Error('The connection already aborted this stream');
-    }
-
     signal.addEventListener(
       'abort',
       () => {

--- a/src/sync/stream.ts
+++ b/src/sync/stream.ts
@@ -428,7 +428,7 @@ export class StreamManager extends AbortController {
     }
 
     // The connection with the fullnode may have been lost during the time waiting to sync
-    if(signal.aborted) {
+    if (signal.aborted) {
       this.abort();
       throw new Error('The connection already aborted this stream');
     }
@@ -570,7 +570,7 @@ export class StreamManager extends AbortController {
        * and other async code to run before we continue processing our event queue.
        * @see https://www.npmjs.com/package/queue-microtask
        */
-      new Promise<void>(resolve => {
+      await new Promise<void>(resolve => {
         queueMicrotask(resolve);
       });
     }


### PR DESCRIPTION
### Acceptance Criteria

- During history stream queue processing, await the end of JS tasks execution at the end of each loop
  - This will make IO tasks and other tasks free to run so the queue processing does not block the main loop.
- If a sync is aborted while it waits for execution, we should abort as soon as possible to avoid executing needlessly.
- Save the capabilities set from the fullnode and check if the fullnode is history-streaming capable.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
