### PR TITLE
fix: p2sh output type comes as MultiSig from hathor core

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.ts
+++ b/__tests__/integration/hathorwallet_facade.test.ts
@@ -1585,6 +1585,17 @@ describe('sendTransaction', () => {
         }),
       ],
     });
+
+    const fullNodeTx = await mhWallet1.getFullTxById(sentTx.hash);
+    expect(fullNodeTx.tx).toMatchObject({
+      hash: partiallyAssembledTx.hash,
+      inputs: [
+        expect.objectContaining({
+          tx_id: inputTxId,
+          value: 10n,
+        }),
+      ],
+    });
   });
 });
 

--- a/src/api/schemas/txApi.ts
+++ b/src/api/schemas/txApi.ts
@@ -17,7 +17,7 @@ const p2pkhDecodedScriptSchema = z.object({
 });
 
 const p2shDecodedScriptSchema = z.object({
-  type: z.literal('P2SH'),
+  type: z.literal('MultiSig'),
   address: z.string(),
   timelock: z.number().nullish(),
   value: bigIntCoercibleSchema,


### PR DESCRIPTION
### Motivation

We recently added a zod schema validation to the lib code and, even though we use as output type 'P2SH' in the lib (as we have in our types), the full node uses 'MultiSig'. We didn't notice that and every time we were requesting the `/transaction` API of a tx with a P2SH output, an error was being thrown.

### Acceptance Criteria
- p2sh output type comes as MultiSig from hathor core


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
