### PR TITLE
fix: utxo selection for getUtxosForAmount

### DIFF
--- a/__tests__/new/hathorwallet.test.ts
+++ b/__tests__/new/hathorwallet.test.ts
@@ -22,6 +22,7 @@ import Queue from '../../src/models/queue';
 import { WalletType } from '../../src/types';
 import txApi from '../../src/api/txApi';
 import * as addressUtils from '../../src/utils/address';
+import walletUtils from '../../src/utils/wallet';
 import versionApi from '../../src/api/version';
 import { decryptData, verifyMessage } from '../../src/utils/crypto';
 
@@ -1370,4 +1371,42 @@ test('setExternalTxSigningMethod', async () => {
   hwallet.storage = storage;
   hwallet.setExternalTxSigningMethod(async () => {});
   expect(hwallet.isSignedExternally).toBe(true);
+});
+
+test('getUtxosForAmount - should always get the best utxos', async () => {
+  const seed =
+    'upon tennis increase embark dismiss diamond monitor face magnet jungle scout salute rural master shoulder cry juice jeans radar present close meat antenna mind';
+  const accessData = walletUtils.generateAccessDataFromSeed(seed, {
+    pin: '123',
+    password: '456',
+    networkName: 'testnet',
+  });
+  const store = new MemoryStore();
+  await store.saveAccessData(accessData);
+  const storage = new Storage(store);
+  const hwallet = new FakeHathorWallet();
+  hwallet.storage = storage;
+  // When selecting 6n we should always get the 6n output, even if the sum of
+  // the first 3 may solve the required 6n.
+  for (const amount of [3n, 1n, 2n, 4n, 6n]) {
+    await storage.store.saveUtxo({
+      txId: 'tx1',
+      index: Number(amount),
+      value: amount,
+      address: 'addr',
+      authorities: 0n,
+      height: 0,
+      timelock: null,
+      token: '00',
+      type: 1,
+    });
+  }
+
+  expect(hwallet.getUtxosForAmount(6n)).resolves.toEqual({
+    changeAmount: 0n,
+    utxos: [expect.objectContaining({
+      index: 6,
+      value: 6n,
+    })],
+  });
 });

--- a/__tests__/new/hathorwallet.test.ts
+++ b/__tests__/new/hathorwallet.test.ts
@@ -1402,11 +1402,13 @@ test('getUtxosForAmount - should always get the best utxos', async () => {
     });
   }
 
-  expect(hwallet.getUtxosForAmount(6n)).resolves.toEqual({
+  await expect(hwallet.getUtxosForAmount(6n)).resolves.toEqual({
     changeAmount: 0n,
-    utxos: [expect.objectContaining({
-      index: 6,
-      value: 6n,
-    })],
+    utxos: [
+      expect.objectContaining({
+        index: 6,
+        value: 6n,
+      }),
+    ],
   });
 });

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -1070,6 +1070,7 @@ class HathorWallet extends EventEmitter {
       token: NATIVE_TOKEN_UID,
       filter_address: null,
       ...options,
+      order_by_value: 'desc',
     };
 
     const utxos = [];


### PR DESCRIPTION
### Motivation

`selectUtxos` util in `src/utils/transaction.ts` requires the utxo array to be sorted for the selection to be optimal.
The `getUtxosForAmount` method of the wallet facade was not following this and in some cases the utxos chosen by this method were not the best selection possible, maybe even failing some transactions due to going over the input limit.

To fix this we need to get the sorted utxo list.

### Acceptance Criteria

- on `getUtxosForAmount` use the option to retrieve utxos sorted by amount.
- test a case where utxo selection would choose a list of utxos instead of a single utxo that could meet the requirements.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
