### PR TITLE
tests: use rocksdb in the integration tests

### DIFF
--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     networks:
       - hathor-privnet
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/v1a/status')"]
+      test: ["CMD", "python", "-c", "import urllib.request; import json; r = urllib.request.urlopen('http://localhost:8080/v1a/status'); body = json.loads(r.read()); assert body['server']['state'] == 'READY'"]
       interval: 5s
       timeout: 10s
       retries: 10

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       "--wallet-index",
       "--allow-mining-without-peers",
       "--unsafe-mode", "nano-testnet-alpha",
-      "--memory-storage",
+      "--data", "./tmp"
       "--nc-history-index",
     ]
     environment:
@@ -29,12 +29,18 @@ services:
         target: /privnet/conf
     networks:
       - hathor-privnet
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/v1a/status')"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
 
   tx-mining-service:
     image:
       ${HATHOR_LIB_INTEGRATION_TESTS_TXMINING_IMAGE:-hathornetwork/tx-mining-service}
     depends_on:
-      - fullnode
+      fullnode:
+        condition: service_healthy
     ports:
       - "8034:8034" # Not mandatory to keep this port open, but helpful for developer machine debugging
       - "8035:8035"

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       "--wallet-index",
       "--allow-mining-without-peers",
       "--unsafe-mode", "nano-testnet-alpha",
-      "--data", "./tmp"
+      "--data", "./tmp",
       "--nc-history-index",
     ]
     environment:


### PR DESCRIPTION
### Motivation

The next full node version will not support memory storage anymore and one of the nano contract indexes already doesn't support it. The main problem with using rocksdb is that the full node service takes more time to become healthy (with status port ready to receive requests), so the tx mining service and the test itself were breaking. 

Then I created a healthcheck to validate if the node is already receiving http requests. I tried using `curl` or `wget` but the docker container doesn't have them installed, that's why it's using a python script to validate.

### Acceptance Criteria
- Use rocksdb in the fullnode that runs in the integration tests

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
