### PR TITLE
feat: allow multiple actions per token in nano header

### DIFF
--- a/__tests__/integration/configuration/authority.py
+++ b/__tests__/integration/configuration/authority.py
@@ -65,9 +65,12 @@ class AuthorityBlueprint(Blueprint):
             raise NCFail('expect no actions')
 
     @public(allow_deposit=True, allow_grant_authority=True)
-    def deposit_and_grant(self, ctx: Context) -> None:
-        if len(ctx.actions) != 2:
-            raise NCFail('expect two actions')
+    def deposit_and_grant(self, ctx: Context, token_uid: TokenUid) -> None:
+        if len(ctx.actions) != 1:
+            raise NCFail('expect actions for a single token.')
+
+        if len(ctx.actions[token_uid]) != 2:
+            raise NCFail('expect two actions.')
 
     @public
     def mint(self, ctx: Context, token_uid: TokenUid, amount: int) -> None:

--- a/__tests__/integration/configuration/authority.py
+++ b/__tests__/integration/configuration/authority.py
@@ -59,6 +59,17 @@ class AuthorityBlueprint(Blueprint):
         assert isinstance(action, NCAcquireAuthorityAction)
 
     @public
+    def create_token_no_deposit(self, ctx: Context) -> None:
+        # User will pay for token deposit
+        if len(ctx.actions) != 0:
+            raise NCFail('expect no actions')
+
+    @public(allow_deposit=True, allow_grant_authority=True)
+    def deposit_and_grant(self, ctx: Context) -> None:
+        if len(ctx.actions) != 2:
+            raise NCFail('expect two actions')
+
+    @public
     def mint(self, ctx: Context, token_uid: TokenUid, amount: int) -> None:
         self.syscall.mint_tokens(token_uid, amount)
 

--- a/__tests__/integration/nanocontracts/authority.test.ts
+++ b/__tests__/integration/nanocontracts/authority.test.ts
@@ -588,7 +588,7 @@ describe('Authority actions blueprint test', () => {
     expect(newTxCreateTokenData.tx.outputs.length).toBe(4);
     // First the change output of HTR used for the deposit
     expect(newTxCreateTokenData.tx.outputs[0].token_data).toBe(0);
-    // Then the created token output with 1000n amount
+    // Then the created token output with 100n amount
     expect(newTxCreateTokenData.tx.outputs[1].value).toBe(100n);
     expect(newTxCreateTokenData.tx.outputs[1].token_data).toBe(1);
     // Mint authority

--- a/__tests__/integration/nanocontracts/authority.test.ts
+++ b/__tests__/integration/nanocontracts/authority.test.ts
@@ -560,8 +560,6 @@ describe('Authority actions blueprint test', () => {
     // Create a new token with only required params
     const newCreateTokenData = {
       ncId: txInitialize.hash,
-      args: [],
-      actions: []
     };
 
     const newCreateTokenOptions = {
@@ -615,17 +613,18 @@ describe('Authority actions blueprint test', () => {
           type: 'deposit',
           token: newTxCreateToken.hash,
           amount: 10n,
-        }
+        },
       ],
     };
 
     const txDepositAndGrant = await wallet.createAndSendNanoContractTransaction(
       'deposit_and_grant',
       address0,
-      depositAndGrantData,
+      depositAndGrantData
     );
     await checkTxValid(wallet, txDepositAndGrant);
     const txDepositAndGrantData = await wallet.getFullTxById(txDepositAndGrant.hash);
+    console.log('tx deposit data', txDepositAndGrantData);
 
     // TODO Validate data
   };

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -116,17 +116,7 @@ class NanoContractTransactionBuilder {
         `Invalid actions. Error: ${parseResult.error.message}.`
       );
     }
-    const parsedActions = parseResult.data;
-    // Check if there's only one action for each token
-    if (parsedActions) {
-      const tokens = parsedActions.map(action => action.token);
-      const tokensSet = new Set(tokens);
-      if (tokens.length !== tokensSet.size) {
-        throw new NanoContractTransactionError('More than one action per token is not allowed.');
-      }
-    }
-
-    this.actions = parsedActions;
+    this.actions = parseResult.data;
     return this;
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- Add support for having multiple actions for the same token.

Note: the core code currently doesn't support all possibilities, e.g., DEPOSIT + WITHDRAWAL is not allowed, but in the future it might be. Then I decided not to have any restrictions in the builder, allowing the user to build anything they want regarding actions and the core will validate it. With this, we will already have support if the core changes in the future.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
