### PR TITLE
feat: process txs as they arrive

### DIFF
--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { get } from 'lodash';
+import { cloneDeep, get } from 'lodash';
 import bitcore, { HDPrivateKey } from 'bitcore-lib';
 import EventEmitter from 'events';
 import { NATIVE_TOKEN_UID, P2SH_ACCT_PATH, P2PKH_ACCT_PATH } from '../constants';
@@ -699,7 +699,9 @@ class HathorWallet extends EventEmitter {
       throw new WalletError('Not implemented.');
     }
     const uid = token || this.token.uid;
-    let tokenData = await this.storage.getToken(uid);
+    // Using clone deep so the balance returned will not be updated in case
+    // we change the storage
+    let tokenData = cloneDeep(await this.storage.getToken(uid));
     if (tokenData === null) {
       // We don't have the token on storage, so we need to return an empty default response
       tokenData = {

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1348,10 +1348,15 @@ class HathorWallet extends EventEmitter {
     this.state = HathorWallet.PROCESSING;
     // Process history to update metadatas
     if (metadataChanged) {
-      // Save the transaction in the storage
+      // Process the full history because
+      // this tx changed the voided state
+      // XXX in the future we should be able to handle this
+      // voidness alone, without processing everything
+      // but for now it's an isolated case and it's easier
       await this.storage.processHistory();
     } else if (isNewTx) {
-      // Save the transaction in the storage and process it.
+      // Process this single transaction.
+      // Handling new metadatas and deleting utxos that are not available anymore
       await this.storage.processNewTx(newTx);
     }
     // restore previous state

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1348,11 +1348,9 @@ class HathorWallet extends EventEmitter {
     if (metadataChanged) {
       // Save the transaction in the storage
       await this.storage.processHistory();
-    } else {
-      if (isNewTx) {
-        // Save the transaction in the storage and process it.
-        await this.storage.processNewTx(newTx);
-      }
+    } else if (isNewTx) {
+      // Save the transaction in the storage and process it.
+      await this.storage.processNewTx(newTx);
     }
     // restore previous state
     this.state = previousState;

--- a/src/storage/leveldb/store.ts
+++ b/src/storage/leveldb/store.ts
@@ -268,6 +268,10 @@ export default class LevelDBStore implements IStore {
     return this.utxoIndex.saveUtxo(utxo);
   }
 
+  async deleteUtxo(utxo: IUtxo): Promise<void> {
+    await this.utxoIndex.deleteUtxo(utxo);
+  }
+
   /**
    * Save a locked utxo to the database.
    * Used when a new utxo is received but it is either time locked or height locked.

--- a/src/storage/leveldb/utxo_index.ts
+++ b/src/storage/leveldb/utxo_index.ts
@@ -306,6 +306,7 @@ export default class LevelUtxoIndex implements IKVUtxoIndex {
     await this.tokenAddressUtxoDB.put(_token_address_utxo_key(utxo), utxo);
     await this.tokenUtxoDB.put(_token_utxo_key(utxo), utxo);
   }
+
   /**
    * Remove an utxo from the database.
    * @param {IUtxo} utxo utxo to be deleted

--- a/src/storage/leveldb/utxo_index.ts
+++ b/src/storage/leveldb/utxo_index.ts
@@ -306,6 +306,16 @@ export default class LevelUtxoIndex implements IKVUtxoIndex {
     await this.tokenAddressUtxoDB.put(_token_address_utxo_key(utxo), utxo);
     await this.tokenUtxoDB.put(_token_utxo_key(utxo), utxo);
   }
+  /**
+   * Remove an utxo from the database.
+   * @param {IUtxo} utxo utxo to be deleted
+   * @returns {Promise<void>}
+   */
+  async deleteUtxo(utxo: IUtxo): Promise<void> {
+    await this.utxoDB.del(_utxo_id(utxo));
+    await this.tokenAddressUtxoDB.del(_token_address_utxo_key(utxo));
+    await this.tokenUtxoDB.del(_token_utxo_key(utxo));
+  }
 
   /**
    * Save a locked utxo on the database.

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -593,6 +593,10 @@ export class MemoryStore implements IStore {
     }
   }
 
+  async deleteUtxo(utxo: IUtxo): Promise<void> {
+    this.utxos.delete(`${utxo.txId}:${utxo.index}`);
+  }
+
   /**
    * Fetch utxos based on a selection criteria
    * @param {IUtxoFilterOptions} options Options to filter utxos

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -367,8 +367,6 @@ export class Storage implements IStorage {
    * @returns {Promise<void>}
    */
   async processNewTx(tx: IHistoryTx): Promise<void> {
-    // Add tx to storage
-    await this.addTx(tx);
     // Keep tx-timestamp index sorted
     await this.store.preProcessHistory();
     // Process the single tx we received

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -40,7 +40,11 @@ import {
   getDefaultLogger,
 } from '../types';
 import transactionUtils from '../utils/transaction';
-import { processHistory as processHistoryUtil, processSingleTx as processSingleTxUtil, processUtxoUnlock } from '../utils/storage';
+import {
+  processHistory as processHistoryUtil,
+  processSingleTx as processSingleTxUtil,
+  processUtxoUnlock,
+} from '../utils/storage';
 import config, { Config } from '../config';
 import { decryptData, checkPassword } from '../utils/crypto';
 import FullNodeConnection from '../new/connection';

--- a/src/sync/utils.ts
+++ b/src/sync/utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { IHistoryTx, IStorage } from "../types";
+
+/**
+ * Currently we only need to check that a transaction has been voided or un-voided.
+ */
+export async function checkTxMetadataChanged(tx: IHistoryTx, storage: IStorage): Promise<boolean> {
+  const txId = tx.tx_id;
+  const storageTx = await storage.getTx(txId);
+  if (!storageTx) {
+    // This is a new tx
+    return false;
+  }
+
+  return tx.is_voided !== storageTx.is_voided;
+}

--- a/src/sync/utils.ts
+++ b/src/sync/utils.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IHistoryTx, IStorage } from "../types";
+import { IHistoryTx, IStorage } from '../types';
 
 /**
  * Currently we only need to check that a transaction has been voided or un-voided.

--- a/src/types.ts
+++ b/src/types.ts
@@ -429,6 +429,7 @@ export interface IStore {
   saveLockedUtxo(lockedUtxo: ILockedUtxo): Promise<void>;
   iterateLockedUtxos(): AsyncGenerator<ILockedUtxo>;
   unlockUtxo(lockedUtxo: ILockedUtxo): Promise<void>;
+  deleteUtxo(utxoId: IUtxo): Promise<void>;
 
   // Wallet data
   getAccessData(): Promise<IWalletAccessData | null>;
@@ -502,6 +503,7 @@ export interface IStorage {
   getSpentTxs(inputs: Input[]): AsyncGenerator<{ tx: IHistoryTx; input: Input; index: number }>;
   addTx(tx: IHistoryTx): Promise<void>;
   processHistory(): Promise<void>;
+  processNewTx(tx: IHistoryTx): Promise<void>;
 
   // Tokens
   isTokenRegistered(tokenUid: string): Promise<boolean>;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -419,18 +419,23 @@ export async function processSingleTx(
       // The tx being spent is not from the wallet.
       continue;
     }
+
     if (origTx.outputs.length <= input.index) {
       throw new Error('Spending an unexistent output');
     }
+
     const output = origTx.outputs[input.index];
     if (!output.decoded.address) {
       // Tx is ours but output is not from an address.
       continue;
     }
+
     if (!(await storage.isAddressMine(output.decoded.address))) {
       // Address is not ours.
       continue;
     }
+
+    // Now we get the utxo object to be deleted from the store
     const utxo: IUtxo = {
       txId: input.tx_id,
       index: input.index,
@@ -442,11 +447,12 @@ export async function processSingleTx(
       type: origTx.version,
       height: origTx.height ?? null,
     };
-    // Delete utxo if it is being spent
+
+    // Delete utxo
     await store.deleteUtxo(utxo);
   }
 
-  // Update wallet data
+  // Update wallet data in the store
   await updateWalletMetadataFromProcessedTxData(storage, { maxIndexUsed, tokens });
 }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -400,7 +400,7 @@ export async function processHistory(
 export async function processSingleTx(
   storage: IStorage,
   tx: IHistoryTx,
-  { rewardLock }: { rewardLock?: number } = {},
+  { rewardLock }: { rewardLock?: number } = {}
 ): Promise<void> {
   const { store } = storage;
   const nowTs = Math.floor(Date.now() / 1000);


### PR DESCRIPTION
### Context

Nowadays we run the method to process the wallet full history every time a new tx arrives in the ws. Wallets with many transactions/addresses usually take a long time (0.5s) to process their entire history. There are cases where the wallet returns and error because of insufficient funds because it's processing the history of a recent transaction that has just arrived when the user wants to send a new tx.

### Acceptance Criteria
- Process only the single tx that arrives in the ws (including delete the utxos that are being spent in this tx).
- If this tx is an update and the voided state has changed, then we run the full process history, just to make this easier.
- While this processing is being done we change the wallet state to PROCESSING, so users know that they must wait until creating the next tx.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
