### PR TITLE
feat: update nano contract integration with new hathor core version

### DIFF
--- a/__tests__/integration/configuration/authority.py
+++ b/__tests__/integration/configuration/authority.py
@@ -19,10 +19,9 @@ from hathor.nanocontracts.types import (
     NCAction,
     NCDepositAction,
     NCGrantAuthorityAction,
-    NCInvokeAuthorityAction,
+    NCAcquireAuthorityAction,
     NCWithdrawalAction,
     TokenUid,
-    is_action_type,
     public,
 )
 
@@ -41,23 +40,23 @@ class AuthorityBlueprint(Blueprint):
         # Deposit so it can have funds to pay token deposit fee
         # for create token method
         action = self._get_action(ctx)
-        assert is_action_type(action, NCDepositAction)
+        assert isinstance(action, NCDepositAction)
 
     @public(allow_withdrawal=True)
     def create_token(self, ctx: Context) -> None:
         # Withdrawal to pay for token creation
         action = self._get_action(ctx)
-        assert is_action_type(action, NCWithdrawalAction)
+        assert isinstance(action, NCWithdrawalAction)
 
     @public(allow_grant_authority=True)
     def grant_authority(self, ctx: Context) -> None:
         action = self._get_action(ctx)
-        assert is_action_type(action, NCGrantAuthorityAction)
+        assert isinstance(action, NCGrantAuthorityAction)
 
-    @public(allow_invoke_authority=True)
-    def invoke_authority(self, ctx: Context) -> None:
+    @public(allow_acquire_authority=True)
+    def acquire_authority(self, ctx: Context) -> None:
         action = self._get_action(ctx)
-        assert is_action_type(action, NCInvokeAuthorityAction)
+        assert isinstance(action, NCAcquireAuthorityAction)
 
     @public
     def mint(self, ctx: Context, token_uid: TokenUid, amount: int) -> None:

--- a/__tests__/integration/configuration/bet.py
+++ b/__tests__/integration/configuration/bet.py
@@ -27,7 +27,6 @@ from hathor.nanocontracts.types import (
     Timestamp,
     TokenUid,
     TxOutputScript,
-    is_action_type,
     public,
     view,
 )
@@ -152,7 +151,7 @@ class Bet(Blueprint):
     def bet(self, ctx: Context, address: Address, score: str) -> None:
         """Make a bet."""
         action = self._get_action(ctx)
-        assert is_action_type(action, NCDepositAction)
+        assert isinstance(action, NCDepositAction)
         self.fail_if_result_is_available()
         self.fail_if_invalid_token(action)
         if ctx.timestamp > self.date_last_bet:
@@ -189,7 +188,7 @@ class Bet(Blueprint):
     def withdraw(self, ctx: Context) -> None:
         """Withdraw tokens after the final result is set."""
         action = self._get_action(ctx)
-        assert is_action_type(action, NCWithdrawalAction)
+        assert isinstance(action, NCWithdrawalAction)
         self.fail_if_result_is_not_available()
         self.fail_if_invalid_token(action)
         address = Address(ctx.address)

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 
   fullnode:
     image:
-      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:experimental-nano-preview-202505211850-python3.12}
+      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:experimental-nano-preview-20250602-python3.12}
     command: [
       "run_node",
       "--listen", "tcp:40404",

--- a/__tests__/integration/nanocontracts/authority.test.ts
+++ b/__tests__/integration/nanocontracts/authority.test.ts
@@ -333,18 +333,18 @@ describe('Authority actions blueprint test', () => {
     expect(ncStateMelt.balances[txCreateToken.hash].can_mint).toBe(true);
     expect(ncStateMelt.balances[txCreateToken.hash].can_melt).toBe(true);
 
-    // Mint/melt in the contract world doesn't affect this API from utxo world
+    // Mint/melt in the contract affect the token info in the utxo world
     const tokenDetail3 = await wallet.getTokenDetails(txCreateToken.hash);
-    expect(tokenDetail3.totalSupply).toBe(1000n);
+    expect(tokenDetail3.totalSupply).toBe(2000n);
     expect(tokenDetail3.authorities.mint).toBe(false);
     expect(tokenDetail3.authorities.melt).toBe(true);
 
-    // We will invoke a mint authority to an output
-    const invokeData = {
+    // We will acquire a mint authority to an output
+    const acquireData = {
       ncId: txInitialize.hash,
       actions: [
         {
-          type: 'invoke_authority',
+          type: 'acquire_authority',
           token: txCreateToken.hash,
           authority: 'mint',
           address: address1,
@@ -352,37 +352,37 @@ describe('Authority actions blueprint test', () => {
       ],
     };
 
-    const txInvoke = await wallet.createAndSendNanoContractTransaction(
-      'invoke_authority',
+    const txAcquire = await wallet.createAndSendNanoContractTransaction(
+      'acquire_authority',
       address0,
-      invokeData
+      acquireData
     );
-    await checkTxValid(wallet, txInvoke);
-    const txInvokeData = await wallet.getFullTxById(txInvoke.hash);
+    await checkTxValid(wallet, txAcquire);
+    const txAcquireData = await wallet.getFullTxById(txAcquire.hash);
 
-    expect(txInvokeData.tx.nc_id).toBe(txInitialize.hash);
-    expect(txInvokeData.tx.nc_method).toBe('invoke_authority');
-    expect(txInvokeData.tx.outputs.length).toBe(1);
-    expect(txInvokeData.tx.inputs.length).toBe(0);
+    expect(txAcquireData.tx.nc_id).toBe(txInitialize.hash);
+    expect(txAcquireData.tx.nc_method).toBe('acquire_authority');
+    expect(txAcquireData.tx.outputs.length).toBe(1);
+    expect(txAcquireData.tx.inputs.length).toBe(0);
     // Mint authority output
-    expect(txInvokeData.tx.outputs[0].value).toBe(1n);
-    expect(txInvokeData.tx.outputs[0].token_data).toBe(129);
-    expect(txInvokeData.tx.outputs[0].decoded.address).toBe(address1);
+    expect(txAcquireData.tx.outputs[0].value).toBe(1n);
+    expect(txAcquireData.tx.outputs[0].token_data).toBe(129);
+    expect(txAcquireData.tx.outputs[0].decoded.address).toBe(address1);
 
-    const ncStateInvoke = await ncApi.getNanoContractState(
+    const ncStateAcquire = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
       [txCreateToken.hash, NATIVE_TOKEN_UID]
     );
 
-    expect(BigInt(ncStateInvoke.balances[NATIVE_TOKEN_UID].value)).toBe(60n);
-    expect(BigInt(ncStateInvoke.balances[txCreateToken.hash].value)).toBe(1000n);
-    expect(ncStateInvoke.balances[txCreateToken.hash].can_mint).toBe(true);
-    expect(ncStateInvoke.balances[txCreateToken.hash].can_melt).toBe(true);
+    expect(BigInt(ncStateAcquire.balances[NATIVE_TOKEN_UID].value)).toBe(60n);
+    expect(BigInt(ncStateAcquire.balances[txCreateToken.hash].value)).toBe(1000n);
+    expect(ncStateAcquire.balances[txCreateToken.hash].can_mint).toBe(true);
+    expect(ncStateAcquire.balances[txCreateToken.hash].can_melt).toBe(true);
 
     // Now we can mint again in the utxo world
     const tokenDetail4 = await wallet.getTokenDetails(txCreateToken.hash);
-    expect(tokenDetail4.totalSupply).toBe(1000n);
+    expect(tokenDetail4.totalSupply).toBe(2000n);
     expect(tokenDetail4.authorities.mint).toBe(true);
     expect(tokenDetail4.authorities.melt).toBe(true);
 
@@ -412,7 +412,7 @@ describe('Authority actions blueprint test', () => {
 
     // The token detail in the utxo world did not change
     const tokenDetail5 = await wallet.getTokenDetails(txCreateToken.hash);
-    expect(tokenDetail5.totalSupply).toBe(1000n);
+    expect(tokenDetail5.totalSupply).toBe(2000n);
     expect(tokenDetail5.authorities.mint).toBe(true);
     expect(tokenDetail5.authorities.melt).toBe(true);
 

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -310,10 +310,13 @@ describe('full cycle of bet nano contract', () => {
       'final_result',
       'oracle_script',
       'date_last_bet',
+      /*
+      `address_details.${address2}`,
       `address_details.a'${address2}'`,
-      `withdrawals.a'${address2}'`,
-      `address_details.a'${address3}'`,
-      `withdrawals.a'${address3}'`,
+      `withdrawals.${address2}`,
+      `address_details.${address3}`,
+      `withdrawals.${address3}`,
+      */
     ]);
     const addressObj1 = new Address(address1, { network });
     const outputScriptType = addressObj1.getType();
@@ -332,10 +335,12 @@ describe('full cycle of bet nano contract', () => {
     expect(ncState.fields.oracle_script.value).toBe(bufferToHex(outputScriptBuffer1));
     expect(ncState.fields.final_result.value).toBeNull();
     expect(ncState.fields.total.value).toBe(300);
-    expect(ncState.fields[`address_details.a'${address2}'`].value).toHaveProperty('1x0', 100);
-    expect(ncState.fields[`withdrawals.a'${address2}'`].value).toBeUndefined();
-    expect(ncState.fields[`address_details.a'${address3}'`].value).toHaveProperty('2x0', 200);
-    expect(ncState.fields[`withdrawals.a'${address3}'`].value).toBeUndefined();
+    /*
+    expect(ncState.fields[`address_details.${address2}`].value).toHaveProperty('1x0', 100);
+    expect(ncState.fields[`withdrawals.${address2}`].value).toBeUndefined();
+    expect(ncState.fields[`address_details.${address3}`].value).toHaveProperty('2x0', 200);
+    expect(ncState.fields[`withdrawals.${address3}`].value).toBeUndefined();
+    */
 
     // Set result to '1x0'
     const nanoSerializer = new Serializer(network);
@@ -482,20 +487,24 @@ describe('full cycle of bet nano contract', () => {
       'final_result',
       'oracle_script',
       'date_last_bet',
-      `address_details.a'${address2}'`,
-      `withdrawals.a'${address2}'`,
-      `address_details.a'${address3}'`,
-      `withdrawals.a'${address3}'`,
+      /*
+      `address_details.${address2}`,
+      `withdrawals.${address2}`,
+      `address_details.${address3}`,
+      `withdrawals.${address3}`,
+      */
     ]);
     expect(ncState2.fields.token_uid.value).toBe(NATIVE_TOKEN_UID);
     expect(ncState2.fields.date_last_bet.value).toBe(dateLastBet);
     expect(ncState2.fields.oracle_script.value).toBe(bufferToHex(outputScriptBuffer1));
     expect(ncState2.fields.final_result.value).toBe('1x0');
     expect(ncState2.fields.total.value).toBe(300);
-    expect(ncState2.fields[`address_details.a'${address2}'`].value).toHaveProperty('1x0', 100);
-    expect(ncState2.fields[`withdrawals.a'${address2}'`].value).toBe(300);
-    expect(ncState2.fields[`address_details.a'${address3}'`].value).toHaveProperty('2x0', 200);
-    expect(ncState2.fields[`withdrawals.a'${address3}'`].value).toBeUndefined();
+    /*
+    expect(ncState2.fields[`address_details.${address2}`].value).toHaveProperty('1x0', 100);
+    expect(ncState2.fields[`withdrawals.${address2}`].value).toBe(300);
+    expect(ncState2.fields[`address_details.${address3}`].value).toHaveProperty('2x0', 200);
+    expect(ncState2.fields[`withdrawals.${address3}`].value).toBeUndefined();
+    */
     // Get history again
     const ncHistory2 = await ncApi.getNanoContractHistory(tx1.hash);
     expect(ncHistory2.history.length).toBe(5);
@@ -521,10 +530,12 @@ describe('full cycle of bet nano contract', () => {
         'final_result',
         'oracle_script',
         'date_last_bet',
-        `address_details.a'${address2}'`,
-        `withdrawals.a'${address2}'`,
-        `address_details.a'${address3}'`,
-        `withdrawals.a'${address3}'`,
+        /*
+        `address_details.${address2}`,
+        `withdrawals.${address2}`,
+        `address_details.${address3}`,
+        `withdrawals.${address3}`,
+        */
       ],
       [],
       [],
@@ -536,16 +547,18 @@ describe('full cycle of bet nano contract', () => {
     expect(ncStateFirstBlock.fields.oracle_script.value).toBe(bufferToHex(outputScriptBuffer1));
     expect(ncStateFirstBlock.fields.final_result.value).toBeNull();
     expect(ncStateFirstBlock.fields.total.value).toBe(300);
-    expect(ncStateFirstBlock.fields[`address_details.a'${address2}'`].value).toHaveProperty(
+    /*
+    expect(ncStateFirstBlock.fields[`address_details.${address2}`].value).toHaveProperty(
       '1x0',
       100
     );
-    expect(ncStateFirstBlock.fields[`withdrawals.a'${address2}'`].value).toBeUndefined();
-    expect(ncStateFirstBlock.fields[`address_details.a'${address3}'`].value).toHaveProperty(
+    expect(ncStateFirstBlock.fields[`withdrawals.${address2}`].value).toBeUndefined();
+    expect(ncStateFirstBlock.fields[`address_details.${address3}`].value).toHaveProperty(
       '2x0',
       200
     );
-    expect(ncStateFirstBlock.fields[`withdrawals.a'${address3}'`].value).toBeUndefined();
+    expect(ncStateFirstBlock.fields[`withdrawals.${address3}`].value).toBeUndefined();
+    */
 
     // Get NC state in the past, using txBet2 first block height
     const ncStateFirstBlockHeight = await ncApi.getNanoContractState(
@@ -556,10 +569,12 @@ describe('full cycle of bet nano contract', () => {
         'final_result',
         'oracle_script',
         'date_last_bet',
-        `address_details.a'${address2}'`,
-        `withdrawals.a'${address2}'`,
-        `address_details.a'${address3}'`,
-        `withdrawals.a'${address3}'`,
+        /*
+        `address_details.${address2}`,
+        `withdrawals.${address2}`,
+        `address_details.${address3}`,
+        `withdrawals.${address3}`,
+        */
       ],
       [],
       [],
@@ -574,16 +589,18 @@ describe('full cycle of bet nano contract', () => {
     );
     expect(ncStateFirstBlockHeight.fields.final_result.value).toBeNull();
     expect(ncStateFirstBlockHeight.fields.total.value).toBe(300);
-    expect(ncStateFirstBlockHeight.fields[`address_details.a'${address2}'`].value).toHaveProperty(
+    /*
+    expect(ncStateFirstBlockHeight.fields[`address_details.${address2}`].value).toHaveProperty(
       '1x0',
       100
     );
-    expect(ncStateFirstBlockHeight.fields[`withdrawals.a'${address2}'`].value).toBeUndefined();
-    expect(ncStateFirstBlockHeight.fields[`address_details.a'${address3}'`].value).toHaveProperty(
+    expect(ncStateFirstBlockHeight.fields[`withdrawals.${address2}`].value).toBeUndefined();
+    expect(ncStateFirstBlockHeight.fields[`address_details.${address3}`].value).toHaveProperty(
       '2x0',
       200
     );
-    expect(ncStateFirstBlockHeight.fields[`withdrawals.a'${address3}'`].value).toBeUndefined();
+    expect(ncStateFirstBlockHeight.fields[`withdrawals.${address3}`].value).toBeUndefined();
+    */
 
     // Test a tx that becomes voided after the nano execution
     const txWithdrawal2 = await wallet.createAndSendNanoContractTransaction('withdraw', address2, {

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -624,6 +624,13 @@ describe('full cycle of bet nano contract', () => {
     // This voidness called the full processHistory method
     expect(isEmpty(txWithdrawal2Data.meta.voided_by)).toBe(false);
     expect(wallet.storage.processHistory.mock.calls.length).toBe(1);
+
+    // Even if the tx is voided, if it has first_block, the seqnum should increase. This
+    // case the tx became voided after getting a first_block and the nano execution failed
+    // but the number of transactions should still be the same
+    const address2Meta3 = await wallet.storage.store.getAddressMeta(address2);
+    expect(address2Meta3.seqnum).toBe(2);
+    expect(address2Meta3.numTransactions).toBe(2);
   };
 
   it('bet deposit built in', async () => {

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -127,6 +127,7 @@ test('getSignatureForTx signing nano contract when we are not the caller', async
     'drip',
     Buffer.from('cafe', 'hex'),
     [],
+    1,
     new Address('WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp')
   );
   const tx = new Transaction([input], [], { headers: [nano] });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -84,14 +84,6 @@ export const ON_CHAIN_BLUEPRINTS_VERSION = 6;
 export const POA_BLOCK_VERSION = 5;
 
 /**
- * Nano Contracts information version
- * If we decide to change the serialization of nano information
- * data, then we can change this version, so we can
- * correctly deserialize all the nano contract transactions
- */
-export const NANO_CONTRACTS_INFO_VERSION = 1;
-
-/**
  * String with the name of the initialize method of all blueprints
  */
 export const NANO_CONTRACTS_INITIALIZE_METHOD = 'initialize';

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -726,6 +726,7 @@ class NanoContractTransactionBuilder {
       }
 
       const tx = await this.buildTransaction(inputs, outputs, tokens);
+      const seqnum = await this.wallet.getNanoHeaderSeqnum(this.caller!)
 
       let nanoHeaderActions: NanoContractActionHeader[] = [];
 
@@ -740,6 +741,7 @@ class NanoContractTransactionBuilder {
         this.method!,
         this.serializedArgs!,
         nanoHeaderActions,
+        seqnum,
         this.caller!,
         null
       );

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -449,23 +449,23 @@ class NanoContractTransactionBuilder {
   }
 
   /**
-   * Execute an invoke authority action
+   * Execute an acquire authority action
    *
-   * @param {action} Action to be completed (must be an invoke authority type)
+   * @param {action} Action to be completed (must be an acquire authority type)
    *
    * @memberof NanoContractTransactionBuilder
    * @inner
    */
-  executeInvokeAuthority(action: NanoContractAction): IDataOutput | null {
-    if (action.type !== NanoContractActionType.INVOKE_AUTHORITY) {
+  executeAcquireAuthority(action: NanoContractAction): IDataOutput | null {
+    if (action.type !== NanoContractActionType.ACQUIRE_AUTHORITY) {
       throw new NanoContractTransactionError(
-        "Can't execute an invoke authority with an action which type is different than invoke authority."
+        "Can't execute an acquire authority with an action which type is different than acquire authority."
       );
     }
 
     if (!action.address || !action.authority || !action.token) {
       throw new NanoContractTransactionError(
-        'Address, authority, and token are required for invoke authority action.'
+        'Address, authority, and token are required for acquire authority action.'
       );
     }
 
@@ -615,10 +615,10 @@ class NanoContractTransactionBuilder {
             outputs = concat(outputs, grantOutputs);
             break;
           }
-          case NanoContractActionType.INVOKE_AUTHORITY: {
-            const outputInvoke = this.executeInvokeAuthority(action);
-            if (outputInvoke) {
-              outputs = concat(outputs, outputInvoke);
+          case NanoContractActionType.ACQUIRE_AUTHORITY: {
+            const outputAcquire = this.executeAcquireAuthority(action);
+            if (outputAcquire) {
+              outputs = concat(outputs, outputAcquire);
             }
             break;
           }

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -726,7 +726,7 @@ class NanoContractTransactionBuilder {
       }
 
       const tx = await this.buildTransaction(inputs, outputs, tokens);
-      const seqnum = await this.wallet.getNanoHeaderSeqnum(this.caller!)
+      const seqnum = await this.wallet.getNanoHeaderSeqnum(this.caller!);
 
       let nanoHeaderActions: NanoContractActionHeader[] = [];
 

--- a/src/nano_contracts/header.ts
+++ b/src/nano_contracts/header.ts
@@ -112,11 +112,11 @@ class NanoContractHeader extends Header {
     array.push(addressBytes);
 
     if (addScript && this.script !== null) {
-      array.push(intToBytes(this.script.length, 2));
+      array.push(leb128Util.encodeUnsigned(this.script.length, 2));
       array.push(this.script);
     } else {
       // Script with length 0 indicates there is no script.
-      array.push(intToBytes(0, 2));
+      array.push(leb128Util.encodeUnsigned(0, 2));
     }
   }
 
@@ -221,13 +221,16 @@ class NanoContractHeader extends Header {
 
     // nc script
     let scriptLen: number;
-    [scriptLen, buf] = unpackToInt(2, false, buf);
+    ({
+      value: scriptLen,
+      rest: buf,
+    } = leb128Util.decodeUnsigned(buf, 2));
 
     const header = new NanoContractHeader(ncId, method, args, actions, address);
 
     if (scriptLen !== 0) {
       // script might be null
-      [header.script, buf] = unpackLen(scriptLen, buf);
+      [header.script, buf] = unpackLen(Number(scriptLen), buf);
     }
     /* eslint-enable prefer-const */
 

--- a/src/nano_contracts/header.ts
+++ b/src/nano_contracts/header.ts
@@ -178,11 +178,8 @@ class NanoContractHeader extends Header {
     ncId = ncIdBuffer.toString('hex');
 
     // Seqnum has variable length with maximum of 8 bytes
-    let seqnum: number;
-    ({
-      value: seqnum,
-      rest: buf,
-    } = leb128Util.decodeUnsigned(buf, 8));
+    let seqnum: bigint;
+    ({ value: seqnum, rest: buf } = leb128Util.decodeUnsigned(buf, 8));
 
     // nc method
     let methodLen: number;
@@ -220,15 +217,12 @@ class NanoContractHeader extends Header {
     address = helpersUtils.getAddressFromBytes(addressBytes, network);
 
     // nc script
-    let scriptLen: number;
-    ({
-      value: scriptLen,
-      rest: buf,
-    } = leb128Util.decodeUnsigned(buf, 2));
+    let scriptLen: bigint;
+    ({ value: scriptLen, rest: buf } = leb128Util.decodeUnsigned(buf, 2));
 
     const header = new NanoContractHeader(ncId, method, args, actions, Number(seqnum), address);
 
-    if (scriptLen !== 0) {
+    if (scriptLen !== 0n) {
       // script might be null
       [header.script, buf] = unpackLen(Number(scriptLen), buf);
     }

--- a/src/nano_contracts/header.ts
+++ b/src/nano_contracts/header.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { NANO_CONTRACTS_INFO_VERSION } from '../constants';
 import { NanoContractActionHeader } from './types';
 import type Transaction from '../models/transaction';
 import {
@@ -29,9 +28,6 @@ import Network from '../models/network';
 import { OutputValueType } from '../types';
 
 class NanoContractHeader extends Header {
-  // Used to create serialization versioning (hard coded as NANO_CONTRACTS_INFO_VERSION for now)
-  nc_info_version: number;
-
   // It's the blueprint id when this header is calling a initialize method
   // and it's the nano contract id when it's executing another method of a nano
   id: string;
@@ -67,7 +63,6 @@ class NanoContractHeader extends Header {
     script: Buffer | null = null
   ) {
     super();
-    this.nc_info_version = NANO_CONTRACTS_INFO_VERSION;
     this.id = id;
     this.method = method;
     this.args = args;
@@ -88,9 +83,6 @@ class NanoContractHeader extends Header {
    * @inner
    */
   serializeFields(array: Buffer[], addScript: boolean) {
-    // Info version
-    array.push(intToBytes(this.nc_info_version, 1));
-
     // nano contract id
     array.push(hexToBuffer(this.id));
 
@@ -171,7 +163,6 @@ class NanoContractHeader extends Header {
 
     buf = buf.subarray(1);
 
-    let nc_info_version: number;
     let ncId: string;
     let method: string;
     let args: Buffer;
@@ -180,12 +171,6 @@ class NanoContractHeader extends Header {
 
     /* eslint-disable prefer-const -- To split these declarations would be confusing.
      * In all of them the first parameter should be a const and the second a let. */
-    // nc info version
-    [nc_info_version, buf] = unpackToInt(1, false, buf);
-
-    if (nc_info_version !== NANO_CONTRACTS_INFO_VERSION) {
-      throw new Error('Invalid info version for nano header.');
-    }
 
     // NC ID is 32 bytes in hex
     let ncIdBuffer: Buffer;

--- a/src/nano_contracts/header.ts
+++ b/src/nano_contracts/header.ts
@@ -87,7 +87,7 @@ class NanoContractHeader extends Header {
     array.push(hexToBuffer(this.id));
 
     // Seqnum
-    array.push(encodeUnsigned(this.seqnum));
+    array.push(leb128Util.encodeUnsigned(this.seqnum));
 
     const methodBytes = Buffer.from(this.method, 'ascii');
     array.push(intToBytes(methodBytes.length, 1));
@@ -178,11 +178,11 @@ class NanoContractHeader extends Header {
     ncId = ncIdBuffer.toString('hex');
 
     // Seqnum has variable length with maximum of 8 bytes
-    const {
+    let seqnum: number;
+    ({
       value: seqnum,
       rest: buf,
-    } = leb128Util.decodeUnsigned(buf, 8);
-    header.seqnum = seqnum;
+    } = leb128Util.decodeUnsigned(buf, 8));
 
     // nc method
     let methodLen: number;
@@ -226,7 +226,7 @@ class NanoContractHeader extends Header {
       rest: buf,
     } = leb128Util.decodeUnsigned(buf, 2));
 
-    const header = new NanoContractHeader(ncId, method, args, actions, address);
+    const header = new NanoContractHeader(ncId, method, args, actions, Number(seqnum), address);
 
     if (scriptLen !== 0) {
       // script might be null

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -125,14 +125,14 @@ export enum NanoContractActionType {
   DEPOSIT = 'deposit',
   WITHDRAWAL = 'withdrawal',
   GRANT_AUTHORITY = 'grant_authority',
-  INVOKE_AUTHORITY = 'invoke_authority',
+  ACQUIRE_AUTHORITY = 'acquire_authority',
 }
 
 export enum NanoContractHeaderActionType {
   DEPOSIT = 1,
   WITHDRAWAL = 2,
   GRANT_AUTHORITY = 3,
-  INVOKE_AUTHORITY = 4,
+  ACQUIRE_AUTHORITY = 4,
 }
 
 export const ActionTypeToActionHeaderType: Record<
@@ -142,7 +142,7 @@ export const ActionTypeToActionHeaderType: Record<
   [NanoContractActionType.DEPOSIT]: NanoContractHeaderActionType.DEPOSIT,
   [NanoContractActionType.WITHDRAWAL]: NanoContractHeaderActionType.WITHDRAWAL,
   [NanoContractActionType.GRANT_AUTHORITY]: NanoContractHeaderActionType.GRANT_AUTHORITY,
-  [NanoContractActionType.INVOKE_AUTHORITY]: NanoContractHeaderActionType.INVOKE_AUTHORITY,
+  [NanoContractActionType.ACQUIRE_AUTHORITY]: NanoContractHeaderActionType.ACQUIRE_AUTHORITY,
 };
 
 // The action in the header is serialized/deserialized in the class
@@ -183,8 +183,8 @@ export const INanoContractActionGrantAuthoritySchema = INanoContractActionAuthor
   authorityAddress: z.string().optional(),
 }).passthrough();
 
-export const INanoContractActionInvokeAuthoritySchema = INanoContractActionAuthorityBase.extend({
-  type: z.literal('invoke_authority'),
+export const INanoContractActionAcquireAuthoritySchema = INanoContractActionAuthorityBase.extend({
+  type: z.literal('acquire_authority'),
   address: z.string(),
 }).passthrough();
 
@@ -192,7 +192,7 @@ export const INanoContractActionSchema = z.discriminatedUnion('type', [
   INanoContractActionWithdrawalSchema,
   INanoContractActionDepositSchema,
   INanoContractActionGrantAuthoritySchema,
-  INanoContractActionInvokeAuthoritySchema,
+  INanoContractActionAcquireAuthoritySchema,
 ]);
 
 export type NanoContractAction = z.output<typeof INanoContractActionSchema>;

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -153,7 +153,7 @@ export const getOracleInputData = async (
   wallet: HathorWallet
 ) => {
   const ncId = Buffer.from(contractId, 'hex');
-  const actualValue = Buffer.concat([leb128.encodeUnsigned(ncId.length), ncId, resultSerialized]);
+  const actualValue = Buffer.concat([ncId, resultSerialized]);
   return unsafeGetOracleInputData(oracleData, actualValue, wallet);
 };
 

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -285,7 +285,7 @@ export const mapActionToActionHeader = (
   let amount;
   if (
     action.type === NanoContractActionType.GRANT_AUTHORITY ||
-    action.type === NanoContractActionType.INVOKE_AUTHORITY
+    action.type === NanoContractActionType.ACQUIRE_AUTHORITY
   ) {
     amount = action.authority === 'mint' ? TOKEN_MINT_MASK : TOKEN_MELT_MASK;
   } else if (

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -37,7 +37,6 @@ import {
 } from './types';
 import { NANO_CONTRACTS_INITIALIZE_METHOD, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../constants';
 import { NanoContractMethodArgument } from './methodArg';
-import leb128 from '../utils/leb128';
 
 export function getContainerInternalType(
   type: string

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -3367,6 +3367,18 @@ class HathorWallet extends EventEmitter {
 
     return prepareNanoSendTransaction(tx, pin, this.storage);
   }
+
+  /**
+   * Get the seqnum to be used in a nano header for the address
+   *
+   * @param {string} address Address that will be the nano header caller
+   *
+   * @returns {Promise<number>}
+   */
+  async getNanoHeaderSeqnum(address) {
+    const addressInfo = await this.storage.getAddressInfo(address);
+    return addressInfo.seqnum + 1;
+  }
 }
 
 // State constants.

--- a/src/new/wallet.js
+++ b/src/new/wallet.js
@@ -3376,7 +3376,7 @@ class HathorWallet extends EventEmitter {
    * @returns {Promise<number>}
    */
   async getNanoHeaderSeqnum(address) {
-    const addressInfo = await this.storage.getAddressInfo(address);
+    const addressInfo = await this.storage.getAddressInfo(address.base58);
     return addressInfo.seqnum + 1;
   }
 }

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -52,6 +52,7 @@ export const IAddressMetadataAsRecordSchema: ZodSchema<IAddressMetadataAsRecord>
   .object({
     numTransactions: z.number(),
     balance: z.record(IBalanceSchema),
+    seqnum: z.number(),
   })
   .passthrough();
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -122,16 +122,16 @@ export const IHistoryNanoContractActionGrantAuthoritySchema =
     type: z.literal('GRANT_AUTHORITY'),
   }).passthrough();
 
-export const IHistoryNanoContractActionInvokeAuthoritySchema =
+export const IHistoryNanoContractActionAcquireAuthoritySchema =
   IHistoryNanoContractBaseAuthorityAction.extend({
-    type: z.literal('INVOKE_AUTHORITY'),
+    type: z.literal('ACQUIRE_AUTHORITY'),
   }).passthrough();
 
 export const IHistoryNanoContractActionSchema = z.discriminatedUnion('type', [
   IHistoryNanoContractActionDepositSchema,
   IHistoryNanoContractActionWithdrawalSchema,
   IHistoryNanoContractActionGrantAuthoritySchema,
-  IHistoryNanoContractActionInvokeAuthoritySchema,
+  IHistoryNanoContractActionAcquireAuthoritySchema,
 ]);
 
 export const IHistoryNanoContractContextSchema = z

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -119,12 +119,12 @@ export const IHistoryNanoContractActionDepositSchema = IHistoryNanoContractBaseT
 
 export const IHistoryNanoContractActionGrantAuthoritySchema =
   IHistoryNanoContractBaseAuthorityAction.extend({
-    type: z.literal('GRANT_AUTHORITY'),
+    type: z.literal('grant_authority'),
   }).passthrough();
 
 export const IHistoryNanoContractActionAcquireAuthoritySchema =
   IHistoryNanoContractBaseAuthorityAction.extend({
-    type: z.literal('ACQUIRE_AUTHORITY'),
+    type: z.literal('acquire_authority'),
   }).passthrough();
 
 export const IHistoryNanoContractActionSchema = z.discriminatedUnion('type', [

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -61,9 +61,10 @@ import {
 import { UninitializedWalletError } from '../errors';
 import Transaction from '../models/transaction';
 
-const DEFAULT_ADDRESS_META: IAddressMetadata = {
+export const DEFAULT_ADDRESS_META: IAddressMetadata = {
   numTransactions: 0,
   balance: new Map<string, IBalance>(),
+  seqnum: -1,
 };
 
 export class Storage implements IStorage {

--- a/src/types.ts
+++ b/src/types.ts
@@ -131,8 +131,8 @@ export interface IHistoryNanoContractActionGrantAuthority {
   melt: boolean;
 }
 
-export interface IHistoryNanoContractActionInvokeAuthority {
-  type: 'INVOKE_AUTHORITY';
+export interface IHistoryNanoContractActionAcquireAuthority {
+  type: 'ACQUIRE_AUTHORITY';
   token_uid: string;
   mint: boolean;
   melt: boolean;
@@ -142,7 +142,7 @@ export type IHistoryNanoContractAction =
   | IHistoryNanoContractActionDeposit
   | IHistoryNanoContractActionWithdrawal
   | IHistoryNanoContractActionGrantAuthority
-  | IHistoryNanoContractActionInvokeAuthority;
+  | IHistoryNanoContractActionAcquireAuthority;
 
 export interface IHistoryNanoContractContext {
   actions: IHistoryNanoContractAction[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,14 +125,14 @@ export interface IHistoryNanoContractActionDeposit {
 }
 
 export interface IHistoryNanoContractActionGrantAuthority {
-  type: 'GRANT_AUTHORITY';
+  type: 'grant_authority';
   token_uid: string;
   mint: boolean;
   melt: boolean;
 }
 
 export interface IHistoryNanoContractActionAcquireAuthority {
-  type: 'ACQUIRE_AUTHORITY';
+  type: 'acquire_authority';
   token_uid: string;
   mint: boolean;
   melt: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,7 @@ export interface IHistoryTx {
   nc_address?: string; // For nano contract. address in base58
   nc_pubkey?: string; // For on-chain-blueprints. pubkey DER encoded as hex
   nc_context?: IHistoryNanoContractContext;
+  nc_seqnum?: number; // For nano contract
   first_block?: string | null;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,11 +75,15 @@ export interface IAddressInfo {
 export interface IAddressMetadata {
   numTransactions: number;
   balance: Map<string, IBalance>;
+  // Sequential number used when creating nano header in a transaction
+  // each address has this sequence and we get the next number of the caller
+  seqnum: number;
 }
 
 export interface IAddressMetadataAsRecord {
   numTransactions: number;
   balance: Record<string, IBalance>;
+  seqnum: number;
 }
 
 export interface ITokenData {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -670,7 +670,7 @@ export async function processNewTx(
 
     // create metadata for address and token if it does not exist
     if (!addressMeta) {
-      addressMeta = DEFAULT_ADDRESS_META;
+      addressMeta = { ...DEFAULT_ADDRESS_META };
     }
     if (!tokenMeta) {
       tokenMeta = { numTransactions: 0, balance: getEmptyBalance() };
@@ -764,7 +764,7 @@ export async function processNewTx(
 
     // create metadata for address and token if it does not exist
     if (!addressMeta) {
-      addressMeta = DEFAULT_ADDRESS_META;
+      addressMeta = { ...DEFAULT_ADDRESS_META };
     }
     if (!tokenMeta) {
       tokenMeta = { numTransactions: 0, balance: getEmptyBalance() };
@@ -822,7 +822,7 @@ export async function processNewTx(
       // create metadata for address if it does not exist
       let addressMeta = await store.getAddressMeta(caller);
       if (!addressMeta) {
-        addressMeta = DEFAULT_ADDRESS_META;
+        addressMeta = { ...DEFAULT_ADDRESS_META };
       }
 
       if (tx.nc_id) {
@@ -912,7 +912,7 @@ export async function processUtxoUnlock(
   // create metadata for address and token if it does not exist
   // This should not happen, but we check so that typescript compiler can guarantee the type
   if (!addressMeta) {
-    addressMeta = DEFAULT_ADDRESS_META;
+    addressMeta = { ...DEFAULT_ADDRESS_META };
   }
   if (!tokenMeta) {
     tokenMeta = { numTransactions: 0, balance: getEmptyBalance() };


### PR DESCRIPTION
### Context

The latest nano core version had some breaking changes with nano integration that are fixed in this PR.

The most important is the `seqnum` in the nano header class, which is a sequential number for each nano transaction that is signed by the same caller, i.e., the seqnum increases when the same address is used as caller for a nano transaction.

This number should also increase if the nano execution fails and the tx becomes voided because it was confirmed by a block.

### Acceptance Criteria

- Action name was changed from `Invoke Authority` to `Acquire Authority`.
- Authority action types str was updated to lower case (previously on `deposit` and `withdrawal` were in lower case).
- Blueprint sdk removed support for `is_action_type` method.
- Token info API now considers amount minted by contracts for the total supply value (contract mint/melt authorities are still not being considered in this API, which is a bug, and will be fixed - I will need to adjust the tests after this fix).
- State API does not support querying by address keys in dict attributes. This support was removed but will be added again. For now I just commented the tests but I will undo this when the support is back.
- Nano contract info version was removed from the nano header class.
- Fix: contract Id serialization in `getOracleInputData` has fixed length.
- Nano header script len serialization changed to use `leb128`.
- Add `seqnum` attribute to the nano header class.