### PR TITLE
fix: bigint reviver

### DIFF
--- a/__tests__/utils/bigint.test.js.ts
+++ b/__tests__/utils/bigint.test.js.ts
@@ -54,18 +54,41 @@ const bigIntObjSchema = z.object({
 
 describe('test JSONBigInt', () => {
   test('should parse numbers', () => {
+    // Doubles should be parsed normally as JS Numbers.
     expect(JSONBigInt.parse('123')).toStrictEqual(123);
     expect(JSONBigInt.parse('123.456')).toStrictEqual(123.456);
     expect(JSONBigInt.parse('1.0')).toStrictEqual(1);
     expect(JSONBigInt.parse('1.000000000000')).toStrictEqual(1);
-    expect(JSONBigInt.parse('12345678901234567890')).toStrictEqual(12345678901234567890n);
-    expect(JSONBigInt.parse('12345678901234567890.000')).toStrictEqual(12345678901234567890n);
     expect(JSONBigInt.parse('1e2')).toStrictEqual(100);
     expect(JSONBigInt.parse('1E2')).toStrictEqual(100);
 
-    expect(() => JSONBigInt.parse('12345678901234567890.1')).toThrow(
-      Error('large float will lose precision! in "12345678901234567890.1"')
-    );
+    // This is 2**53-1 which is the MAX_SAFE_INTEGER, so it remains a Number, not a BigInt.
+    // And the analogous for MIN_SAFE_INTEGER.
+    expect(JSONBigInt.parse('9007199254740991')).toStrictEqual(9007199254740991);
+    expect(JSONBigInt.parse('-9007199254740991')).toStrictEqual(-9007199254740991);
+
+    // One more than the MAX_SAFE_INTEGER, so it becomes a BigInt. And the analogous for MIN_SAFE_INTEGER.
+    expect(JSONBigInt.parse('9007199254740992')).toStrictEqual(9007199254740992n);
+    expect(JSONBigInt.parse('-9007199254740992')).toStrictEqual(-9007199254740992n);
+
+    // This is just a random large value that would lose precision as a Number.
+    expect(JSONBigInt.parse('12345678901234567890')).toStrictEqual(12345678901234567890n);
+
+    // This is 2n**63n, which is the max output value.
+    expect(JSONBigInt.parse('9223372036854775808')).toStrictEqual(9223372036854775808n);
+
+    // This is the value 2n**63n would have when converted to a Number with loss of precision,
+    // and then some variation around it. Notice it's actually greater than 2n**63n.
+    expect(JSONBigInt.parse('9223372036854776000')).toStrictEqual(9223372036854776000n);
+    expect(JSONBigInt.parse('9223372036854775998')).toStrictEqual(9223372036854775998n);
+    expect(JSONBigInt.parse('9223372036854775999')).toStrictEqual(9223372036854775999n);
+    expect(JSONBigInt.parse('9223372036854776001')).toStrictEqual(9223372036854776001n);
+    expect(JSONBigInt.parse('9223372036854776002')).toStrictEqual(9223372036854776002n);
+
+    // This is 2n**63n - 800n and the value it would have when converted to a Number with loss of precision.
+    // Notice it becomes less than the original value.
+    expect(JSONBigInt.parse('9223372036854775008')).toStrictEqual(9223372036854775008n);
+    expect(JSONBigInt.parse('9223372036854775000')).toStrictEqual(9223372036854775000n);
   });
 
   test('should parse normal JSON', () => {


### PR DESCRIPTION
### Motivation

During manual testing with the updated wallet-headless, I found a bug in the logic used to revive BigInts. We should check using JS `Number.MAX_SAFE_INTEGER`, instead.

### Acceptance Criteria

- Make `bigIntReviver()` a standalone function in the `JSONBigInt` object.
- Fix logic `bigIntReviver()` uses to determine when it should return a `BigInt`.
- Add more tests.


### Security Checklist

- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
