### PR TITLE
tests: improve how we wait for a tx to be confirmed

### DIFF
--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -478,7 +478,7 @@ describe('full cycle of bet nano contract', () => {
 
     jest.spyOn(wallet.storage, 'processHistory');
     expect(wallet.storage.processHistory.mock.calls.length).toBe(0);
-    await waitNextBlock(wallet.storage);
+    await waitTxConfirmed(wallet, txWithdrawal2.hash);
     const txWithdrawal2Data = await wallet.getFullTxById(txWithdrawal2.hash);
 
     // The tx became voided after the block because of the nano execution

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -6,7 +6,6 @@ import {
   generateMultisigWalletHelper,
   generateWalletHelper,
   waitForTxReceived,
-  waitNextBlock,
   waitTxConfirmed,
 } from '../helpers/wallet.helper';
 import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';


### PR DESCRIPTION
### Motivation

The test wants to wait until the nano contract tx has its method executed and I was using `waitNextBlock`. This method was causing some intermittent errors because it's an async call. The best way to guarantee that the nano method will have already been executed is to use `waitTxConfirmed`, then the tx will have a `first_block`.

### Acceptance Criteria
- Use `waitTxConfirmed` to guarantee a tx has first block.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
