### PR TITLE
chore: fixed size bytes serialization

### DIFF
--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -43,17 +43,6 @@ test('String', () => {
   expect(value).toStrictEqual(deserialized);
 });
 
-test('Int', () => {
-  const serializer = new Serializer(new Network('testnet'));
-  const deserializer = new Deserializer(new Network('testnet'));
-
-  const value = 300;
-  const serialized = serializer.serializeFromType(value, 'int');
-  const { value: deserialized } = deserializer.deserializeFromType(serialized, 'int');
-
-  expect(value).toStrictEqual(deserialized);
-});
-
 test('Amount', () => {
   const serializer = new Serializer(new Network('testnet'));
   const deserializer = new Deserializer(new Network('testnet'));
@@ -163,7 +152,7 @@ test('Optional', () => {
 
   expect(deserializedEmptyInt).toBe(valueEmptyInt);
 
-  const valueInt = 300;
+  const valueInt = 300n;
   const serializedInt = serializer.serializeFromType(valueInt, 'int?');
   const { value: deserializedInt } = deserializer.deserializeFromType(serializedInt, 'int?');
 
@@ -219,22 +208,6 @@ test('Optional', () => {
 test('SignedData', () => {
   const serializer = new Serializer(new Network('testnet'));
   const deserializer = new Deserializer(new Network('testnet'));
-
-  const valueInt: NanoContractSignedData = {
-    type: 'int',
-    value: 300,
-    signature: Buffer.from('74657374', 'hex'),
-  };
-  const serializedInt = serializer.serializeFromType(valueInt, 'SignedData[int]');
-  const { value: deserializedInt } = deserializer.deserializeFromType(
-    serializedInt,
-    'SignedData[int]'
-  );
-
-  expect((deserializedInt as NanoContractSignedData).type).toEqual(valueInt.type);
-  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect((deserializedInt as NanoContractSignedData).signature).toMatchBuffer(valueInt.signature);
-  expect((deserializedInt as NanoContractSignedData).value).toEqual(valueInt.value);
 
   const valueStr: NanoContractSignedData = {
     type: 'str',
@@ -307,23 +280,23 @@ test('SignedData', () => {
   );
   expect((deserializedBoolTrue as NanoContractSignedData).value).toEqual(valueBoolTrue.value);
 
-  const valueVarInt: NanoContractSignedData = {
-    type: 'VarInt',
+  const valueInt: NanoContractSignedData = {
+    type: 'int',
     value: 300n,
     signature: Buffer.from('74657374', 'hex'),
   };
-  const serializedVarInt = serializer.serializeFromType(valueVarInt, 'SignedData[VarInt]');
-  const { value: deserializedVarInt } = deserializer.deserializeFromType(
-    serializedVarInt,
-    'SignedData[VarInt]'
+  const serializedInt = serializer.serializeFromType(valueInt, 'SignedData[int]');
+  const { value: deserializedInt } = deserializer.deserializeFromType(
+    serializedInt,
+    'SignedData[int]'
   );
 
-  expect((deserializedVarInt as NanoContractSignedData).type).toEqual(valueVarInt.type);
+  expect((deserializedInt as NanoContractSignedData).type).toEqual(valueInt.type);
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect((deserializedVarInt as NanoContractSignedData).signature).toMatchBuffer(
-    valueVarInt.signature
+  expect((deserializedInt as NanoContractSignedData).signature).toMatchBuffer(
+    valueInt.signature
   );
-  expect((deserializedVarInt as NanoContractSignedData).value).toEqual(valueVarInt.value);
+  expect((deserializedInt as NanoContractSignedData).value).toEqual(valueInt.value);
 });
 
 test('Address', () => {
@@ -342,7 +315,7 @@ test('Address', () => {
   expect(() => deserializer.deserializeFromType(wrongNetworkAddressBuffer, 'Address')).toThrow();
 });
 
-test('VarInt', () => {
+test('int', () => {
   const network = new Network('testnet');
   const deserializer = new Deserializer(network);
   const DWARF5TestCases: [bigint, Buffer][] = [
@@ -356,7 +329,7 @@ test('VarInt', () => {
     [-129n, Buffer.from([0x7f + 0x80, 0x7e])],
   ];
   for (const testCase of DWARF5TestCases) {
-    const resp = deserializer.toVarInt(testCase[1] as Buffer);
+    const resp = deserializer.toInt(testCase[1] as Buffer);
     expect(resp.value).toEqual(testCase[0] as bigint);
     expect(resp.bytesRead).toEqual(testCase[1].length);
   }

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -293,9 +293,7 @@ test('SignedData', () => {
 
   expect((deserializedInt as NanoContractSignedData).type).toEqual(valueInt.type);
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect((deserializedInt as NanoContractSignedData).signature).toMatchBuffer(
-    valueInt.signature
-  );
+  expect((deserializedInt as NanoContractSignedData).signature).toMatchBuffer(valueInt.signature);
   expect((deserializedInt as NanoContractSignedData).value).toEqual(valueInt.value);
 });
 

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -70,7 +70,10 @@ test('TokenUid', () => {
   const serializer = new Serializer(new Network('testnet'));
   const deserializer = new Deserializer(new Network('testnet'));
 
-  const value = Buffer.from('cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe', 'hex');
+  const value = Buffer.from(
+    'cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe',
+    'hex'
+  );
   const serializedToken = serializer.serializeFromType(value, 'TokenUid');
   const { value: deserializedToken, bytesRead: bytesReadToken } = deserializer.deserializeFromType(
     serializedToken,
@@ -80,7 +83,6 @@ test('TokenUid', () => {
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   expect(deserializedToken).toMatchBuffer(value);
   expect(bytesReadToken).toStrictEqual(33); // 1 byte of tag + 32 bytes of value
-
 
   const { value: deserializedHTR, bytesRead: bytesReadHTR } = deserializer.deserializeFromType(
     Buffer.from([0]),
@@ -96,7 +98,10 @@ test('Sized Bytes', () => {
   const serializer = new Serializer(new Network('testnet'));
   const deserializer = new Deserializer(new Network('testnet'));
 
-  const value = Buffer.from('cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe', 'hex');
+  const value = Buffer.from(
+    'cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe',
+    'hex'
+  );
   const serializedVertex = serializer.serializeFromType(value, 'VertexId');
   const { value: deserializedVertex, bytesRead: bytesReadVertex } =
     deserializer.deserializeFromType(serializedVertex, 'VertexId');

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -66,6 +66,62 @@ test('Amount', () => {
   expect(value).toStrictEqual(deserialized);
 });
 
+test('TokenUid', () => {
+  const serializer = new Serializer(new Network('testnet'));
+  const deserializer = new Deserializer(new Network('testnet'));
+
+  const value = Buffer.from('cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe', 'hex');
+  const serializedToken = serializer.serializeFromType(value, 'TokenUid');
+  const { value: deserializedToken, bytesRead: bytesReadToken } = deserializer.deserializeFromType(
+    serializedToken,
+    'TokenUid'
+  );
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(deserializedToken).toMatchBuffer(value);
+  expect(bytesReadToken).toStrictEqual(33); // 1 byte of tag + 32 bytes of value
+
+
+  const { value: deserializedHTR, bytesRead: bytesReadHTR } = deserializer.deserializeFromType(
+    Buffer.from([0]),
+    'TokenUid'
+  );
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(deserializedHTR).toMatchBuffer(Buffer.from('00', 'hex'));
+  expect(bytesReadHTR).toStrictEqual(1); // 1 byte of tag
+});
+
+test('Sized Bytes', () => {
+  const serializer = new Serializer(new Network('testnet'));
+  const deserializer = new Deserializer(new Network('testnet'));
+
+  const value = Buffer.from('cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe', 'hex');
+  const serializedVertex = serializer.serializeFromType(value, 'VertexId');
+  const { value: deserializedVertex, bytesRead: bytesReadVertex } =
+    deserializer.deserializeFromType(serializedVertex, 'VertexId');
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(deserializedVertex).toMatchBuffer(value);
+  expect(bytesReadVertex).toStrictEqual(32);
+
+  const serializedContract = serializer.serializeFromType(value, 'ContractId');
+  const { value: deserializedContract, bytesRead: bytesReadContract } =
+    deserializer.deserializeFromType(serializedContract, 'ContractId');
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(deserializedContract).toMatchBuffer(value);
+  expect(bytesReadContract).toStrictEqual(32);
+
+  const serializedBlueprint = serializer.serializeFromType(value, 'BlueprintId');
+  const { value: deserializedBlueprint, bytesRead: bytesReadBlueprint } =
+    deserializer.deserializeFromType(serializedBlueprint, 'BlueprintId');
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(deserializedBlueprint).toMatchBuffer(value);
+  expect(bytesReadBlueprint).toStrictEqual(32);
+});
+
 test('Bytes', () => {
   const serializer = new Serializer(new Network('testnet'));
   const deserializer = new Deserializer(new Network('testnet'));
@@ -81,24 +137,6 @@ test('Bytes', () => {
   expect(deserialized).toMatchBuffer(value);
   expect(bytesReadBytes).toStrictEqual(5); // 1 byte of length + 4 bytes of value
 
-  const serializedVertex = serializer.serializeFromType(value, 'VertexId');
-  const { value: deserializedVertex, bytesRead: bytesReadVertex } =
-    deserializer.deserializeFromType(serializedVertex, 'VertexId');
-
-  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect(deserializedVertex).toMatchBuffer(value);
-  expect(bytesReadVertex).toStrictEqual(5); // 1 byte of length + 4 bytes of value
-
-  const serializedToken = serializer.serializeFromType(value, 'TokenUid');
-  const { value: deserializedToken, bytesRead: bytesReadToken } = deserializer.deserializeFromType(
-    serializedToken,
-    'TokenUid'
-  );
-
-  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect(deserializedToken).toMatchBuffer(value);
-  expect(bytesReadToken).toStrictEqual(5); // 1 byte of length + 4 bytes of value
-
   const serializedScript = serializer.serializeFromType(value, 'TxOutputScript');
   const { value: deserializedScript, bytesRead: bytesReadScript } =
     deserializer.deserializeFromType(serializedScript, 'TxOutputScript');
@@ -106,14 +144,6 @@ test('Bytes', () => {
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   expect(deserializedScript).toMatchBuffer(value);
   expect(bytesReadScript).toStrictEqual(5); // 1 byte of length + 4 bytes of value
-
-  const serializedContract = serializer.serializeFromType(value, 'ContractId');
-  const { value: deserializedContract, bytesRead: bytesReadContract } =
-    deserializer.deserializeFromType(serializedContract, 'ContractId');
-
-  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect(deserializedContract).toMatchBuffer(value);
-  expect(bytesReadContract).toStrictEqual(5); // 1 byte of length + 4 bytes of value
 });
 
 test('Optional', () => {

--- a/__tests__/nano_contracts/deserializer.test.ts
+++ b/__tests__/nano_contracts/deserializer.test.ts
@@ -9,7 +9,6 @@ import Serializer from '../../src/nano_contracts/serializer';
 import Deserializer from '../../src/nano_contracts/deserializer';
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
-import leb128 from '../../src/utils/leb128';
 import { NanoContractSignedData } from '../../src/nano_contracts/types';
 
 test('Bool', () => {
@@ -334,24 +333,13 @@ test('Address', () => {
   const address = 'WfthPUEecMNRs6eZ2m2EQBpVH6tbqQxYuU';
   const addressBuffer = new Address(address).decode();
 
-  const { value: deserialized } = deserializer.deserializeFromType(
-    Buffer.concat([leb128.encodeUnsigned(addressBuffer.length), addressBuffer]),
-    'Address'
-  );
+  const { value: deserialized } = deserializer.deserializeFromType(addressBuffer, 'Address');
   expect(deserialized).toBe(address);
 
   const wrongNetworkAddress = 'HDeadDeadDeadDeadDeadDeadDeagTPgmn';
   const wrongNetworkAddressBuffer = new Address(wrongNetworkAddress).decode();
 
-  expect(() =>
-    deserializer.deserializeFromType(
-      Buffer.concat([
-        leb128.encodeUnsigned(wrongNetworkAddressBuffer.length),
-        wrongNetworkAddressBuffer,
-      ]),
-      'Address'
-    )
-  ).toThrow();
+  expect(() => deserializer.deserializeFromType(wrongNetworkAddressBuffer, 'Address')).toThrow();
 });
 
 test('VarInt', () => {

--- a/__tests__/nano_contracts/methodArg.test.ts
+++ b/__tests__/nano_contracts/methodArg.test.ts
@@ -21,27 +21,6 @@ describe('fromApiInput', () => {
       value: {
         type: 'int',
         signature: expect.anything(),
-        value: 300,
-      },
-    });
-    // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-    expect((arg.value as NanoContractSignedData).signature).toMatchBuffer(
-      Buffer.from([0x74, 0x65, 0x73, 0x74])
-    );
-  });
-
-  it('should read SignedData[VarInt]', () => {
-    const arg = NanoContractMethodArgument.fromApiInput(
-      'a-test',
-      'SignedData[VarInt]',
-      '74657374,300,VarInt'
-    );
-    expect(arg).toMatchObject({
-      name: 'a-test',
-      type: 'SignedData[VarInt]',
-      value: {
-        type: 'VarInt',
-        signature: expect.anything(),
         value: 300n,
       },
     });
@@ -153,12 +132,7 @@ describe('fromApiInput', () => {
 
   it('should read int values', () => {
     const arg = NanoContractMethodArgument.fromApiInput('a-test', 'int', 300);
-    expect(arg).toMatchObject({ name: 'a-test', type: 'int', value: 300 });
-  });
-
-  it('should read VarInt values', () => {
-    const arg = NanoContractMethodArgument.fromApiInput('a-test', 'VarInt', 300);
-    expect(arg).toMatchObject({ name: 'a-test', type: 'VarInt', value: 300n });
+    expect(arg).toMatchObject({ name: 'a-test', type: 'int', value: 300n });
   });
 
   it('should read bool values', () => {
@@ -205,18 +179,7 @@ describe('fromApiInput', () => {
 
   it('should read int? values', () => {
     const arg = NanoContractMethodArgument.fromApiInput('a-test', 'int?', 300);
-    expect(arg).toMatchObject({ name: 'a-test', type: 'int?', value: 300 });
-
-    expect(NanoContractMethodArgument.fromApiInput('a-test', 'int?', null)).toMatchObject({
-      name: 'a-test',
-      type: 'int?',
-      value: null,
-    });
-  });
-
-  it('should read VarInt? values', () => {
-    const arg = NanoContractMethodArgument.fromApiInput('a-test', 'VarInt?', 300);
-    expect(arg).toMatchObject({ name: 'a-test', type: 'VarInt?', value: 300n });
+    expect(arg).toMatchObject({ name: 'a-test', type: 'int?', value: 300n });
   });
 
   it('should read bool? values', () => {
@@ -288,25 +251,12 @@ describe('toApiInput', () => {
     const arg = new NanoContractMethodArgument('a-test', 'SignedData[int]', {
       type: 'int',
       signature: Buffer.from('74657374', 'hex'),
-      value: 300,
+      value: 300n,
     });
     expect(arg.toApiInput()).toMatchObject({
       name: 'a-test',
       type: 'SignedData[int]',
       parsed: '74657374,300,int',
-    });
-  });
-
-  it('should read SignedData[VarInt]', () => {
-    const arg = new NanoContractMethodArgument('a-test', 'SignedData[VarInt]', {
-      type: 'VarInt',
-      signature: Buffer.from('74657374', 'hex'),
-      value: 300n,
-    });
-    expect(arg.toApiInput()).toMatchObject({
-      name: 'a-test',
-      type: 'SignedData[VarInt]',
-      parsed: '74657374,300,VarInt',
     });
   });
 
@@ -381,19 +331,10 @@ describe('toApiInput', () => {
   });
 
   it('should read int values', () => {
-    const arg = new NanoContractMethodArgument('a-test', 'int', 300);
+    const arg = new NanoContractMethodArgument('a-test', 'int', 300n);
     expect(arg.toApiInput()).toMatchObject({
       name: 'a-test',
       type: 'int',
-      parsed: 300,
-    });
-  });
-
-  it('should read VarInt values', () => {
-    const arg = new NanoContractMethodArgument('a-test', 'VarInt', 300n);
-    expect(arg.toApiInput()).toMatchObject({
-      name: 'a-test',
-      type: 'VarInt',
       parsed: '300',
     });
   });
@@ -455,19 +396,11 @@ describe('toApiInput', () => {
   // Optional
 
   it('should read int? values', () => {
-    const arg1 = new NanoContractMethodArgument('a-test', 'int?', 300);
-    expect(arg1.toApiInput()).toMatchObject({ name: 'a-test', type: 'int?', parsed: 300 });
+    const arg1 = new NanoContractMethodArgument('a-test', 'int?', 300n);
+    expect(arg1.toApiInput()).toMatchObject({ name: 'a-test', type: 'int?', parsed: '300' });
 
-    const arg2 = new NanoContractMethodArgument('a-test', 'int?', null);
+    const arg2 = NanoContractMethodArgument.fromApiInput('a-test', 'int?', null);
     expect(arg2.toApiInput()).toMatchObject({ name: 'a-test', type: 'int?', parsed: null });
-  });
-
-  it('should read VarInt? values', () => {
-    const arg1 = new NanoContractMethodArgument('a-test', 'VarInt?', 300n);
-    expect(arg1.toApiInput()).toMatchObject({ name: 'a-test', type: 'VarInt?', parsed: '300' });
-
-    const arg2 = NanoContractMethodArgument.fromApiInput('a-test', 'VarInt?', null);
-    expect(arg2.toApiInput()).toMatchObject({ name: 'a-test', type: 'VarInt?', parsed: null });
   });
 
   it('should read bool? values', () => {

--- a/__tests__/nano_contracts/serializer.test.ts
+++ b/__tests__/nano_contracts/serializer.test.ts
@@ -42,11 +42,12 @@ test('Int', () => {
 
 test('TokenUid', () => {
   const serializer = new Serializer(new Network('testnet'));
-  const token = Buffer.from('cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe', 'hex');
-  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect(serializer.fromTokenUid(token)).toMatchBuffer(
-    Buffer.concat([Buffer.from([1]), token])
+  const token = Buffer.from(
+    'cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe',
+    'hex'
   );
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(serializer.fromTokenUid(token)).toMatchBuffer(Buffer.concat([Buffer.from([1]), token]));
 
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   expect(serializer.fromTokenUid(Buffer.from([0]))).toMatchBuffer(Buffer.from([0]));

--- a/__tests__/nano_contracts/serializer.test.ts
+++ b/__tests__/nano_contracts/serializer.test.ts
@@ -34,12 +34,6 @@ test('String', () => {
   );
 });
 
-test('Int', () => {
-  const serializer = new Serializer(new Network('testnet'));
-  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect(serializer.fromInt(300)).toMatchBuffer(Buffer.from([0x00, 0x00, 0x01, 0x2c]));
-});
-
 test('TokenUid', () => {
   const serializer = new Serializer(new Network('testnet'));
   const token = Buffer.from(
@@ -93,7 +87,7 @@ test('Optional', () => {
   expect(serializer.fromOptional(null, 'int')).toMatchBuffer(Buffer.from([0x00]));
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   expect(serializer.fromOptional(300, 'int')).toMatchBuffer(
-    Buffer.from([0x01, 0x00, 0x00, 0x01, 0x2c])
+    Buffer.from('01ac02', 'hex')
   );
 
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
@@ -123,24 +117,9 @@ test('SignedData', () => {
       {
         signature: Buffer.from('74657374', 'hex'),
         type: 'int',
-        value: 300,
-      },
-      'int'
-    )
-    // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  ).toMatchBuffer(
-    // value + 4 + test
-    Buffer.from([0x00, 0x00, 0x01, 0x2c, 0x04, 0x74, 0x65, 0x73, 0x74])
-  );
-
-  expect(
-    serializer.fromSignedData(
-      {
-        signature: Buffer.from('74657374', 'hex'),
-        type: 'VarInt',
         value: 300n,
       },
-      'VarInt'
+      'int'
     )
     // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   ).toMatchBuffer(Buffer.from([0xac, 0x02, 0x04, 0x74, 0x65, 0x73, 0x74]));
@@ -194,7 +173,7 @@ test('SignedData', () => {
   ).toMatchBuffer(Buffer.from([0x01, 0x04, 0x74, 0x65, 0x73, 0x74]));
 });
 
-test('VarInt', () => {
+test('int', () => {
   const DWARF5TestCases = [
     [2n, Buffer.from([2])],
     [-2n, Buffer.from([0x7e])],
@@ -207,6 +186,6 @@ test('VarInt', () => {
   ];
   const serializer = new Serializer(new Network('testnet'));
   for (const testCase of DWARF5TestCases) {
-    expect(serializer.fromVarInt(testCase[0] as bigint)).toEqual(testCase[1] as Buffer);
+    expect(serializer.fromInt(testCase[0] as bigint)).toEqual(testCase[1] as Buffer);
   }
 });

--- a/__tests__/nano_contracts/serializer.test.ts
+++ b/__tests__/nano_contracts/serializer.test.ts
@@ -40,6 +40,18 @@ test('Int', () => {
   expect(serializer.fromInt(300)).toMatchBuffer(Buffer.from([0x00, 0x00, 0x01, 0x2c]));
 });
 
+test('TokenUid', () => {
+  const serializer = new Serializer(new Network('testnet'));
+  const token = Buffer.from('cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe', 'hex');
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(serializer.fromTokenUid(token)).toMatchBuffer(
+    Buffer.concat([Buffer.from([1]), token])
+  );
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(serializer.fromTokenUid(Buffer.from([0]))).toMatchBuffer(Buffer.from([0]));
+});
+
 test('Bytes', () => {
   const serializer = new Serializer(new Network('testnet'));
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
@@ -56,6 +68,22 @@ test('Bytes', () => {
       bigBuffer,
     ])
   );
+});
+
+test('SizedBytes', () => {
+  const serializer = new Serializer(new Network('testnet'));
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(serializer.fromSizedBytes(Buffer.from([0x74, 0x65, 0x73, 0x74]))).toMatchBuffer(
+    Buffer.from([0x74, 0x65, 0x73, 0x74])
+  );
+
+  // Encoding a big string
+  const bigBuffer = Buffer.from(Array(2048).fill('A').join(''), 'utf-8');
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(serializer.fromSizedBytes(bigBuffer)).toMatchBuffer(bigBuffer);
+
+  // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
+  expect(serializer.fromSizedBytes(Buffer.from([0]))).toMatchBuffer(Buffer.from([0]));
 });
 
 test('Optional', () => {

--- a/__tests__/nano_contracts/serializer.test.ts
+++ b/__tests__/nano_contracts/serializer.test.ts
@@ -86,9 +86,7 @@ test('Optional', () => {
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   expect(serializer.fromOptional(null, 'int')).toMatchBuffer(Buffer.from([0x00]));
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
-  expect(serializer.fromOptional(300, 'int')).toMatchBuffer(
-    Buffer.from('01ac02', 'hex')
-  );
+  expect(serializer.fromOptional(300, 'int')).toMatchBuffer(Buffer.from('01ac02', 'hex'));
 
   // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
   expect(serializer.fromOptional(null, 'bool')).toMatchBuffer(Buffer.from([0x00]));
@@ -189,7 +187,6 @@ test('int', () => {
     expect(serializer.fromInt(testCase[0] as bigint)).toEqual(testCase[1] as Buffer);
   }
 });
-
 
 test('Amount', () => {
   const DWARF5UnsignedTestCases: [bigint, Buffer][] = [

--- a/__tests__/nano_contracts/serializer.test.ts
+++ b/__tests__/nano_contracts/serializer.test.ts
@@ -189,3 +189,18 @@ test('int', () => {
     expect(serializer.fromInt(testCase[0] as bigint)).toEqual(testCase[1] as Buffer);
   }
 });
+
+
+test('Amount', () => {
+  const DWARF5UnsignedTestCases: [bigint, Buffer][] = [
+    [2n, Buffer.from([2])],
+    [127n, Buffer.from([127])],
+    [128n, Buffer.from([0x80, 1])],
+    [129n, Buffer.from([1 + 0x80, 1])],
+    [12857n, Buffer.from([57 + 0x80, 100])],
+  ];
+  const serializer = new Serializer(new Network('testnet'));
+  for (const testCase of DWARF5UnsignedTestCases) {
+    expect(serializer.fromAmount(testCase[0] as bigint)).toEqual(testCase[1] as Buffer);
+  }
+});

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -143,6 +143,14 @@ class Deserializer {
     };
   }
 
+  /**
+   * Deserialize a bytes value with known size
+   *
+   * @param buf Value to deserialize
+   *
+   * @memberof Deserializer
+   * @inner
+   */
   toSizedBytes(len: number, buf: Buffer): BufferROExtract<Buffer> {
     if (buf.length < len) {
       throw new Error('Do not have enough bytes to read the expected length');
@@ -153,6 +161,19 @@ class Deserializer {
     };
   }
 
+  /**
+   * Deserialize a Token UID
+   * The serialized value starts with a tag:
+   * - 0x00 for HTR
+   * - 0x01 for custom token
+   *
+   * For custom tokens we will also read the next 32 bytes.
+   *
+   * @param {Buffer} buf Value to deserialize
+   *
+   * @memberof Deserializer
+   * @inner
+   */
   toTokenUid(buf: Buffer): BufferROExtract<Buffer> {
     if (buf[0] === 0x00) {
       return {

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -60,14 +60,13 @@ class Deserializer {
       case 'Address':
         return this.toAddress(buf);
       case 'int':
-      case 'Timestamp':
         return this.toInt(buf);
+      case 'Timestamp':
+        return this.toInt32(buf);
       case 'Amount':
         return this.toAmount(buf);
       case 'bool':
         return this.toBool(buf);
-      case 'VarInt':
-        return this.toVarInt(buf);
       default:
         throw new Error('Invalid type.');
     }
@@ -171,14 +170,14 @@ class Deserializer {
   }
 
   /**
-   * Deserialize int value
+   * Deserialize a 32bit int value
    *
    * @param {Buffer} buf Value to deserialize
    *
    * @memberof Deserializer
    * @inner
    */
-  toInt(buf: Buffer): BufferROExtract<number> {
+  toInt32(buf: Buffer): BufferROExtract<number> {
     return {
       value: unpackToInt(4, true, buf)[0],
       bytesRead: 4,
@@ -196,7 +195,7 @@ class Deserializer {
   toAmount(buf: Buffer): BufferROExtract<OutputValueType> {
     // Nano `Amount` currently only supports up to 4 bytes, so we simply use the `number` value converted to `BigInt`.
     // If we change Nano to support up to 8 bytes, we must update this.
-    const { value, bytesRead } = this.toInt(buf);
+    const { value, bytesRead } = this.toInt32(buf);
     return {
       value: BigInt(value),
       bytesRead,
@@ -225,13 +224,13 @@ class Deserializer {
   }
 
   /**
-   * Deserialize a variable integer encoded as a leb128 buffer to a bigint.
+   * Deserialize an integer encoded as a leb128 buffer to a bigint.
    *
    * @param buf Value to deserialize
    *
    * @memberof Deserializer
    */
-  toVarInt(buf: Buffer): BufferROExtract<bigint> {
+  toInt(buf: Buffer): BufferROExtract<bigint> {
     const { value, bytesRead } = leb128Util.decodeSigned(buf);
     return { value, bytesRead };
   }
@@ -363,7 +362,7 @@ class Deserializer {
    * It does not support chained container types, meaning Tuple[Dict[str,str]] should not happen.
    *
    * @param buf Value to deserialize
-   * @param typeArr List of types to read from buffer, e.g. `['str', 'int', 'VarInt']`
+   * @param typeArr List of types to read from buffer, e.g. `['str', 'int']`
    *
    * @memberof Deserializer
    * @inner

--- a/src/nano_contracts/deserializer.ts
+++ b/src/nano_contracts/deserializer.ts
@@ -193,13 +193,7 @@ class Deserializer {
    * @inner
    */
   toAmount(buf: Buffer): BufferROExtract<OutputValueType> {
-    // Nano `Amount` currently only supports up to 4 bytes, so we simply use the `number` value converted to `BigInt`.
-    // If we change Nano to support up to 8 bytes, we must update this.
-    const { value, bytesRead } = this.toInt32(buf);
-    return {
-      value: BigInt(value),
-      bytesRead,
-    };
+    return leb128Util.decodeUnsigned(buf);
   }
 
   /**
@@ -231,8 +225,7 @@ class Deserializer {
    * @memberof Deserializer
    */
   toInt(buf: Buffer): BufferROExtract<bigint> {
-    const { value, bytesRead } = leb128Util.decodeSigned(buf);
-    return { value, bytesRead };
+    return leb128Util.decodeSigned(buf);
   }
 
   /* eslint-enable class-methods-use-this */

--- a/src/nano_contracts/methodArg.ts
+++ b/src/nano_contracts/methodArg.ts
@@ -36,7 +36,7 @@ function refineSingleValue(
   inputVal: NanoContractArgumentApiInputType,
   type: NanoContractArgumentSingleTypeName
 ) {
-  if (type === 'int' || type === 'Timestamp') {
+  if (type === 'Timestamp') {
     const parse = z.coerce.number().safeParse(inputVal);
     if (!parse.success) {
       ctx.addIssue({
@@ -47,7 +47,7 @@ function refineSingleValue(
     } else {
       return parse.data;
     }
-  } else if (type === 'VarInt' || type === 'Amount') {
+  } else if (type === 'int' || type === 'Amount') {
     const parse = z.coerce.bigint().safeParse(inputVal);
     if (!parse.success) {
       ctx.addIssue({
@@ -301,7 +301,7 @@ export class NanoContractMethodArgument {
       // Should not happen since all bytes values were caught, this is to satisfy typing
       return value.toString('hex');
     }
-    if (type === 'VarInt' || type === 'Amount') {
+    if (type === 'int' || type === 'Amount') {
       return String(value as bigint);
     }
     return value;

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -17,7 +17,6 @@ import {
 import { OutputValueType } from '../types';
 import leb128Util from '../utils/leb128';
 import { getContainerInternalType, getContainerType } from './utils';
-import { NATIVE_TOKEN_UID } from '../constants';
 
 /* eslint-disable class-methods-use-this -- XXX: Methods that do not use `this` should be made static */
 class Serializer {
@@ -142,9 +141,8 @@ class Serializer {
   fromTokenUid(value: Buffer): Buffer {
     if (value.length === 1 && value[0] === 0x00) {
       return Buffer.from([0]);
-    } else {
-      return Buffer.concat([Buffer.from([1]), Buffer.from(value)]);
     }
+    return Buffer.concat([Buffer.from([1]), Buffer.from(value)]);
   }
 
   /**

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -58,14 +58,13 @@ class Serializer {
       case 'Address':
         return this.fromAddress(value as string);
       case 'int':
+        return this.fromInt(value as bigint);
       case 'Timestamp':
-        return this.fromInt(value as number);
+        return this.fromInt32(value as number);
       case 'Amount':
         return this.fromAmount(value as OutputValueType);
       case 'bool':
         return this.fromBool(value as boolean);
-      case 'VarInt':
-        return this.fromVarInt(value as bigint);
       default:
         throw new Error(`Invalid type. ${type}.`);
     }
@@ -153,7 +152,7 @@ class Serializer {
    * @memberof Serializer
    * @inner
    */
-  fromInt(value: number): Buffer {
+  fromInt32(value: number): Buffer {
     return signedIntToBytes(value, 4);
   }
 
@@ -194,7 +193,7 @@ class Serializer {
    *
    * @memberof Serializer
    */
-  fromVarInt(value: bigint): Buffer {
+  fromInt(value: bigint): Buffer {
     return leb128Util.encodeSigned(value);
   }
   /* eslint-disable class-methods-use-this */

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -133,10 +133,28 @@ class Serializer {
     return Buffer.concat([leb128Util.encodeUnsigned(value.length), Buffer.from(value)]);
   }
 
+  /**
+   * Serialize a bytes value with known size
+   *
+   * @param value Value to serialize
+   *
+   * @memberof Serializer
+   * @inner
+   */
   fromSizedBytes(value: Buffer): Buffer {
     return Buffer.from(value);
   }
 
+  /**
+   * Serialize a Token UID
+   * For HTR we only add the tag 0x00
+   * For custom tokens we add the tag 0x01 and the uid bytes
+   *
+   * @param value Value to serialize
+   *
+   * @memberof Serializer
+   * @inner
+   */
   fromTokenUid(value: Buffer): Buffer {
     if (value.length === 1 && value[0] === 0x00) {
       return Buffer.from([0]);

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -165,9 +165,7 @@ class Serializer {
    * @inner
    */
   fromAmount(value: OutputValueType): Buffer {
-    // Nano `Amount` currently only supports up to 4 bytes.
-    // If we change Nano to support up to 8 bytes, we must update this.
-    return bigIntToBytes(value, 4);
+    return leb128Util.encodeUnsigned(value);
   }
 
   /**

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -119,7 +119,7 @@ class Serializer {
   fromAddress(value: string): Buffer {
     const address = new Address(value, { network: this.network });
     address.validateAddress();
-    return this.fromBytes(address.decode());
+    return this.fromSizedBytes(address.decode());
   }
 
   /**

--- a/src/nano_contracts/serializer.ts
+++ b/src/nano_contracts/serializer.ts
@@ -7,7 +7,7 @@
 
 import Address from '../models/address';
 import Network from '../models/network';
-import { signedIntToBytes, bigIntToBytes } from '../utils/buffer';
+import { signedIntToBytes } from '../utils/buffer';
 import {
   NanoContractArgumentSingleTypeName,
   NanoContractArgumentSingleTypeNameSchema,

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -27,7 +27,6 @@ export const NanoContractArgumentSingleTypeNameSchema = z.enum([
   'Address',
   'Timestamp',
   'Amount',
-  'VarInt',
   ...NanoContractArgumentByteTypes.options,
 ]);
 export type NanoContractArgumentSingleTypeName = z.output<


### PR DESCRIPTION
### Acceptance Criteria

- Change `ContractId`, `BlueprintId`, `VertexId` and `Address` to use a fixed size bytes serialization where the length is not on the serialized value.
- Change `TokenUid` to use a custom serialization.
- Change `Amount` to use leb128 unsigned serialization
- Change `int` to use leb128 signed serialization
- Remove `VarInt` nano contract type

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
