### PR TITLE
fix: SendTransaction should enqueue call to onNewTx

### DIFF
--- a/src/new/sendTransaction.ts
+++ b/src/new/sendTransaction.ts
@@ -447,7 +447,7 @@ export default class SendTransaction extends EventEmitter {
                 // This just returns if the transaction is not a CREATE_TOKEN_TX
                 await addCreatedTokenFromTx(transaction as CreateTokenTransaction, storage);
                 // Add new transaction to the wallet's storage.
-                await wallet.onNewTx({ history: historyTx });
+                wallet.enqueueOnNewTx({ history: historyTx });
               })(this.wallet, this.storage, this.transaction);
             }
             this.emit('send-tx-success', this.transaction);

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -675,7 +675,7 @@ class HathorWallet extends EventEmitter {
         // So we will enqueue this message to be processed later
         this.wsTxQueue.enqueue(wsData);
       } else {
-        this.newTxPromise = this.newTxPromise.then(() => this.onNewTx(wsData));
+        this.enqueueOnNewTx(wsData);
       }
     }
   }
@@ -1328,6 +1328,14 @@ class HathorWallet extends EventEmitter {
     }
     this.state = state;
     this.emit('state', state);
+  }
+
+  /**
+   * Enqueue the call for onNewTx with the given data.
+   * @param {{ history: import('../types').IHistoryTx }} wsData
+   */
+  enqueueOnNewTx(wsData) {
+    this.newTxPromise = this.newTxPromise.then(() => this.onNewTx(wsData));
   }
 
   /**


### PR DESCRIPTION
### Motivation

When running a localnet with streaming sync, users wallet's would fail after sending a transaction due to having requests to start multiple streams at the same time.

### Acceptance Criteria

All calls to `onNewTx` should be enqueued so 2 calls to `onNewTx` cannot run at the same time.

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
