### PR TITLE
tests: improved tests with more test cases for height in txById

### DIFF
--- a/__tests__/wallet/walletSchemas.test.ts
+++ b/__tests__/wallet/walletSchemas.test.ts
@@ -667,7 +667,7 @@ describe('Wallet API Schemas', () => {
   });
 
   describe('txByIdResponseSchema', () => {
-    it('should validate valid tx by id response', () => {
+    it('should validate valid tx by id response with height present', () => {
       const validData = {
         success: true,
         txTokens: [
@@ -676,7 +676,7 @@ describe('Wallet API Schemas', () => {
             timestamp: 1234567890,
             version: 1,
             voided: false,
-            height: 1,
+            height: 1, // height is present and a number
             weight: 1,
             balance: 100n,
             tokenId: token1,
@@ -688,7 +688,71 @@ describe('Wallet API Schemas', () => {
       expect(() => txByIdResponseSchema.parse(validData)).not.toThrow();
     });
 
-    it('should reject invalid tx by id response', () => {
+    it('should validate valid tx by id response with height null', () => {
+      const validData = {
+        success: true,
+        txTokens: [
+          {
+            txId: tx1,
+            timestamp: 1234567890,
+            version: 1,
+            voided: false,
+            height: null, // height is present and null
+            weight: 1,
+            balance: 100n,
+            tokenId: token1,
+            tokenName: 'Token 1',
+            tokenSymbol: 'T1',
+          },
+        ],
+      };
+      expect(() => txByIdResponseSchema.parse(validData)).not.toThrow();
+    });
+
+    it('should validate valid tx by id response with height omitted', () => {
+      const validData = {
+        success: true,
+        txTokens: [
+          {
+            txId: tx1,
+            timestamp: 1234567890,
+            version: 1,
+            voided: false,
+            // height is omitted (optional)
+            weight: 1,
+            balance: 100n,
+            tokenId: token1,
+            tokenName: 'Token 1',
+            tokenSymbol: 'T1',
+          },
+        ],
+      };
+      expect(() => txByIdResponseSchema.parse(validData)).not.toThrow();
+    });
+
+    it('should reject invalid tx by id response with invalid height type', () => {
+      const invalidData = {
+        success: true,
+        txTokens: [
+          {
+            txId: tx1,
+            timestamp: 1234567890,
+            version: 1,
+            voided: false,
+            height: '1', // height should be number or null, not string
+            weight: 1,
+            balance: 283n,
+            tokenId: token1,
+            tokenName: 'Token 1',
+            tokenSymbol: 'T1',
+          },
+        ],
+      };
+      expect(() => txByIdResponseSchema.parse(invalidData)).toThrow();
+    });
+
+    it('should reject invalid tx by id response due to other fields', () => {
+      // Keep a test for general invalidity unrelated to height
       const invalidData = {
         success: true,
         txTokens: [

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -417,7 +417,7 @@ export const txByIdResponseSchema = baseResponseSchema.extend({
       timestamp: z.number(),
       version: z.number(),
       voided: z.boolean(),
-      height: z.number().nullable(),
+      height: z.number().nullable().optional(),
       weight: z.number(),
       balance: bigIntCoercibleSchema,
       tokenId: z.string(),


### PR DESCRIPTION
### Acceptance Criteria
- Update `txByIdResponseSchema` to make the `height` field optional and nullable (as it makes sense since a transaction might not be confirmed yet)
- Modify tests in `__tests__/wallet/walletSchemas.test.ts` for `txByIdResponseSchema` to reflect the changes

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.