### PR TITLE
fix: use single utxo selection for deposit action and token deposit fee

### DIFF
--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -356,11 +356,8 @@ const tokens = {
     // We might have transactions where the nano contract will pay for deposit fees
     // so we must consider the skipDepositFee flag to skip the utxo selection
     if (!skipDepositFee) {
-      depositAmount += this.getMintDeposit(amount, storage);
-
-      if (data) {
-        depositAmount += this.getDataFee(data.length);
-      }
+      const dataLen = data ? data.length : 0;
+      depositAmount += this.getTransactionHTRDeposit(amount, dataLen, storage);
     }
 
     if (depositAmount) {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -356,8 +356,7 @@ const tokens = {
     // We might have transactions where the nano contract will pay for deposit fees
     // so we must consider the skipDepositFee flag to skip the utxo selection
     if (!skipDepositFee) {
-      const dataLen = data ? data.length : 0;
-      depositAmount += this.getTransactionHTRDeposit(amount, dataLen, storage);
+      depositAmount += this.getTransactionHTRDeposit(amount, data?.length ?? 0, storage);
     }
 
     if (depositAmount) {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -356,14 +356,11 @@ const tokens = {
     // We might have transactions where the nano contract will pay for deposit fees
     // so we must consider the skipDepositFee flag to skip the utxo selection
     if (!skipDepositFee) {
-      const depositPercent = storage.getTokenDepositPercentage();
-      depositAmount += this.getDepositAmount(amount, depositPercent);
-    }
+      depositAmount += this.getMintDeposit(amount, storage);
 
-    if (data) {
-      // The deposit amount will be the quantity of data strings in the array
-      // multiplied by the fee
-      depositAmount += this.getDataScriptOutputFee() * BigInt(data.length);
+      if (data) {
+        depositAmount += this.getDataFee(data.length);
+      }
     }
 
     if (depositAmount) {
@@ -772,6 +769,41 @@ const tokens = {
       outputs: [],
       tokens: [],
     };
+  },
+
+  /**
+   * Get the total HTR to deposit for a mint transaction
+   * including mint deposit and data output fee
+   */
+  getTransactionHTRDeposit(
+    mintAmount: OutputValueType,
+    dataLen: number,
+    storage: IStorage
+  ): OutputValueType {
+    let mintDeposit = this.getMintDeposit(mintAmount, storage);
+    mintDeposit += this.getDataFee(dataLen);
+    return mintDeposit;
+  },
+
+  /**
+   * Get data output fee for a transaction from the len of data outputs
+   */
+  getDataFee(dataLen: number): OutputValueType {
+    let fee = 0n;
+    if (dataLen > 0) {
+      // The deposit amount will be the quantity of data strings in the array
+      // multiplied by the fee
+      fee += this.getDataScriptOutputFee() * BigInt(dataLen);
+    }
+    return fee;
+  },
+
+  /**
+   * Get the deposit amount for a mint
+   */
+  getMintDeposit(mintAmount: OutputValueType, storage: IStorage): OutputValueType {
+    const depositPercent = storage.getTokenDepositPercentage();
+    return this.getDepositAmount(mintAmount, depositPercent);
   },
 };
 


### PR DESCRIPTION
### Motivation

There were two bugs:

(i) the utxo selection for deposit action and token creation deposit fee happens in different phases, so we must mark the utxos as selected after the first phase, so we don't select the same one in the second phase.
(ii) we were selecting two different utxos when we could have only one for an HTR deposit action and token creation deposit fee.

### Acceptance Criteria
- Mark utxos selected in actions as used.
- When selecting an HTR utxo for deposit action, it already selects also for the token creation deposit, if there are any creation.

Note: I decided to change the logic a bit for the `contractPaysForTokenDeposit` flag. Now it will pay for any data output fee in the token creation as well. The nano contract method code will validate any logic like this.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
