### PR TITLE
fix: use fallback for hermes to format integer values

### DIFF
--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -3,6 +3,28 @@ import { DECIMAL_PLACES } from '../constants';
 const formatter = new Intl.NumberFormat('en-US');
 
 /**
+ * Get the formatted integer value with thousand separators
+ *
+ * Hermes does not have support for Intl.NumberFormat format method
+ * with bigint values, and we use it in the Android for a better performance.
+ * The iOS app runs with JSC, which doesn't work with bigint and toLocaleString.
+ * Then I have this method that tries both options to format the integer value.
+ *
+ * @param value Amount to be formatted
+ *
+ * @return {string} Formatted value
+ *
+ * @inner
+ */
+function getLocaleString(value: bigint): string {
+  try {
+    return formatter.format(value);
+  } catch (e) {
+    return value.toLocaleString('en-US');
+  }
+}
+
+/**
  * Get the formatted value with decimal places and thousand separators
  *
  * @param inputValue Amount to be formatted
@@ -21,14 +43,14 @@ export function prettyValue(
     throw Error(`value ${value} should be a bigint`);
   }
   if (decimalPlaces === 0) {
-    return formatter.format(value);
+    return getLocaleString(value);
   }
   const absValue = value >= 0 ? value : -value;
   const decimalDivisor = 10n ** BigInt(decimalPlaces);
   const integerPart = absValue / decimalDivisor;
   const decimalPart = absValue % decimalDivisor;
   const signal = value < 0 ? '-' : '';
-  const integerString = formatter.format(integerPart);
+  const integerString = getLocaleString(integerPart);
   const decimalString = decimalPart.toString().padStart(decimalPlaces, '0');
   return `${signal}${integerString}.${decimalString}`;
 }


### PR DESCRIPTION
### Context

Hermes does not have support for `Intl.NumberFormat.format` method with bigint, and we use it to run the Android app for performance reasons.

The iOS app runs with JSC, which does not work with `toLocaleString`.

Then I decided to keep the default solution as our current one and add a fallback in case it throws.

### Acceptance Criteria
- We should use a fallback to format integer values in case the current solution fails.


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
