### PR TITLE
feat: explorer required changes

### DIFF
--- a/__tests__/utils/numbers.test.ts
+++ b/__tests__/utils/numbers.test.ts
@@ -19,5 +19,13 @@ test('Pretty value', () => {
   expect(prettyValue(-12345678901234567890n)).toBe('-123,456,789,012,345,678.90');
   expect(prettyValue(-12345678901234567890n, 4)).toBe('-1,234,567,890,123,456.7890');
 
-  expect(() => prettyValue(123)).toThrow('value 123 should be a bigint');
+  expect(prettyValue(123, 0)).toBe('123');
+  expect(prettyValue(123)).toBe('1.23');
+  expect(prettyValue(123, 2)).toBe('1.23');
+  expect(prettyValue('123', 0)).toBe('123');
+  expect(prettyValue('123')).toBe('1.23');
+  expect(prettyValue('123', 2)).toBe('1.23');
+
+  expect(() => prettyValue('1e2')).toThrow();
+  expect(() => prettyValue(123.45)).toThrow();
 });

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -44,7 +44,8 @@ export const JSONBigInt = {
     } catch (e) {
       if (
         e instanceof SyntaxError &&
-        (e.message === `Cannot convert ${context.source} to a BigInt` || e.message === `invalid BigInt syntax`)
+        (e.message === `Cannot convert ${context.source} to a BigInt` ||
+          e.message === `invalid BigInt syntax`)
       ) {
         // When this error happens, it means the number cannot be converted to a BigInt,
         // so it's a double, for example '123.456' or '1e2'.

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -12,7 +12,10 @@ const formatter = new Intl.NumberFormat('en-US');
  *
  * @inner
  */
-export function prettyValue(inputValue: bigint|number|string, decimalPlaces = DECIMAL_PLACES): string {
+export function prettyValue(
+  inputValue: bigint | number | string,
+  decimalPlaces = DECIMAL_PLACES
+): string {
   const value = BigInt(inputValue);
   if (typeof value !== 'bigint') {
     throw Error(`value ${value} should be a bigint`);


### PR DESCRIPTION
### Acceptance Criteria
- `bigIntReviver` floats and special syntax numbers throw a different message with the SyntaxError on browsers so we must include this on the catch block
- `prettyValue` can and will be called with number and string values, we should convert to `BigInt` if the input value is not a `BitInt` already


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
