### PR TITLE
fix: error message for over available tokens to mint or melt

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.ts
+++ b/__tests__/integration/hathorwallet_facade.test.ts
@@ -1981,8 +1981,9 @@ describe('mintTokens', () => {
     const { hash: tokenUid } = await createTokenHelper(hWallet, 'Token to Mint', 'TMINT', 100);
 
     // Should not mint more tokens than the HTR funds allow
-    await expect(hWallet.mintTokens(tokenUid, 9000))
-      .rejects.toThrow(/^Not enough HTR tokens for deposit: 90 required, \d+ available$/);
+    await expect(hWallet.mintTokens(tokenUid, 9000)).rejects.toThrow(
+      /^Not enough HTR tokens for deposit: 90 required, \d+ available$/
+    );
 
     // Minting more of the tokens
     const mintAmount = getRandomInt(100, 50);
@@ -2184,8 +2185,9 @@ describe('meltTokens', () => {
     const { hash: tokenUid } = await createTokenHelper(hWallet, 'Token to Melt', 'TMELT', 500);
 
     // Should not melt more than there is available
-    await expect(hWallet.meltTokens(tokenUid, 999))
-      .rejects.toThrow('Not enough tokens to melt: 999 requested, 500 available');
+    await expect(hWallet.meltTokens(tokenUid, 999)).rejects.toThrow(
+      'Not enough tokens to melt: 999 requested, 500 available'
+    );
 
     // Melting some tokens
     const meltAmount = getRandomInt(99, 10);

--- a/__tests__/integration/hathorwallet_facade.test.ts
+++ b/__tests__/integration/hathorwallet_facade.test.ts
@@ -1981,7 +1981,8 @@ describe('mintTokens', () => {
     const { hash: tokenUid } = await createTokenHelper(hWallet, 'Token to Mint', 'TMINT', 100);
 
     // Should not mint more tokens than the HTR funds allow
-    await expect(hWallet.mintTokens(tokenUid, 9000)).rejects.toThrow('HTR tokens');
+    await expect(hWallet.mintTokens(tokenUid, 9000))
+      .rejects.toThrow(/^Not enough HTR tokens for deposit: 90 required, \d+ available$/);
 
     // Minting more of the tokens
     const mintAmount = getRandomInt(100, 50);
@@ -2183,7 +2184,8 @@ describe('meltTokens', () => {
     const { hash: tokenUid } = await createTokenHelper(hWallet, 'Token to Melt', 'TMELT', 500);
 
     // Should not melt more than there is available
-    await expect(hWallet.meltTokens(tokenUid, 999)).rejects.toThrow('Not enough tokens to melt');
+    await expect(hWallet.meltTokens(tokenUid, 999))
+      .rejects.toThrow('Not enough tokens to melt: 999 requested, 500 available');
 
     // Melting some tokens
     const meltAmount = getRandomInt(99, 10);

--- a/__tests__/new/hathorwallet.test.ts
+++ b/__tests__/new/hathorwallet.test.ts
@@ -1093,11 +1093,13 @@ describe('prepare transactions without signature', () => {
     jest.spyOn(hWallet, 'getMintAuthority').mockReturnValue(fakeMintAuthority);
 
     // prepare mint
-    await expect(hWallet.prepareMintTokensData('01', amountOverAvailable, {
-      address: fakeAddress.base58,
-      pinCode: '1234',
-      signTx: false, // skip the signature
-    })).rejects.toThrow('Not enough HTR tokens for deposit: 10 required, 1 available');
+    await expect(
+      hWallet.prepareMintTokensData('01', amountOverAvailable, {
+        address: fakeAddress.base58,
+        pinCode: '1234',
+        signTx: false, // skip the signature
+      })
+    ).rejects.toThrow('Not enough HTR tokens for deposit: 10 required, 1 available');
   });
 
   test('prepareMeltTokensData', async () => {
@@ -1351,11 +1353,13 @@ describe('prepare transactions without signature', () => {
     jest.spyOn(hWallet, 'getMeltAuthority').mockReturnValue(fakeMeltAuthority);
 
     // prepare melt
-    await expect(hWallet.prepareMeltTokensData('01', amountOverAvailable, {
-      address: fakeAddress.base58,
-      pinCode: '1234',
-      signTx: false, // skip the signature
-    })).rejects.toThrow('Not enough tokens to melt: 100 requested, 10 available');
+    await expect(
+      hWallet.prepareMeltTokensData('01', amountOverAvailable, {
+        address: fakeAddress.base58,
+        pinCode: '1234',
+        signTx: false, // skip the signature
+      })
+    ).rejects.toThrow('Not enough tokens to melt: 100 requested, 10 available');
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,7 +362,7 @@ export type UtxoSelectionAlgorithm = (
   storage: IStorage,
   token: string,
   amount: OutputValueType
-) => Promise<{ utxos: IUtxo[]; amount: OutputValueType }>;
+) => Promise<{ utxos: IUtxo[]; amount: OutputValueType; available?: OutputValueType }>;
 
 export interface IUtxoSelectionOptions {
   token?: string;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -360,8 +360,9 @@ const tokens = {
     }
 
     if (foundAmount < depositAmount) {
+      const availableAmount = selectedUtxos.available;
       throw new InsufficientFundsError(
-        `Not enough HTR tokens for deposit: ${depositAmount} required, ${foundAmount} available`
+        `Not enough HTR tokens for deposit: ${depositAmount} required, ${availableAmount} available`
       );
     }
 
@@ -510,8 +511,9 @@ const tokens = {
     }
 
     if (foundAmount < amount) {
+      const availableAmount = selectedUtxos.available;
       throw new InsufficientFundsError(
-        `Not enough tokens to melt: ${amount} requested, ${foundAmount} available`
+        `Not enough tokens to melt: ${amount} requested, ${availableAmount} available`
       );
     }
 

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -360,7 +360,7 @@ const tokens = {
     }
 
     if (foundAmount < depositAmount) {
-      const availableAmount = selectedUtxos.available;
+      const availableAmount = selectedUtxos.available ?? 0;
       throw new InsufficientFundsError(
         `Not enough HTR tokens for deposit: ${depositAmount} required, ${availableAmount} available`
       );
@@ -511,7 +511,7 @@ const tokens = {
     }
 
     if (foundAmount < amount) {
-      const availableAmount = selectedUtxos.available;
+      const availableAmount = selectedUtxos.available ?? 0;
       throw new InsufficientFundsError(
         `Not enough tokens to melt: ${amount} requested, ${availableAmount} available`
       );

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -49,7 +49,7 @@ export async function fastUtxoSelection(
   storage: IStorage,
   token: string,
   amount: OutputValueType
-): Promise<{ utxos: IUtxo[]; amount: OutputValueType }> {
+): Promise<{ utxos: IUtxo[]; amount: OutputValueType; available?: OutputValueType }> {
   const utxos: IUtxo[] = [];
   let utxosAmount = 0;
 
@@ -72,6 +72,7 @@ export async function fastUtxoSelection(
     return {
       utxos: [],
       amount: 0,
+      available: utxosAmount,
     };
   }
 
@@ -93,7 +94,7 @@ export async function bestUtxoSelection(
   storage: IStorage,
   token: string,
   amount: OutputValueType
-): Promise<{ utxos: IUtxo[]; amount: OutputValueType }> {
+): Promise<{ utxos: IUtxo[]; amount: OutputValueType; available?: OutputValueType }> {
   const utxos: IUtxo[] = [];
   let utxosAmount = 0;
   let selectedUtxo: IUtxo | null = null;
@@ -150,6 +151,7 @@ export async function bestUtxoSelection(
     return {
       utxos: [],
       amount: 0,
+      available: utxosAmount,
     };
   }
   // We need to ensure we use the smallest number of utxos and avoid hitting the maximum number of inputs

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -88,7 +88,7 @@ export async function fastUtxoSelection(
  * @param {IStorage} storage The wallet storage to select the utxos
  * @param {string} token The token uid to select the utxos
  * @param {OutputValueType} amount The target amount of tokens required
- * @returns {Promise<{ utxos: IUtxo[], utxosAmount: OutputValueType}>
+ * @returns {Promise<{ utxos: IUtxo[], amount: OutputValueType, available?: OutputValueType }>}
  */
 export async function bestUtxoSelection(
   storage: IStorage,

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -43,7 +43,7 @@ export function getAlgorithmFromEnum(algorithm: UtxoSelection): UtxoSelectionAlg
  * @param {IStorage} storage The wallet storage to select the utxos
  * @param {string} token The token uid to select the utxos
  * @param {OutputValueType} amount The target amount of tokens required
- * @returns {Promise<{ utxos: IUtxo[], utxosAmount: OutputValueType}>
+ * @returns {Promise<{ utxos: IUtxo[], amount: OutputValueType, available?: OutputValueType }>}
  */
 export async function fastUtxoSelection(
   storage: IStorage,


### PR DESCRIPTION
### Motivation

When we try to mint or melt tokens with more than the available amount, it throws an error. The error message informs the requested amount to mint or melt and the **available** token amount. The bug here is that the available amount is always zero.

### Acceptance Criteria
- The available amount should be equal to the total available token, not zero

It closes https://github.com/HathorNetwork/internal-issues/issues/398


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
