### PR TITLE
feat: add xpriv util method and getNetwork in wallet service facade

### DIFF
--- a/__tests__/utils/wallet.test.ts
+++ b/__tests__/utils/wallet.test.ts
@@ -671,3 +671,19 @@ test('getWalletIdFromXpub', () => {
   const expected = crypto.Hash.sha256sha256(Buffer.from(str)).toString('hex');
   expect(wallet.getWalletIdFromXPub(str)).toEqual(expected);
 });
+
+test('getXprivFromData', () => {
+  const words =
+    'upon tennis increase embark dismiss diamond monitor face magnet jungle scout salute rural master shoulder cry juice jeans radar present close meat antenna mind';
+  const hdPrivKey = wallet.getXPrivKeyFromSeed(words, { networkName: 'testnet' });
+  const buffers = hdPrivKey._buffers;
+  const xpriv = wallet.xprivFromData(
+    buffers.privateKey,
+    buffers.chainCode,
+    buffers.parentFingerPrint,
+    buffers.depth,
+    buffers.childIndex,
+    'testnet'
+  );
+  expect(xpriv).toEqual(hdPrivKey.xprivkey);
+});

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -666,6 +666,8 @@ test('prepareMintTokens', async () => {
     xpub: null,
   });
 
+  expect(wallet.getNetwork()).toEqual('testnet');
+
   const code = new Mnemonic(seed);
   const xpriv = code.toHDPrivateKey('', network.getNetwork());
 

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -169,9 +169,9 @@ const wallet = {
   xprivFromData(
     privateKey: Buffer,
     chainCode: Buffer,
-    fingerprint: Number,
-    depth: Number,
-    childIndex: Number,
+    fingerprint: number,
+    depth: number,
+    childIndex: number,
     networkName: string
   ): string {
     const network = new Network(networkName);

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -152,6 +152,42 @@ const wallet = {
   },
 
   /**
+   * Get xpriv from data
+   *
+   * @param {Buffer} privateKey Compressed private key
+   * @param {Buffer} chainCode HDPublic key chaincode
+   * @param {Number} fingerprint parent fingerprint
+   * @param {Number} depth Depth derivation of the private key
+   * @param {Number} childIndex Child index of the private key
+   * @param {string} networkName Network to use
+   *
+   * @return {String} xpriv
+   *
+   * @memberof Wallet
+   * @inner
+   */
+  xprivFromData(
+    privateKey: Buffer,
+    chainCode: Buffer,
+    fingerprint: Number,
+    depth: Number,
+    childIndex: Number,
+    networkName: string
+  ): string {
+    const network = new Network(networkName);
+    const hdprivkey = new HDPrivateKey({
+      network: network.bitcoreNetwork,
+      depth,
+      parentFingerPrint: fingerprint,
+      childIndex,
+      chainCode,
+      privateKey,
+    });
+
+    return hdprivkey.xprivkey;
+  },
+
+  /**
    * Get compressed public key from uncompressed
    *
    * @param {Buffer} pubkey Uncompressed public key

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1115,6 +1115,10 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     return addressHDPrivKey;
   }
 
+  getNetwork() {
+    return this.getNetworkObject().name;
+  }
+
   /**
    * Gets the network model object
    *

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1115,7 +1115,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     return addressHDPrivKey;
   }
 
-  getNetwork() {
+  /**
+   * Gets the network name
+   *
+   * @memberof HathorWalletServiceWallet
+   * @inner
+   */
+  getNetwork(): string {
     return this.getNetworkObject().name;
   }
 


### PR DESCRIPTION
### Acceptance Criteria
- Add `getNetwork` method in the wallet service facade, that was missing from the old facade.
- Create util method to get xpriv from private key data.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
