### PR TITLE
fix: selected_as_input ttl

### DIFF
--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -25,7 +25,7 @@ import {
 import * as cryptoUtils from '../../src/utils/crypto';
 import { InvalidPasswdError } from '../../src/errors';
 import Network from '../../src/models/network';
-import { ILockedUtxo, IUtxo, OutputValueType, WALLET_FLAGS } from '../../src/types';
+import { IHistoryTx, ILockedUtxo, IUtxo, IUtxoId, OutputValueType, WALLET_FLAGS } from '../../src/types';
 
 const DATA_DIR = './testdata.leveldb';
 
@@ -362,7 +362,7 @@ test('selecting utxos', async () => {
   const options = {
     filter_method: utxo => utxo.txId === wantedTx,
   };
-  const buf = [];
+  const buf: IUtxo[] = [];
   for await (const utxo of storage.selectUtxos(options)) {
     buf.push(utxo);
   }
@@ -379,14 +379,14 @@ test('utxos selected as inputs', async () => {
   storage.utxosSelectedAsInput.set('a-tx-id2:0', true);
 
   // Should check if the utxo is selected as input
-  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id1', index: '0' })).resolves.toBe(true);
-  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id2', index: '0' })).resolves.toBe(true);
-  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id3', index: '0' })).resolves.toBe(
+  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id1', index: 0 })).resolves.toBe(true);
+  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id2', index: 0 })).resolves.toBe(true);
+  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id3', index: 0 })).resolves.toBe(
     false
   );
 
   // Iterate on all utxos selected as input
-  const buf = [];
+  const buf: IUtxoId[] = [];
   for await (const u of storage.utxoSelectedAsInputIter()) {
     buf.push(u);
   }
@@ -395,7 +395,10 @@ test('utxos selected as inputs', async () => {
   expect(buf).toContainEqual({ txId: 'a-tx-id2', index: 0 });
 
   const tx = { txId: 'a-tx-id3', outputs: [{ value: 10, token: '00', spent_by: null }] };
-  const getTxSpy = jest.spyOn(storage, 'getTx').mockImplementation(async () => tx);
+  const getTxSpy = jest.spyOn(storage, 'getTx').mockImplementation(
+    async _txId => {
+      return tx as unknown as IHistoryTx;
+    });
   // no timeout, mark as selected: true
   await storage.utxoSelectAsInput({ txId: 'a-tx-id3', index: 0 }, true);
   expect(storage.utxosSelectedAsInput.get('a-tx-id3:0')).toBe(true);
@@ -411,12 +414,27 @@ test('utxos selected as inputs', async () => {
   await storage.utxoSelectAsInput({ txId: 'a-tx-id4', index: 0 }, true);
   expect(storage.utxosSelectedAsInput.get('a-tx-id4:0')).toBeUndefined();
   // Or with a spent output
-  getTxSpy.mockImplementation(async () => ({
-    txId: 'a-tx-id3',
-    outputs: [{ value: 10, token: '00', spent_by: 'a-tx-id5' }],
-  }));
+  getTxSpy.mockImplementation(async _txId => {
+    return {
+      txId: 'a-tx-id3',
+      outputs: [{ value: 10, token: '00', spent_by: 'a-tx-id5' }],
+    } as unknown as IHistoryTx;
+  });
   await storage.utxoSelectAsInput({ txId: 'a-tx-id3', index: 0 }, true);
   expect(storage.utxosSelectedAsInput.get('a-tx-id3:0')).toBeUndefined();
+
+  getTxSpy.mockImplementation(async _txId => {
+    return {
+      txId: 'a-tx-id4',
+      outputs: [{ value: 10, token: '00', spent_by: null }],
+    } as unknown as IHistoryTx;
+  });
+  await storage.utxoSelectAsInput({ txId: 'a-tx-id4', index: 0 }, true, 500);
+  expect(storage.utxosSelectedAsInput.get('a-tx-id4:0')).toBe(true);
+  await new Promise<void>(resolve => {
+    setTimeout(resolve, 1000);
+  });
+  expect(storage.utxosSelectedAsInput.get('a-tx-id4:0')).not.toBe(true);
 });
 
 describe('process locked utxos', () => {

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -25,7 +25,14 @@ import {
 import * as cryptoUtils from '../../src/utils/crypto';
 import { InvalidPasswdError } from '../../src/errors';
 import Network from '../../src/models/network';
-import { IHistoryTx, ILockedUtxo, IUtxo, IUtxoId, OutputValueType, WALLET_FLAGS } from '../../src/types';
+import {
+  IHistoryTx,
+  ILockedUtxo,
+  IUtxo,
+  IUtxoId,
+  OutputValueType,
+  WALLET_FLAGS,
+} from '../../src/types';
 
 const DATA_DIR = './testdata.leveldb';
 
@@ -381,9 +388,7 @@ test('utxos selected as inputs', async () => {
   // Should check if the utxo is selected as input
   await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id1', index: 0 })).resolves.toBe(true);
   await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id2', index: 0 })).resolves.toBe(true);
-  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id3', index: 0 })).resolves.toBe(
-    false
-  );
+  await expect(storage.isUtxoSelectedAsInput({ txId: 'a-tx-id3', index: 0 })).resolves.toBe(false);
 
   // Iterate on all utxos selected as input
   const buf: IUtxoId[] = [];
@@ -395,10 +400,9 @@ test('utxos selected as inputs', async () => {
   expect(buf).toContainEqual({ txId: 'a-tx-id2', index: 0 });
 
   const tx = { txId: 'a-tx-id3', outputs: [{ value: 10, token: '00', spent_by: null }] };
-  const getTxSpy = jest.spyOn(storage, 'getTx').mockImplementation(
-    async _txId => {
-      return tx as unknown as IHistoryTx;
-    });
+  const getTxSpy = jest.spyOn(storage, 'getTx').mockImplementation(async _txId => {
+    return tx as unknown as IHistoryTx;
+  });
   // no timeout, mark as selected: true
   await storage.utxoSelectAsInput({ txId: 'a-tx-id3', index: 0 }, true);
   expect(storage.utxosSelectedAsInput.get('a-tx-id3:0')).toBe(true);

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -707,10 +707,8 @@ export class Storage implements IStorage {
       // if a ttl is given, we should reverse
       if (ttl) {
         setTimeout(() => {
-          if (!markAs) {
-            if (this.utxosSelectedAsInput.has(utxoId)) {
-              this.utxosSelectedAsInput.delete(utxoId);
-            }
+          if (this.utxosSelectedAsInput.has(utxoId)) {
+            this.utxosSelectedAsInput.delete(utxoId);
           }
         }, ttl);
       }


### PR DESCRIPTION
### Acceptance Criteria

- Fix the setTimeout of the `selected_as_input` ttl to actually undo the change.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
