### PR TITLE
feat: add support for creating a create token transaction with nano header

### DIFF
--- a/__tests__/integration/hathorwallet_facade.test.ts
+++ b/__tests__/integration/hathorwallet_facade.test.ts
@@ -644,6 +644,9 @@ describe('start', () => {
     await expect(hWallet.createAndSendNanoContractTransaction()).rejects.toThrow(
       WalletFromXPubGuard
     );
+    await expect(hWallet.createAndSendNanoContractCreateTokenTransaction()).rejects.toThrow(
+      WalletFromXPubGuard
+    );
     await expect(hWallet.getPrivateKeyFromAddress()).rejects.toThrow(WalletFromXPubGuard);
     await expect(hWallet.createOnChainBlueprintTransaction()).rejects.toThrow(WalletFromXPubGuard);
 

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -370,37 +370,19 @@ describe('full cycle of bet nano contract', () => {
 
     // Error with invalid mint authority address
     await expect(
-      wallet.createAndSendNanoContractCreateTokenTransaction(
-        'withdraw',
-        address2,
-        withdrawalData,
-        { ...withdrawalCreateTokenOptions, mintAuthorityAddress: 'abc' }
-      )
+      wallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, withdrawalData, {
+        ...withdrawalCreateTokenOptions,
+        mintAuthorityAddress: 'abc',
+      })
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Error with invalid melt authority address
     await expect(
-      wallet.createAndSendNanoContractCreateTokenTransaction(
-        'withdraw',
-        address2,
-        withdrawalData,
-        { ...withdrawalCreateTokenOptions, meltAuthorityAddress: 'abc' }
-      )
+      wallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, withdrawalData, {
+        ...withdrawalCreateTokenOptions,
+        meltAuthorityAddress: 'abc',
+      })
     ).rejects.toThrow(NanoContractTransactionError);
-
-    // If we remove the pin from the wallet object, it should throw error
-    const oldPin = wallet.pinCode;
-    wallet.pinCode = '';
-    await expect(
-      wallet.createAndSendNanoContractCreateTokenTransaction(
-        'withdraw',
-        address2,
-        withdrawalData,
-        withdrawalCreateTokenOptions
-      )
-    ).rejects.toThrow(PinRequiredError);
-    // Add the pin back for the other tests
-    wallet.pinCode = oldPin;
 
     // Try to withdraw to address 2, success
     const txWithdrawal = await wallet.createAndSendNanoContractCreateTokenTransaction(
@@ -730,6 +712,19 @@ describe('full cycle of bet nano contract', () => {
       })
     ).rejects.toThrow(NanoContractTransactionError);
 
+    // If we remove the pin from the wallet object, it should throw error
+    const oldPin = hWallet.pinCode;
+    hWallet.pinCode = '';
+    await expect(
+      hWallet.createAndSendNanoContractTransaction('withdraw', address2, {})
+    ).rejects.toThrow(PinRequiredError);
+
+    await expect(
+      hWallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, {}, {})
+    ).rejects.toThrow(PinRequiredError);
+    // Add the pin back for the other tests
+    hWallet.pinCode = oldPin;
+
     // Test ocb errors
     const { seed } = WALLET_CONSTANTS.ocb;
     const ocbWallet = await generateWalletHelper({ seed });
@@ -741,13 +736,13 @@ describe('full cycle of bet nano contract', () => {
     ).rejects.toThrow(NanoContractTransactionError);
 
     // If we remove the pin from the wallet object, it should throw error
-    const oldPin = ocbWallet.pinCode;
+    const oldOcbPin = ocbWallet.pinCode;
     ocbWallet.pinCode = '';
     await expect(
       ocbWallet.createAndSendOnChainBlueprintTransaction(code, address0)
     ).rejects.toThrow(PinRequiredError);
 
     // Add the pin back in case there are more tests here
-    ocbWallet.pinCode = oldPin;
+    ocbWallet.pinCode = oldOcbPin;
   });
 });

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -8,7 +8,11 @@ import {
   waitForTxReceived,
   waitTxConfirmed,
 } from '../helpers/wallet.helper';
-import { CREATE_TOKEN_TX_VERSION, NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+import {
+  CREATE_TOKEN_TX_VERSION,
+  NATIVE_TOKEN_UID,
+  NANO_CONTRACTS_INITIALIZE_METHOD,
+} from '../../../src/constants';
 import ncApi from '../../../src/api/nano';
 import dateFormatter from '../../../src/utils/date';
 import { bufferToHex } from '../../../src/utils/buffer';

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -5,13 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { concat, get } from 'lodash';
-import Output from '../models/output';
-import Input from '../models/input';
+import { concat, get, uniq } from 'lodash';
 import Transaction from '../models/transaction';
-import { createOutputScriptFromAddress } from '../utils/address';
+import CreateTokenTransaction from '../models/create_token_transaction';
+import { getAddressType } from '../utils/address';
 import tokensUtils from '../utils/tokens';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../constants';
+import transactionUtils from '../utils/transaction';
+import {
+  DEFAULT_TX_VERSION,
+  NATIVE_TOKEN_UID,
+  NANO_CONTRACTS_INITIALIZE_METHOD,
+} from '../constants';
 import Serializer from './serializer';
 import HathorWallet from '../new/wallet';
 import { NanoContractTransactionError } from '../errors';
@@ -23,8 +27,10 @@ import {
   MethodArgInfo,
   NanoContractArgumentApiInputType,
   NanoContractArgumentType,
+  NanoContractBuilderCreateTokenOptions,
+  NanoContractVertexType,
 } from './types';
-import { ITokenData } from '../types';
+import { IDataInput, IDataOutput, ITokenData } from '../types';
 import ncApi from '../api/nano';
 import { validateAndUpdateBlueprintMethodArgs } from './utils';
 import NanoContractHeader from './header';
@@ -43,9 +49,16 @@ class NanoContractTransactionBuilder {
 
   args: NanoContractArgumentType[] | null;
 
-  transaction: Transaction | null;
+  serializedArgs: Buffer[] | null;
 
   wallet: HathorWallet | null;
+
+  // So far we support Transaction or CreateTokenTransaction
+  vertexType: NanoContractVertexType | null;
+
+  // In case of a CreateTokenTransaction, these are the options
+  // for the tx creation used by the tokens utils method
+  createTokenOptions: NanoContractBuilderCreateTokenOptions | null;
 
   constructor() {
     this.blueprintId = null;
@@ -54,8 +67,10 @@ class NanoContractTransactionBuilder {
     this.actions = null;
     this.caller = null;
     this.args = null;
-    this.transaction = null;
+    this.serializedArgs = null;
     this.wallet = null;
+    this.vertexType = null;
+    this.createTokenOptions = null;
   }
 
   /**
@@ -159,6 +174,24 @@ class NanoContractTransactionBuilder {
   }
 
   /**
+   * Set vertex type
+   *
+   * @param {vertexType} The vertex type
+   * @param {createTokenOptions} Options for the token creation tx
+   *
+   * @memberof NanoContractTransactionBuilder
+   * @inner
+   */
+  setVertexType(
+    vertexType: NanoContractVertexType,
+    createTokenOptions: NanoContractBuilderCreateTokenOptions | null = null
+  ) {
+    this.vertexType = vertexType;
+    this.createTokenOptions = createTokenOptions;
+    return this;
+  }
+
+  /**
    * Execute a deposit action
    * Create inputs (and maybe change outputs) to complete the deposit
    *
@@ -168,7 +201,10 @@ class NanoContractTransactionBuilder {
    * @memberof NanoContractTransactionBuilder
    * @inner
    */
-  async executeDeposit(action: NanoContractAction, tokens: string[]): Promise<[Input[], Output[]]> {
+  async executeDeposit(
+    action: NanoContractAction,
+    tokens: string[]
+  ): Promise<[IDataInput[], IDataOutput[]]> {
     if (action.type !== NanoContractActionType.DEPOSIT) {
       throw new NanoContractTransactionError(
         "Can't execute a deposit with an action which type is differente than deposit."
@@ -190,28 +226,33 @@ class NanoContractTransactionBuilder {
       utxoOptions.filter_address = action.address;
     }
     const utxosData = await this.wallet.getUtxosForAmount(action.amount, utxoOptions);
-    const inputs: Input[] = [];
+    // XXX What if I don't have enough funds? Validate it!
+    const inputs: IDataInput[] = [];
     for (const utxo of utxosData.utxos) {
-      inputs.push(new Input(utxo.txId, utxo.index));
+      inputs.push({
+        txId: utxo.txId,
+        index: utxo.index,
+        value: utxo.value,
+        authorities: utxo.authorities,
+        token: utxo.tokenId,
+        address: utxo.address,
+      });
     }
 
-    const outputs: Output[] = [];
-    const network = this.wallet.getNetworkObject();
+    const outputs: IDataOutput[] = [];
     // If there's a change amount left in the utxos, create the change output
     if (utxosData.changeAmount) {
       const changeAddressStr =
         changeAddressParam || (await this.wallet.getCurrentAddress()).address;
-      // This will throw AddressError in case the adress is invalid
-      // this handles p2pkh and p2sh scripts
-      const outputScript = createOutputScriptFromAddress(changeAddressStr, network);
-      const tokenIndex =
-        action.token === NATIVE_TOKEN_UID
-          ? 0
-          : tokens.findIndex(token => token === action.token) + 1;
-      const outputObj = new Output(utxosData.changeAmount, outputScript, {
-        tokenData: tokenIndex,
+      outputs.push({
+        type: getAddressType(changeAddressStr, this.wallet.getNetworkObject()),
+        address: changeAddressStr,
+        value: utxosData.changeAmount,
+        timelock: null,
+        token: action.token,
+        authorities: 0n,
+        isChange: true,
       });
-      outputs.push(outputObj);
     }
 
     return [inputs, outputs];
@@ -220,6 +261,9 @@ class NanoContractTransactionBuilder {
   /**
    * Execute a withdrawal action
    * Create outputs to complete the withdrawal
+   * If the transaction is a token creation and
+   * the contract will pay for the deposit fee,
+   * then creates the output only of the difference
    *
    * @param {action} Action to be completed (must be a withdrawal type)
    * @param {tokens} Array of tokens to get the token data correctly
@@ -227,43 +271,71 @@ class NanoContractTransactionBuilder {
    * @memberof NanoContractTransactionBuilder
    * @inner
    */
-  executeWithdrawal(action: NanoContractAction, tokens: string[]): Output {
+  executeWithdrawal(action: NanoContractAction, tokens: string[]): IDataOutput | null {
     if (action.type !== NanoContractActionType.WITHDRAWAL) {
       throw new NanoContractTransactionError(
         "Can't execute a withdrawal with an action which type is differente than withdrawal."
       );
     }
 
-    if (!action.address || !action.amount || !action.token) {
+    if (!action.amount || !action.token) {
       throw new NanoContractTransactionError(
         'Address, amount and token are required for withdrawal action.'
       );
     }
+
+    // If it's a token creation creation tx and the contract is paying the deposit fee, then
+    // we must reduce the amount created for the output from the total action amount
+    let withdrawalAmount = action.amount;
+    if (this.vertexType === NanoContractVertexType.CREATE_TOKEN_TRANSACTION) {
+      if (this.createTokenOptions === null) {
+        throw new NanoContractTransactionError(
+          'For a token creation transaction we must have the options defined.'
+        );
+      }
+
+      // We pay the deposit in native token uid
+      if (this.createTokenOptions.contractPaysTokenDeposit && action.token === NATIVE_TOKEN_UID) {
+        const depositPercent = this.wallet.storage.getTokenDepositPercentage();
+        const depositAmount = tokensUtils.getDepositAmount(
+          this.createTokenOptions.amount,
+          depositPercent
+        );
+        withdrawalAmount -= depositAmount;
+      }
+    }
+
+    if (withdrawalAmount === 0n) {
+      // The whole withdrawal amount was used to pay deposit token fee
+      return null;
+    }
+
+    if (!action.address) {
+      throw new NanoContractTransactionError(
+        'Address is required for withdrawal action that creates outputs.'
+      );
+    }
+
     // Create the output with the withdrawal address and amount
-
-    // This will throw AddressError in case the adress is invalid
-    // this handles p2pkh and p2sh scripts
-    const outputScript = createOutputScriptFromAddress(
-      action.address,
-      this.wallet.getNetworkObject()
-    );
-
-    const tokenIndex =
-      action.token === NATIVE_TOKEN_UID ? 0 : tokens.findIndex(token => token === action.token) + 1;
-    const output = new Output(action.amount, outputScript, {
-      tokenData: tokenIndex,
-    });
-
-    return output;
+    return {
+      type: getAddressType(action.address, this.wallet.getNetworkObject()),
+      address: action.address,
+      value: withdrawalAmount,
+      timelock: null,
+      token: action.token,
+      authorities: 0n,
+    };
   }
 
   /**
-   * Build the nano contract transaction
+   * Verify if the builder attributes are valid for the nano build
+   *
+   * @throws {NanoContractTransactionError} In case the attributes are not valid
    *
    * @memberof NanoContractTransactionBuilder
    * @inner
    */
-  async build(): Promise<Transaction> {
+  async verify() {
     if (this.method === NANO_CONTRACTS_INITIALIZE_METHOD && !this.blueprintId) {
       // Initialize needs the blueprint ID
       throw new NanoContractTransactionError('Missing blueprint id. Parameter blueprintId in data');
@@ -302,10 +374,55 @@ class NanoContractTransactionBuilder {
 
     // Validate if the arguments match the expected method arguments
     await validateAndUpdateBlueprintMethodArgs(this.blueprintId, this.method, this.args);
+  }
 
-    // Transform actions into inputs and outputs
-    let inputs: Input[] = [];
-    let outputs: Output[] = [];
+  /**
+   * Serialize nano arguments in an array of Buffer
+   * and store the serialized data in this.serializedArgs
+   *
+   * @throws {NanoContractTransactionError} In case the arguments are not valid
+   *
+   * @memberof NanoContractTransactionBuilder
+   * @inner
+   */
+  async serializeArgs() {
+    this.serializedArgs = [];
+    if (this.args) {
+      const serializer = new Serializer();
+      const blueprintInformation = await ncApi.getBlueprintInformation(this.blueprintId!);
+      const methodArgs = get(
+        blueprintInformation,
+        `public_methods.${this.method}.args`,
+        []
+      ) as MethodArgInfo[];
+      if (!methodArgs) {
+        throw new NanoContractTransactionError(`Blueprint does not have method ${this.method}.`);
+      }
+
+      if (this.args.length !== methodArgs.length) {
+        throw new NanoContractTransactionError(
+          `Method needs ${methodArgs.length} parameters but data has ${this.args.length}.`
+        );
+      }
+
+      for (const [index, arg] of methodArgs.entries()) {
+        const serialized = serializer.serializeFromType(this.args[index], arg.type);
+        this.serializedArgs.push(serialized);
+      }
+    }
+  }
+
+  /**
+   * Build inputs and outputs from nano actions
+   *
+   * @throws {Error} If a nano action type is invalid
+   *
+   * @memberof NanoContractTransactionBuilder
+   * @inner
+   */
+  async buildInputsOutputs(): Promise<[IDataInput[], IDataOutput[], string[]]> {
+    let inputs: IDataInput[] = [];
+    let outputs: IDataOutput[] = [];
     let tokens: string[] = [];
     if (this.actions) {
       const tokenSet = new Set<string>();
@@ -324,38 +441,95 @@ class NanoContractTransactionBuilder {
           outputs = concat(outputs, ret[1]);
         } else if (action.type === NanoContractActionType.WITHDRAWAL) {
           const output = this.executeWithdrawal(action, tokens);
-          outputs = concat(outputs, output);
+          if (output) {
+            outputs = concat(outputs, output);
+          }
         } else {
           throw new Error('Invalid type for nano contract action.');
         }
       }
     }
 
-    // Serialize the method arguments
-    const serializedArgs: Buffer[] = [];
-    if (this.args) {
-      const serializer = new Serializer();
-      const blueprintInformation = await ncApi.getBlueprintInformation(this.blueprintId);
-      const methodArgs = get(
-        blueprintInformation,
-        `public_methods.${this.method}.args`,
-        []
-      ) as MethodArgInfo[];
-      if (!methodArgs) {
-        throw new NanoContractTransactionError(`Blueprint does not have method ${this.method}.`);
-      }
+    return [inputs, outputs, tokens];
+  }
 
-      if (this.args.length !== methodArgs.length) {
-        throw new NanoContractTransactionError(
-          `Method needs ${methodArgs.length} parameters but data has ${this.args.length}.`
-        );
-      }
-
-      for (const [index, arg] of methodArgs.entries()) {
-        const serialized = serializer.serializeFromType(this.args[index], arg.type);
-        serializedArgs.push(serialized);
-      }
+  /**
+   * Build a transaction object from the built inputs/outputs/tokens
+   *
+   * It will create a Transaction or CreateTokenTransaction, depending on the vertex type
+   *
+   * @throws {NanoContractTransactionError} In case the create token options is null
+   *
+   * @memberof NanoContractTransactionBuilder
+   * @inner
+   */
+  async buildTransaction(
+    inputs: IDataInput[],
+    outputs: IDataOutput[],
+    tokens: string[]
+  ): Promise<Transaction | CreateTokenTransaction> {
+    if (this.vertexType === NanoContractVertexType.TRANSACTION) {
+      return transactionUtils.createTransactionFromData(
+        {
+          version: DEFAULT_TX_VERSION,
+          inputs,
+          outputs,
+          tokens,
+        },
+        this.wallet.getNetworkObject()
+      );
     }
+
+    if (this.createTokenOptions === null) {
+      throw new NanoContractTransactionError(
+        "Create token options can't be null when creating a create token transaction."
+      );
+    }
+
+    // It's a token creation transaction
+    // then we get the token creation data from the utils method
+    // and concatenate the nano actions inputs/outputs/tokens
+    const data = await tokensUtils.prepareCreateTokenData(
+      this.createTokenOptions.mintAddress,
+      this.createTokenOptions.name,
+      this.createTokenOptions.symbol,
+      this.createTokenOptions.amount,
+      this.wallet.storage,
+      {
+        changeAddress: this.createTokenOptions.changeAddress,
+        createMint: this.createTokenOptions.createMint,
+        mintAuthorityAddress: this.createTokenOptions.mintAuthorityAddress,
+        createMelt: this.createTokenOptions.createMelt,
+        meltAuthorityAddress: this.createTokenOptions.meltAuthorityAddress,
+        data: this.createTokenOptions.data,
+        isCreateNFT: this.createTokenOptions.isCreateNFT,
+        skipDepositFee: this.createTokenOptions.contractPaysTokenDeposit,
+      }
+    );
+
+    data.inputs = concat(data.inputs, inputs);
+    data.outputs = concat(data.outputs, outputs);
+    data.tokens = uniq(concat(data.tokens, tokens));
+
+    return transactionUtils.createTransactionFromData(data, this.wallet.getNetworkObject());
+  }
+
+  /**
+   * Build a full transaction with nano headers from nano contract data
+   *
+   * @throws {NanoContractTransactionError} In case the arguments to build the tx are invalid
+   *
+   * @memberof NanoContractTransactionBuilder
+   * @inner
+   */
+  async build(): Promise<Transaction> {
+    await this.verify();
+
+    // Transform actions into inputs and outputs
+    const [inputs, outputs, tokens] = await this.buildInputsOutputs();
+
+    // Serialize the method arguments
+    await this.serializeArgs();
 
     const ncId = this.method === NANO_CONTRACTS_INITIALIZE_METHOD ? this.blueprintId : this.ncId;
 
@@ -364,7 +538,7 @@ class NanoContractTransactionBuilder {
       throw new Error('This should never happen.');
     }
 
-    const tx = new Transaction(inputs, outputs, { tokens });
+    const tx = await this.buildTransaction(inputs, outputs, tokens);
 
     let nanoHeaderActions: NanoContractActionHeader[] = [];
 
@@ -390,10 +564,10 @@ class NanoContractTransactionBuilder {
 
     const nanoHeader = new NanoContractHeader(
       ncId,
-      this.method,
-      serializedArgs,
+      this.method!,
+      this.serializedArgs!,
       nanoHeaderActions,
-      this.caller,
+      this.caller!,
       null
     );
 

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -480,38 +480,42 @@ class NanoContractTransactionBuilder {
       );
     }
 
-    if (this.createTokenOptions === null) {
-      throw new NanoContractTransactionError(
-        "Create token options can't be null when creating a create token transaction."
+    if (this.vertexType === NanoContractVertexType.CREATE_TOKEN_TRANSACTION) {
+      if (this.createTokenOptions === null) {
+        throw new NanoContractTransactionError(
+          'Create token options can\'t be null when creating a create token transaction.'
+        );
+      }
+
+      // It's a token creation transaction
+      // then we get the token creation data from the utils method
+      // and concatenate the nano actions inputs/outputs/tokens
+      const data = await tokensUtils.prepareCreateTokenData(
+        this.createTokenOptions.mintAddress,
+        this.createTokenOptions.name,
+        this.createTokenOptions.symbol,
+        this.createTokenOptions.amount,
+        this.wallet.storage,
+        {
+          changeAddress: this.createTokenOptions.changeAddress,
+          createMint: this.createTokenOptions.createMint,
+          mintAuthorityAddress: this.createTokenOptions.mintAuthorityAddress,
+          createMelt: this.createTokenOptions.createMelt,
+          meltAuthorityAddress: this.createTokenOptions.meltAuthorityAddress,
+          data: this.createTokenOptions.data,
+          isCreateNFT: this.createTokenOptions.isCreateNFT,
+          skipDepositFee: this.createTokenOptions.contractPaysTokenDeposit,
+        }
       );
+
+      data.inputs = concat(data.inputs, inputs);
+      data.outputs = concat(data.outputs, outputs);
+      data.tokens = uniq(concat(data.tokens, tokens));
+
+      return transactionUtils.createTransactionFromData(data, this.wallet.getNetworkObject());
     }
 
-    // It's a token creation transaction
-    // then we get the token creation data from the utils method
-    // and concatenate the nano actions inputs/outputs/tokens
-    const data = await tokensUtils.prepareCreateTokenData(
-      this.createTokenOptions.mintAddress,
-      this.createTokenOptions.name,
-      this.createTokenOptions.symbol,
-      this.createTokenOptions.amount,
-      this.wallet.storage,
-      {
-        changeAddress: this.createTokenOptions.changeAddress,
-        createMint: this.createTokenOptions.createMint,
-        mintAuthorityAddress: this.createTokenOptions.mintAuthorityAddress,
-        createMelt: this.createTokenOptions.createMelt,
-        meltAuthorityAddress: this.createTokenOptions.meltAuthorityAddress,
-        data: this.createTokenOptions.data,
-        isCreateNFT: this.createTokenOptions.isCreateNFT,
-        skipDepositFee: this.createTokenOptions.contractPaysTokenDeposit,
-      }
-    );
-
-    data.inputs = concat(data.inputs, inputs);
-    data.outputs = concat(data.outputs, outputs);
-    data.tokens = uniq(concat(data.tokens, tokens));
-
-    return transactionUtils.createTransactionFromData(data, this.wallet.getNetworkObject());
+    throw new NanoContractTransactionError('Invalid vertex type.');
   }
 
   /**

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -483,7 +483,7 @@ class NanoContractTransactionBuilder {
     if (this.vertexType === NanoContractVertexType.CREATE_TOKEN_TRANSACTION) {
       if (this.createTokenOptions === null) {
         throw new NanoContractTransactionError(
-          'Create token options can\'t be null when creating a create token transaction.'
+          'Create token options cannot be null when creating a create token transaction.'
         );
       }
 

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -15,6 +15,11 @@ export type NanoContractArgumentApiInputType =
   | null;
 export type NanoContractArgumentType = NanoContractArgumentApiInputType | Buffer;
 
+export enum NanoContractVertexType {
+  TRANSACTION = 'transaction',
+  CREATE_TOKEN_TRANSACTION = 'createTokenTransaction',
+}
+
 export enum NanoContractActionType {
   DEPOSIT = 'deposit',
   WITHDRAWAL = 'withdrawal',
@@ -46,7 +51,7 @@ export interface NanoContractAction {
   type: NanoContractActionType;
   token: string;
   amount: OutputValueType;
-  // For withdrawal is required, which is address to send the output
+  // For withdrawal is optional, which is address to send the output, in case one is created
   // For deposit is optional, and it's the address to filter the utxos
   address: string | null;
   // For deposit action is the change address used by the change output after selecting the utxos
@@ -134,4 +139,31 @@ export interface NanoContractStateAPIParameters {
   calls: string[];
   block_hash?: string;
   block_height?: number;
+}
+
+export interface NanoContractBuilderCreateTokenOptions {
+  // Token name
+  name: string;
+  // Token symbol
+  symbol: string;
+  // Token mint amount
+  amount: OutputValueType;
+  // Address to send the minted tokens
+  mintAddress: string;
+  // If the contract will pay for the token deposit fee
+  contractPaysTokenDeposit: boolean;
+  // Change address to send change values
+  changeAddress: string | null;
+  // If should create a mint authority output
+  createMint: boolean;
+  // The address to send the mint authority output to
+  mintAuthorityAddress: string | null;
+  // If should create a melt authority output
+  createMelt: boolean;
+  // The address to send the melt authority output to
+  meltAuthorityAddress: string | null;
+  // List of data strings to create data outputs
+  data: string[] | null;
+  // If this token is an NFT
+  isCreateNFT: boolean;
 }

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -3094,7 +3094,9 @@ class HathorWallet extends EventEmitter {
       // Validate that the mint authority address belongs to the wallet
       const isAddressMine = await this.isAddressMine(newCreateTokenOptions.mintAuthorityAddress);
       if (!isAddressMine) {
-        throw new NanoContractTransactionError('The mint authority address must belong to your wallet.');
+        throw new NanoContractTransactionError(
+          'The mint authority address must belong to your wallet.'
+        );
       }
     }
 
@@ -3105,7 +3107,9 @@ class HathorWallet extends EventEmitter {
       // Validate that the melt authority address belongs to the wallet
       const isAddressMine = await this.isAddressMine(newCreateTokenOptions.meltAuthorityAddress);
       if (!isAddressMine) {
-        throw new NanoContractTransactionError('The melt authority address must belong to your wallet.');
+        throw new NanoContractTransactionError(
+          'The melt authority address must belong to your wallet.'
+        );
       }
     }
 

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -3094,7 +3094,7 @@ class HathorWallet extends EventEmitter {
       // Validate that the mint authority address belongs to the wallet
       const isAddressMine = await this.isAddressMine(newCreateTokenOptions.mintAuthorityAddress);
       if (!isAddressMine) {
-        throw new Error('The mint authority address must belong to your wallet.');
+        throw new NanoContractTransactionError('The mint authority address must belong to your wallet.');
       }
     }
 
@@ -3105,7 +3105,7 @@ class HathorWallet extends EventEmitter {
       // Validate that the melt authority address belongs to the wallet
       const isAddressMine = await this.isAddressMine(newCreateTokenOptions.meltAuthorityAddress);
       if (!isAddressMine) {
-        throw new Error('The melt authority address must belong to your wallet.');
+        throw new NanoContractTransactionError('The melt authority address must belong to your wallet.');
       }
     }
 

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -51,6 +51,7 @@ import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../
 import NanoContractTransactionBuilder from '../nano_contracts/builder';
 import { prepareNanoSendTransaction } from '../nano_contracts/utils';
 import OnChainBlueprint, { Code, CodeKind } from '../nano_contracts/on_chain_blueprint';
+import { NanoContractVertexType } from '../nano_contracts/types';
 import { IHistoryTxSchema } from '../schemas';
 import GLL from '../sync/gll';
 import { WalletTxTemplateInterpreter, TransactionTemplate } from '../template/transaction';
@@ -2935,7 +2936,7 @@ class HathorWallet extends EventEmitter {
    */
 
   /**
-   * Create and send a nano contract transaction
+   * Create and send a Transaction with nano header
    *
    * @param {string} method Method of nano contract to have the transaction created
    * @param {string} address Address that will be used to sign the nano contract transaction
@@ -2955,7 +2956,7 @@ class HathorWallet extends EventEmitter {
   }
 
   /**
-   * Create a nano contract transaction and return the SendTransaction object
+   * Create a Transaction with nano header and return the SendTransaction object
    *
    * @param {string} method Method of nano contract to have the transaction created
    * @param {string} address Address that will be used to sign the nano contract transaction
@@ -2991,7 +2992,145 @@ class HathorWallet extends EventEmitter {
       .setNcId(data.ncId)
       .setCaller(Buffer.from(pubkeyStr, 'hex'))
       .setActions(data.actions)
-      .setArgs(data.args);
+      .setArgs(data.args)
+      .setVertexType(NanoContractVertexType.TRANSACTION);
+
+    const nc = await builder.build();
+    return prepareNanoSendTransaction(nc, pin, this.storage);
+  }
+
+  /**
+   * @typedef {Object} CreateTokenTxOptions
+   * @property {string} [name] Token name
+   * @property {string} [symbol] Token symbol
+   * @property {OutputValueType} [amount] Token mint amount
+   * @property {boolean} [contractPaysTokenDeposit] If the contract will pay for the token deposit fee
+   * @property {string?} [mintAddress] Address to send the minted tokens
+   * @property {string?} [changeAddress] Change address to send change values
+   * @property {boolean?} [createMint] If should create a mint authority output
+   * @property {string?} [mintAuthorityAddress] The address to send the mint authority output to
+   * @property {boolean?} [allowExternalMintAuthorityAddress] If should accept an external mint authority address
+   * @property {boolean?} [createMelt] If should create a melt authority output
+   * @property {string?} [meltAuthorityAddress] The address to send the melt authority output to
+   * @property {boolean?} [allowExternalMeltAuthorityAddress] If should accept an external melt authority address
+   * @property {string[]?} [data] List of data strings to create data outputs
+   * @property {boolean?} [isCreateNFT] If this token is an NFT
+   */
+
+  /**
+   * Create and send a Create Token Transaction with nano header
+   *
+   * @param {string} method Method of nano contract to have the transaction created
+   * @param {string} address Address that will be used to sign the nano contract transaction
+   * @param {CreateNanoTxData} [data]
+   * @param {CreateNanoTxData} [data]
+   * @param {CreateTokenTxOptions} [createTokenOptions]
+   * @param {CreateNanoTxOptions} [options]
+   *
+   * @returns {Promise<Transaction>}
+   */
+  async createAndSendNanoContractCreateTokenTransaction(
+    method,
+    address,
+    data,
+    createTokenOptions,
+    options = {}
+  ) {
+    const sendTransaction = await this.createNanoContractCreateTokenTransaction(
+      method,
+      address,
+      data,
+      createTokenOptions,
+      options
+    );
+    return sendTransaction.runFromMining();
+  }
+
+  /**
+   * Create a Create Token Transaction with nano header and return the SendTransaction object
+   *
+   * @param {string} method Method of nano contract to have the transaction created
+   * @param {string} address Address that will be used to sign the nano contract transaction
+   * @param {CreateNanoTxData} [data]
+   * @param {CreateTokenTxOptions} [createTokenOptions]
+   * @param {CreateNanoTxOptions} [options]
+   *
+   * @returns {Promise<SendTransaction>}
+   */
+  async createNanoContractCreateTokenTransaction(
+    method,
+    address,
+    data,
+    createTokenOptions,
+    options = {}
+  ) {
+    if (await this.storage.isReadonly()) {
+      throw new WalletFromXPubGuard('createNanoContractCreateTokenTransaction');
+    }
+    const newOptions = { pinCode: null, ...options };
+    const pin = newOptions.pinCode || this.pinCode;
+    if (!pin) {
+      throw new PinRequiredError(ERROR_MESSAGE_PIN_REQUIRED);
+    }
+
+    const newCreateTokenOptions = {
+      mintAddress: null,
+      changeAddress: null,
+      createMint: true,
+      mintAuthorityAddress: null,
+      allowExternalMintAuthorityAddress: false,
+      createMelt: true,
+      meltAuthorityAddress: null,
+      allowExternalMeltAuthorityAddress: false,
+      data: null,
+      isCreateNFT: false,
+      ...createTokenOptions,
+    };
+
+    if (
+      newCreateTokenOptions.mintAuthorityAddress &&
+      !newCreateTokenOptions.allowExternalMintAuthorityAddress
+    ) {
+      // Validate that the mint authority address belongs to the wallet
+      const isAddressMine = await this.isAddressMine(newCreateTokenOptions.mintAuthorityAddress);
+      if (!isAddressMine) {
+        throw new Error('The mint authority address must belong to your wallet.');
+      }
+    }
+
+    if (
+      newCreateTokenOptions.meltAuthorityAddress &&
+      !newCreateTokenOptions.allowExternalMeltAuthorityAddress
+    ) {
+      // Validate that the melt authority address belongs to the wallet
+      const isAddressMine = await this.isAddressMine(newCreateTokenOptions.meltAuthorityAddress);
+      if (!isAddressMine) {
+        throw new Error('The melt authority address must belong to your wallet.');
+      }
+    }
+
+    newCreateTokenOptions.mintAddress =
+      newCreateTokenOptions.mintAddress || (await this.getCurrentAddress()).address;
+
+    // Get caller pubkey
+    const addressInfo = await this.storage.getAddressInfo(address);
+    if (!addressInfo) {
+      throw new NanoContractTransactionError(
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+      );
+    }
+    const pubkeyStr = await this.storage.getAddressPubkey(addressInfo.bip32AddressIndex);
+
+    // Build and send transaction
+    const builder = new NanoContractTransactionBuilder()
+      .setMethod(method)
+      .setWallet(this)
+      .setBlueprintId(data.blueprintId)
+      .setNcId(data.ncId)
+      .setCaller(Buffer.from(pubkeyStr, 'hex'))
+      .setActions(data.actions)
+      .setArgs(data.args)
+      .setVertexType(NanoContractVertexType.CREATE_TOKEN_TRANSACTION, createTokenOptions);
 
     const nc = await builder.build();
     return prepareNanoSendTransaction(nc, pin, this.storage);


### PR DESCRIPTION
### Acceptance Criteria

- Add method in the wallet facade to create a Create Token Transaction with nano header.
- Add new flag to the mint/create token utils methods to skip deposit fee management (so the contract can handle it)
- Refactor NanoContractBuilder build method in different methods (verify, serializeArgs, buildInputsOutputs, buildTransaction)
- Add support in NanoContractBuilder to create a Transaction or CreateTokenTransaction with nano header and with possibility for the contract's withdrawal action to pay for the token creation deposit fee.