### PR TITLE
chore: prepare nc argument to api input

### DIFF
--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -14,6 +14,8 @@ import {
   BufferROExtract,
   NanoContractSignedData,
   NanoContractArgumentSingleType,
+  NanoContractArgumentSingleTypeName,
+  NanoContractArgumentSingleTypeNameSchema,
 } from './types';
 import { OutputValueType } from '../types';
 import { NC_ARGS_MAX_BYTES_LENGTH } from '../constants';
@@ -267,7 +269,7 @@ class Deserializer {
    * @memberof Deserializer
    * @inner
    */
-  toOptional(buf: Buffer, type: string): BufferROExtract<NanoContractArgumentType> {
+  toOptional(buf: Buffer, type: NanoContractArgumentSingleTypeName): BufferROExtract<NanoContractArgumentType> {
     if (buf[0] === 0) {
       // It's an empty optional
       return {
@@ -297,7 +299,7 @@ class Deserializer {
    * @memberof Deserializer
    * @inner
    */
-  toSignedData(signedData: Buffer, type: string): BufferROExtract<NanoContractSignedData> {
+  toSignedData(signedData: Buffer, type: NanoContractArgumentSingleTypeName): BufferROExtract<NanoContractSignedData> {
     // The SignedData is serialized as `data+Signature`
 
     // Reading argument
@@ -334,7 +336,7 @@ class Deserializer {
    * @inner
    */
   toTuple(buf: Buffer, type: string): BufferROExtract<NanoContractArgumentSingleType[]> {
-    const typeArr = type.split(',').map(s => s.trim());
+    const typeArr = type.split(',').map(s => NanoContractArgumentSingleTypeNameSchema.parse(s.trim()));
     const tupleValues: NanoContractArgumentSingleType[] = [];
     let bytesReadTotal = 0;
     let tupleBuf = buf.subarray();

--- a/src/nano_contracts/methodArg.ts
+++ b/src/nano_contracts/methodArg.ts
@@ -15,6 +15,11 @@ import {
   NanoContractArgumentApiInputType,
   NanoContractArgumentApiInputSchema,
   NanoContractArgumentByteTypes,
+  NanoContractArgumentTypeName,
+  NanoContractArgumentSingleTypeName,
+  NanoContractArgumentSingleSchema,
+  NanoContractArgumentSingleTypeNameSchema,
+  NanoContractArgumentTypeNameSchema,
 } from './types';
 import Serializer from './serializer';
 import Deserializer from './deserializer';
@@ -29,7 +34,7 @@ import Address from '../models/address';
 function refineSingleValue(
   ctx: z.RefinementCtx,
   inputVal: NanoContractArgumentApiInputType,
-  type: string
+  type: NanoContractArgumentSingleTypeName
 ) {
   if (['int', 'Timestamp'].includes(type)) {
     const parse = z.coerce.number().safeParse(inputVal);
@@ -133,7 +138,7 @@ function refineSingleValue(
  */
 const SingleValueApiInputScheme = z
   .tuple([
-    z.string(), // type
+    NanoContractArgumentSingleTypeNameSchema, // type
     NanoContractArgumentApiInputSchema, // value
   ])
   .transform((value, ctx) => {
@@ -146,7 +151,7 @@ const SingleValueApiInputScheme = z
  */
 const OptionalApiInputScheme = z
   .tuple([
-    z.string(), // Inner type
+    NanoContractArgumentSingleTypeNameSchema, // Inner type
     NanoContractArgumentApiInputSchema, // value
   ])
   .transform((value, ctx) => {
@@ -165,7 +170,7 @@ const OptionalApiInputScheme = z
 const SignedDataApiInputScheme = z
   .string()
   .transform(value => value.split(','))
-  .pipe(z.tuple([z.string().regex(/^[0-9A-Fa-f]+$/), z.string(), z.string()]))
+  .pipe(z.tuple([z.string().regex(/^[0-9A-Fa-f]+$/), z.string(), NanoContractArgumentSingleTypeNameSchema]))
   .transform((value, ctx) => {
     const signature = Buffer.from(value[0], 'hex');
     const type = value[2];
@@ -181,7 +186,7 @@ const SignedDataApiInputScheme = z
 export class NanoContractMethodArgument {
   name: string;
 
-  type: string;
+  type: NanoContractArgumentTypeName;
 
   value: NanoContractArgumentType;
 
@@ -189,7 +194,7 @@ export class NanoContractMethodArgument {
 
   constructor(name: string, type: string, value: NanoContractArgumentType) {
     this.name = name;
-    this.type = type;
+    this.type = NanoContractArgumentTypeNameSchema.parse(type);
     this.value = value;
     this._serialized = Buffer.alloc(0);
   }
@@ -266,36 +271,60 @@ export class NanoContractMethodArgument {
    * This is a helper method, so we can create the api input representation of the arg value.
    */
   toApiInput(): NanoContractParsedArgument {
-    function prepSingleValue(type: string, value: NanoContractArgumentSingleType) {
-      if (type === 'bool') {
-        return (value as boolean) ? 'true' : 'false';
-      }
-      if (NanoContractArgumentByteTypes.safeParse(type).success) {
-        return (value as Buffer).toString('hex');
-      }
-      if (type === 'VarInt') {
-        return String(value as bigint);
-      }
-      return value;
-    }
-
-    if (this.type.startsWith('SignedData') || this.type.startsWith('RawSignedData')) {
-      const data = this.value as NanoContractSignedData;
-      return {
-        name: this.name,
-        type: this.type,
-        parsed: [
-          data.signature.toString('hex'),
-          prepSingleValue(data.type, data.value),
-          this.type,
-        ].join(','),
-      };
-    }
-
     return {
       name: this.name,
       type: this.type,
-      parsed: prepSingleValue(this.type, this.value as NanoContractArgumentSingleType),
+      parsed: NanoContractMethodArgument.prepValue(this.value, this.type),
     };
+  }
+
+  /**
+   * Prepare value for ApiInput, converting single types to NanoContractArgumentApiInputType
+   */
+  static prepSingleValue(value: NanoContractArgumentSingleType, type: NanoContractArgumentSingleTypeName): NanoContractArgumentApiInputType {
+    if (type === 'bool') {
+      return (value as boolean) ? 'true' : 'false';
+    }
+    if (NanoContractArgumentByteTypes.safeParse(type).success) {
+      return (value as Buffer).toString('hex');
+    }
+    if (value instanceof Buffer) {
+      // Should not happen since all bytes values were caught, this is to satisfy typing
+      return value.toString('hex');
+    }
+    if (type === 'VarInt') {
+      return String(value as bigint);
+    }
+    return value;
+  }
+
+  /**
+   * Prepare value for ApiInput, converting any type to NanoContractArgumentApiInputType
+   * Works for container values, converting the inner value as well if needed
+   */
+  static prepValue(value: NanoContractArgumentType, type: NanoContractArgumentTypeName): NanoContractArgumentApiInputType {
+    const isContainerType = getContainerType(type) !== null;
+    if (isContainerType) {
+      const [containerType, innerType] = getContainerInternalType(type);
+      if (containerType === 'SignedData' || containerType === 'RawSignedData') {
+        const data = value as NanoContractSignedData;
+        return [
+          data.signature.toString('hex'),
+          NanoContractMethodArgument.prepSingleValue(data.value, data.type),
+          type,
+        ].join(',');
+      }
+
+      if (containerType === 'Optional') {
+        return value && NanoContractMethodArgument.prepSingleValue(value as NanoContractArgumentSingleType, innerType);
+      }
+
+      throw new Error(`Untreated container type(${type}) for value ${value}`);
+    }
+
+    return NanoContractMethodArgument.prepSingleValue(
+      NanoContractArgumentSingleSchema.parse(value),
+      NanoContractArgumentSingleTypeNameSchema.parse(type),
+    );
   }
 }

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -7,57 +7,6 @@
 import { z } from 'zod';
 import { IHistoryTx, OutputValueType } from '../types';
 
-/**
- * There are the types that can be received via api
- * when querying for a nano contract value.
- */
-export const NanoContractArgumentApiInputSchema = z.union([
-  z.string(),
-  z.number(),
-  z.bigint(),
-  z.boolean(),
-  z.null(),
-]);
-export type NanoContractArgumentApiInputType = z.output<typeof NanoContractArgumentApiInputSchema>;
-
-/**
- * These are the possible `Single` types after parsing
- * We include Buffer since some types are decoded as Buffer (e.g. bytes, TokenUid, ContractId)
- */
-export const NanoContractArgumentSingleSchema = z.union([
-  NanoContractArgumentApiInputSchema,
-  z.instanceof(Buffer),
-]);
-export type NanoContractArgumentSingleType = z.output<typeof NanoContractArgumentSingleSchema>;
-
-/**
- * NanoContract SignedData method argument type
- */
-export const NanoContractSignedDataSchema = z.object({
-  type: z.string(),
-  signature: z.instanceof(Buffer),
-  value: NanoContractArgumentSingleSchema,
-});
-export type NanoContractSignedData = z.output<typeof NanoContractSignedDataSchema>;
-
-/**
- * Intermediate schema for all possible Nano contract argument type
- * that do not include tuple/arrays/repetition
- */
-const _NanoContractArgumentType1Schema = z.union([
-  NanoContractArgumentSingleSchema,
-  NanoContractSignedDataSchema,
-]);
-
-/**
- * Nano Contract method argument type as a native TS type
- */
-export const NanoContractArgumentSchema = z.union([
-  _NanoContractArgumentType1Schema,
-  z.array(_NanoContractArgumentType1Schema),
-]);
-export type NanoContractArgumentType = z.output<typeof NanoContractArgumentSchema>;
-
 export const NanoContractArgumentByteTypes = z.enum([
   'bytes',
   'BlueprintId',
@@ -95,6 +44,63 @@ export const NanoContractArgumentContainerTypeNameSchema = z.enum([
 export type NanoContractArgumentContainerType = z.output<
   typeof NanoContractArgumentContainerTypeNameSchema
 >;
+
+export const NanoContractArgumentTypeNameSchema = z.enum([
+  ...NanoContractArgumentSingleTypeNameSchema.options,
+  ...NanoContractArgumentContainerTypeNameSchema.options,
+]);
+export type NanoContractArgumentTypeName = z.output<typeof NanoContractArgumentTypeNameSchema>;
+
+/**
+ * There are the types that can be received via api
+ * when querying for a nano contract value.
+ */
+export const NanoContractArgumentApiInputSchema = z.union([
+  z.string(),
+  z.number(),
+  z.bigint(),
+  z.boolean(),
+  z.null(),
+]);
+export type NanoContractArgumentApiInputType = z.output<typeof NanoContractArgumentApiInputSchema>;
+
+/**
+ * These are the possible `Single` types after parsing
+ * We include Buffer since some types are decoded as Buffer (e.g. bytes, TokenUid, ContractId)
+ */
+export const NanoContractArgumentSingleSchema = z.union([
+  NanoContractArgumentApiInputSchema,
+  z.instanceof(Buffer),
+]);
+export type NanoContractArgumentSingleType = z.output<typeof NanoContractArgumentSingleSchema>;
+
+/**
+ * NanoContract SignedData method argument type
+ */
+export const NanoContractSignedDataSchema = z.object({
+  type: NanoContractArgumentSingleTypeNameSchema,
+  signature: z.instanceof(Buffer),
+  value: NanoContractArgumentSingleSchema,
+});
+export type NanoContractSignedData = z.output<typeof NanoContractSignedDataSchema>;
+
+/**
+ * Intermediate schema for all possible Nano contract argument type
+ * that do not include tuple/arrays/repetition
+ */
+const _NanoContractArgumentType1Schema = z.union([
+  NanoContractArgumentSingleSchema,
+  NanoContractSignedDataSchema,
+]);
+
+/**
+ * Nano Contract method argument type as a native TS type
+ */
+export const NanoContractArgumentSchema = z.union([
+  _NanoContractArgumentType1Schema,
+  z.array(_NanoContractArgumentType1Schema),
+]);
+export type NanoContractArgumentType = z.output<typeof NanoContractArgumentSchema>;
 
 export enum NanoContractVertexType {
   TRANSACTION = 'transaction',

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -27,6 +27,8 @@ import {
   MethodArgInfo,
   NanoContractArgumentContainerType,
   NanoContractArgumentApiInputType,
+  NanoContractArgumentSingleTypeName,
+  NanoContractArgumentSingleTypeNameSchema,
 } from './types';
 import { NANO_CONTRACTS_INITIALIZE_METHOD } from '../constants';
 import { NanoContractMethodArgument } from './methodArg';
@@ -34,10 +36,11 @@ import leb128 from '../utils/leb128';
 
 export function getContainerInternalType(
   type: string
-): [NanoContractArgumentContainerType, string] {
+): [NanoContractArgumentContainerType, NanoContractArgumentSingleTypeName] {
   if (type.endsWith('?')) {
     // Optional value
-    return ['Optional', type.slice(0, -1)];
+    const innerType = type.slice(0, -1);
+    return ['Optional', NanoContractArgumentSingleTypeNameSchema.parse(innerType)];
   }
 
   // ContainerType[internalType]
@@ -53,7 +56,7 @@ export function getContainerInternalType(
     case 'SignedData':
     case 'RawSignedData':
     case 'Optional':
-      return [containerType, internalType];
+      return [containerType, NanoContractArgumentSingleTypeNameSchema.parse(internalType)];
     default:
       throw new Error('Not a ContainerType');
   }


### PR DESCRIPTION
### Motivation

The old nano contract argument parsed values would convert to either number or string (with formats based on type), we improved this system to use typescript native typing and left a `NanoContractMethodArgument.toApiInput` method to convert to the old value if needed but since there was no use on the lib it stayed untested.

The explorer was using the old parsed values to show a human-readable version of the values so we now have a reason to improve the `toApiInput` method, making it complete (convert all supported types) and checking the types and values being converted so we do not silently show an invalid type on the explorer.

### Acceptance Criteria
- Make the `NanoContractMethodArgument.toApiInput` complete and more strictly validated.


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
