### PR TITLE
refactor: send nano contract tx working on the wallet-service

### DIFF
--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -1456,7 +1456,7 @@ test('createTokens', async () => {
   await expect(
     wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
       address: addresses[1],
-      createMintAuthority: true,
+      createMint: true,
       mintAuthorityAddress: 'abc',
       pinCode: '123456',
     })
@@ -1466,7 +1466,7 @@ test('createTokens', async () => {
   await expect(
     wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
       address: addresses[1],
-      createMeltAuthority: true,
+      createMelt: true,
       meltAuthorityAddress: 'abc',
       pinCode: '123456',
     })
@@ -1476,7 +1476,7 @@ test('createTokens', async () => {
   await expect(
     wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
       address: addresses[1],
-      createMintAuthority: true,
+      createMint: true,
       mintAuthorityAddress: 'abc',
       allowExternalMintAuthorityAddress: true,
       pinCode: '123456',
@@ -1487,7 +1487,7 @@ test('createTokens', async () => {
   await expect(
     wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
       address: addresses[1],
-      createMeltAuthority: true,
+      createMelt: true,
       meltAuthorityAddress: 'abc',
       allowExternalMeltAuthorityAddress: true,
       pinCode: '123456',
@@ -1510,7 +1510,7 @@ test('createTokens', async () => {
   // create token with correct address for authority output
   const tokenData = await wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
     address: addresses[1],
-    createMintAuthority: true,
+    createMint: true,
     mintAuthorityAddress: addresses[2],
     pinCode: '123456',
   });
@@ -1537,7 +1537,8 @@ test('createTokens', async () => {
   // create token with correct address for authority output
   const tokenData2 = await wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
     address: addresses[1],
-    createMintAuthority: false,
+    createMint: false,
+    createMelt: true,
     meltAuthorityAddress: addresses[2],
     pinCode: '123456',
   });
@@ -1632,10 +1633,11 @@ test('createNFTs', async () => {
   await expect(
     wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
       address: addresses[1],
-      createMintAuthority: true,
+      createMint: true,
       mintAuthorityAddress: 'abc',
       pinCode: '123456',
-      nftData: 'data',
+      data: ['data'],
+      isCreateNFT: true,
     })
   ).rejects.toThrow(SendTxError);
 
@@ -1643,21 +1645,23 @@ test('createNFTs', async () => {
   await expect(
     wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
       address: addresses[1],
-      createMintAuthority: true,
+      createMint: true,
       mintAuthorityAddress: 'abc',
       pinCode: '123456',
-      nftData: 'data',
+      data: ['data'],
+      isCreateNFT: true,
     })
   ).rejects.toThrow(SendTxError);
 
   // create token with correct address for authority output
   const tokenData = await wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
     address: addresses[1],
-    createMintAuthority: true,
+    createMint: true,
     mintAuthorityAddress: addresses[2],
-    createMeltAuthority: false,
+    createMelt: false,
     pinCode: '123456',
-    nftData: 'data',
+    data: ['data'],
+    isCreateNFT: true,
   });
 
   // Token minted, mint authority, and data output
@@ -1678,11 +1682,12 @@ test('createNFTs', async () => {
   // create token with correct address for authority output
   const tokenData2 = await wallet.prepareCreateNewToken('Test Token', 'TST', 100n, {
     address: addresses[1],
-    createMintAuthority: false,
-    createMeltAuthority: true,
+    createMint: false,
+    createMelt: true,
     meltAuthorityAddress: addresses[2],
     pinCode: '123456',
-    nftData: 'data',
+    data: ['data'],
+    isCreateNFT: true,
   });
 
   // Token minted, melt authority, and data output

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -578,6 +578,7 @@ class NanoContractTransactionBuilder {
         }
       }
       tokens = Array.from(tokenSet);
+
       for (const action of this.actions) {
         // Call action
         switch (action.type) {

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -275,6 +275,7 @@ const transaction = {
       input.setData(inputData);
     }
 
+
     if (tx.isNanoContract()) {
       // Store signature in nano header
       const nanoHeaders = tx.getNanoHeaders();

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -275,7 +275,6 @@ const transaction = {
       input.setData(inputData);
     }
 
-
     if (tx.isNanoContract()) {
       // Store signature in nano header
       const nanoHeaders = tx.getNanoHeaders();

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -275,8 +275,8 @@ export const fullNodeOutputSchema = z.object({
   }),
   address: AddressSchema.nullable().optional(),
   token: tokenIdSchema.nullable().optional(),
-  authorities: bigIntCoercibleSchema,
-  timelock: z.number().nullable(),
+  authorities: bigIntCoercibleSchema.optional(),
+  timelock: z.number().nullable().optional(),
 });
 
 /**
@@ -304,8 +304,8 @@ export const fullNodeTxSchema = z.object({
   inputs: z.array(fullNodeInputSchema),
   outputs: z.array(fullNodeOutputSchema),
   tokens: z.array(fullNodeTokenSchema),
-  token_name: z.string().nullable(),
-  token_symbol: z.string().nullable(),
+  token_name: z.string().nullable().optional(),
+  token_symbol: z.string().nullable().optional(),
   raw: z.string(),
 });
 
@@ -322,9 +322,9 @@ export const fullNodeMetaSchema = z.object({
   height: z.number(),
   voided_by: z.array(z.string()),
   spent_outputs: z.array(z.tuple([z.number(), z.array(z.string())])),
-  received_timestamp: z.number().nullable(),
-  is_voided: z.boolean(),
-  verification_status: z.string(),
+  received_timestamp: z.number().nullable().optional(),
+  is_voided: z.boolean().optional(),
+  verification_status: z.string().optional(),
   twins: z.array(z.string()),
   accumulated_weight: z.number(),
   score: z.number(),

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -282,12 +282,15 @@ export const fullNodeOutputSchema = z.object({
 /**
  * Schema for full node token information.
  * Represents token details as seen by the full node.
+ * Note: amount is optional because this schema is reused across different APIs:
+ * - Regular transaction APIs include amount field
+ * - Nano contract token creation APIs only include uid, name, and symbol
  */
 export const fullNodeTokenSchema = z.object({
   uid: z.string(),
   name: z.string(),
   symbol: z.string(),
-  amount: bigIntCoercibleSchema,
+  amount: bigIntCoercibleSchema.optional(),
 });
 
 /**

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -308,9 +308,8 @@ export const ncActionSchema = z.object({
  */
 export const ncContextSchema = z.object({
   actions: z.array(ncActionSchema),
-  address: AddressSchema,
+  caller_id: AddressSchema,
   timestamp: z.number(),
-  address: AddressSchema,
 });
 
 /**

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -298,7 +298,7 @@ export const fullNodeTokenSchema = z.object({
  */
 export const ncActionSchema = z.object({
   type: z.string(),
-  token_uid: z.string().optional(),
+  token_uid: z.string(),
   mint: z.boolean().optional(),
   melt: z.boolean().optional(),
 });

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -291,6 +291,24 @@ export const fullNodeTokenSchema = z.object({
 });
 
 /**
+ * Schema for nano contract context actions.
+ */
+export const ncActionSchema = z.object({
+  type: z.string(),
+  token_uid: z.string(),
+  amount: z.number(),
+});
+
+/**
+ * Schema for nano contract context.
+ */
+export const ncContextSchema = z.object({
+  actions: z.array(ncActionSchema),
+  address: AddressSchema,
+  timestamp: z.number(),
+});
+
+/**
  * Schema for full node transaction data.
  * Contains all information about a transaction as seen by the full node.
  */
@@ -300,12 +318,20 @@ export const fullNodeTxSchema = z.object({
   timestamp: z.number(),
   version: z.number(),
   weight: z.number(),
+  signal_bits: z.number().optional(),
   parents: z.array(z.string()),
   inputs: z.array(fullNodeInputSchema),
   outputs: z.array(fullNodeOutputSchema),
   tokens: z.array(fullNodeTokenSchema),
   token_name: z.string().nullable().optional(),
   token_symbol: z.string().nullable().optional(),
+  nc_id: z.string().optional(),
+  nc_seqnum: z.number().optional(),
+  nc_blueprint_id: z.string().optional(),
+  nc_method: z.string().optional(),
+  nc_args: z.string().optional(),
+  nc_address: AddressSchema.optional(),
+  nc_context: ncContextSchema.optional(),
   raw: z.string(),
 });
 

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -298,8 +298,9 @@ export const fullNodeTokenSchema = z.object({
  */
 export const ncActionSchema = z.object({
   type: z.string(),
-  token_uid: z.string(),
-  amount: z.number(),
+  token_uid: z.string().optional(),
+  mint: z.boolean().optional(),
+  melt: z.boolean().optional(),
 });
 
 /**
@@ -309,6 +310,7 @@ export const ncContextSchema = z.object({
   actions: z.array(ncActionSchema),
   address: AddressSchema,
   timestamp: z.number(),
+  address: AddressSchema,
 });
 
 /**

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -19,6 +19,7 @@ import {
   TxProposalUpdateResponseData,
   TokenDetailsResponseData,
   TxOutputResponseData,
+  GetTxOutputsOptions,
   AuthTokenResponseData,
   FullNodeVersionData,
   TxByIdTokensResponseData,
@@ -220,7 +221,7 @@ const walletApi = {
 
   async getTxOutputs(
     wallet: HathorWalletServiceWallet,
-    options = {}
+    options: GetTxOutputsOptions = {}
   ): Promise<TxOutputResponseData> {
     const data = { params: options };
     const axios = await axiosInstance(wallet, true);

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -104,7 +104,6 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
    * @returns {Promise<IDataTx>} A promise that resolves with the prepared transaction data.
    */
   async prepareTxData(): Promise<IDataTx> {
-    
     // 1. Calculate total output amount for each token
     const tokenAmountMap: TokenAmountMap = {};
     for (const output of this.outputs) {
@@ -161,7 +160,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         const { utxos, changeAmount } = await this.wallet.getUtxosForAmount(tokenAmountMap[token], {
           tokenId: token,
         });
-        
+
         if (utxos.length === 0) {
           throw new UtxoError(
             `No utxos available to fill the request. Token: ${token} - Amount: ${tokenAmountMap[token]}.`

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -635,7 +635,6 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       this.transaction!.nonce = mineData.nonce;
       this.transaction!.weight = mineData.weight;
 
-
       if (until === 'mine-tx') {
         return this.transaction!;
       }

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -104,6 +104,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
    * @returns {Promise<IDataTx>} A promise that resolves with the prepared transaction data.
    */
   async prepareTxData(): Promise<IDataTx> {
+    
     // 1. Calculate total output amount for each token
     const tokenAmountMap: TokenAmountMap = {};
     for (const output of this.outputs) {
@@ -160,7 +161,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         const { utxos, changeAmount } = await this.wallet.getUtxosForAmount(tokenAmountMap[token], {
           tokenId: token,
         });
-
+        
         if (utxos.length === 0) {
           throw new UtxoError(
             `No utxos available to fill the request. Token: ${token} - Amount: ${tokenAmountMap[token]}.`

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -635,6 +635,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       this.transaction!.nonce = mineData.nonce;
       this.transaction!.weight = mineData.weight;
 
+
       if (until === 'mine-tx') {
         return this.transaction!;
       }

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -177,6 +177,21 @@ export interface SendTxOptionsParam {
   changeAddress: string | undefined;
 }
 
+export interface GetTxOutputsOptions {
+  tokenId?: string;
+  authority?: OutputValueType | null;
+  skipSpent?: boolean;
+  maxOutputs?: number;
+  addresses?: string[] | null;
+  totalAmount?: OutputValueType;
+  smallerThan?: number;
+  biggerThan?: number;
+  count?: number;
+  ignoreLocked?: boolean;
+  txId?: string;
+  index?: number;
+}
+
 export interface TxOutputResponseData {
   success: boolean;
   txOutputs: Utxo[];
@@ -613,7 +628,6 @@ export interface FullNodeTx {
     }>;
     caller_id: string;
     timestamp: number;
-    address: string;
   };
 }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2700,14 +2700,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     if (createTokenOptions.symbol === undefined || createTokenOptions.symbol === null) {
       throw new Error('createTokenOptions.symbol is required and cannot be null or undefined');
     }
-    // If mintAddress is not provided, use the address from the nano contract caller
-    if (!createTokenOptions.mintAddress) {
-      createTokenOptions.mintAddress = address;
-    }
-
     // Defaults below match wallet.js (see lines 3077-3087)
     const mergedCreateTokenOptions: NanoContractBuilderCreateTokenOptions = {
-      mintAddress: createTokenOptions.mintAddress,
+      mintAddress: null,
       changeAddress: null,
       createMint: true,
       mintAuthorityAddress: null,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2598,8 +2598,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async prepareNanoSendTransactionWalletService(
     tx: Transaction,
     address: string,
-    pinCode: string,
-    storageProxy?: IStorage
+    pinCode: string
   ): Promise<SendTransactionWalletService> {
     // Get the index for the address
     const addressDetails = await this.getAddressDetails(address);
@@ -2611,14 +2610,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       );
     }
 
-    // Use provided storage proxy or create a new one
-    let finalStorageProxy = storageProxy;
-    if (!finalStorageProxy) {
-      const storageProxyHelper = new WalletServiceStorageProxy(this, this.storage);
-      finalStorageProxy = storageProxyHelper.createProxy();
-    }
+    const storageProxy = new WalletServiceStorageProxy(this, this.storage);
 
-    await transaction.signTransaction(tx, finalStorageProxy, pinCode);
+    await transaction.signTransaction(tx, storageProxy.createProxy(), pinCode);
 
     // Finalize the transaction
     tx.prepareToSend();
@@ -2700,7 +2694,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     if (createTokenOptions.symbol === undefined || createTokenOptions.symbol === null) {
       throw new Error('createTokenOptions.symbol is required and cannot be null or undefined');
     }
-    // Defaults below match wallet.js (see lines 3077-3087)
+
     const mergedCreateTokenOptions: NanoContractBuilderCreateTokenOptions = {
       mintAddress: null,
       changeAddress: null,
@@ -2727,7 +2721,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = await builder.build();
 
-    return this.prepareNanoSendTransactionWalletService(tx, address, pin, storageProxy);
+    return this.prepareNanoSendTransactionWalletService(tx, address, pin);
   }
 }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1367,7 +1367,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     // First get the address index
     const addressIndex = await this.getAddressIndex(address);
-    if (addressIndex === undefined) {
+    if (addressIndex === null) {
       throw new WalletError(`Address ${address} does not belong to this wallet`);
     }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2412,6 +2412,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     data: CreateNanoTxData,
     options: { pinCode?: string } = {}
   ): Promise<SendTransactionWalletService> {
+    
     this.failIfWalletNotReady();
 
     if (await this.storage.isReadonly()) {
@@ -2534,9 +2535,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const storageProxy = storageProxyHelper.createProxy();
 
     await transaction.signTransaction(tx, storageProxy, pinCode);
+    
     // Finalize the transaction
     tx.prepareToSend();
-    return new SendTransactionWalletService(this, { transaction: tx, pin: pinCode });
+    
+    const sendTransaction = new SendTransactionWalletService(this, { transaction: tx, pin: pinCode });
+    return sendTransaction;
   }
 
   /**

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1322,17 +1322,17 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * Get the address index of a base58 address
    *
    * @param {string} address Address to check
-   * @returns {number | undefined} The address index or undefined
+   * @returns {number | null} The address index or undefined
    */
-  async getAddressIndex(address: string): Promise<number | undefined> {
+  async getAddressIndex(address: string): Promise<number | null> {
     try {
       const addressDetails = await this.getAddressDetails(address);
       const addressIndex = addressDetails?.index;
 
       return addressIndex;
     } catch (_e) {
-      // Return undefined if the address is not found
-      return undefined;
+      // Return null if the address is not found
+      return null;
     }
   }
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1712,6 +1712,54 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   }
 
   /**
+   * Get authority utxo
+   *
+   * @param tokenUid UID of the token to select the authority utxo
+   * @param authority The authority to filter ('mint' or 'melt')
+   * @param options Object with custom options.
+   *  {
+   *    'many': if should return many utxos or just one (default false),
+   *    'only_available_utxos': If we should filter for available utxos (default false),
+   *    'filter_address': Address to filter the utxo to get (default null)
+   *  }
+   *
+   * @return Promise that resolves with an Array of objects with {txId, index, address, authorities} of the authority output.
+   * Returns an empty array in case there are no tx outputs for this type
+   * */
+  async getAuthorityUtxo(
+    tokenUid: string,
+    authority: string,
+    options: {
+      many?: boolean;
+      only_available_utxos?: boolean;
+      filter_address?: string | null;
+    } = {}
+  ): Promise<AuthorityTxOutput[]> {
+    let authorityValue: OutputValueType;
+    if (authority === 'mint') {
+      authorityValue = TOKEN_MINT_MASK;
+    } else if (authority === 'melt') {
+      authorityValue = TOKEN_MELT_MASK;
+    } else {
+      throw new Error('Invalid authority value.');
+    }
+
+    const newOptions = {
+      many: false,
+      only_available_utxos: false,
+      filter_address: null,
+      ...options,
+    };
+
+    return this._getAuthorityTxOutput({
+      tokenId: tokenUid,
+      authority: authorityValue,
+      skipSpent: newOptions.only_available_utxos,
+      maxOutputs: newOptions.many ? undefined : 1,
+    });
+  }
+
+  /**
    * Create a new custom token in the network
    *
    * @memberof HathorWalletServiceWallet
@@ -2524,14 +2572,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     createTokenOptions: Partial<NanoContractBuilderCreateTokenOptions> = {},
     options: { pinCode?: string } = {}
   ): Promise<Transaction> {
-    console.log('[createAndSendNanoContractCreateTokenTransaction] Called with:', {
-      method,
-      address,
-      data,
-      createTokenOptions,
-      options: { ...options, pinCode: options.pinCode ? '[REDACTED]' : undefined },
-    });
-
     const sendTransaction = await this.createNanoContractCreateTokenTransaction(
       method,
       address,
@@ -2608,14 +2648,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     createTokenOptions: Partial<NanoContractBuilderCreateTokenOptions> = {},
     options: { pinCode?: string } = {}
   ): Promise<SendTransactionWalletService> {
-    console.log('[createNanoContractCreateTokenTransaction] Called with:', {
-      method,
-      address,
-      data,
-      createTokenOptions,
-      options: { ...options, pinCode: options.pinCode ? '[REDACTED]' : undefined },
-    });
-
     this.failIfWalletNotReady();
     if (await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('createNanoContractCreateTokenTransaction');
@@ -2688,16 +2720,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       ...createTokenOptions,
     } as NanoContractBuilderCreateTokenOptions;
 
-    console.log('[createNanoContractCreateTokenTransaction] Building transaction with:', {
-      method,
-      blueprintId: data.blueprintId,
-      ncId: data.ncId,
-      actions,
-      processedArgs,
-      vertexType: 'CREATE_TOKEN_TRANSACTION',
-      mergedCreateTokenOptions,
-    });
-
     const builder = new NanoContractTransactionBuilder()
       .setMethod(method)
       .setWallet(this)
@@ -2709,8 +2731,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       .setVertexType(NanoContractVertexType.CREATE_TOKEN_TRANSACTION, mergedCreateTokenOptions);
 
     const tx = await builder.build();
-
-    console.log('[createNanoContractCreateTokenTransaction] Built transaction successfully');
 
     return this.prepareNanoSendTransactionWalletService(tx, address, pin, storageProxy);
   }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2698,16 +2698,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       }
       return arg;
     });
-    // Validate required createTokenOptions fields
-    if (createTokenOptions.amount === undefined || createTokenOptions.amount === null) {
-      throw new Error('createTokenOptions.amount is required and cannot be null or undefined');
-    }
-    if (createTokenOptions.name === undefined || createTokenOptions.name === null) {
-      throw new Error('createTokenOptions.name is required and cannot be null or undefined');
-    }
-    if (createTokenOptions.symbol === undefined || createTokenOptions.symbol === null) {
-      throw new Error('createTokenOptions.symbol is required and cannot be null or undefined');
-    }
 
     const mergedCreateTokenOptions: NanoContractBuilderCreateTokenOptions = {
       mintAddress: null,

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1395,14 +1395,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     return addressDetails.data;
   }
 
-  /**
-   * TODO: Currently a no-op... We currently have a very specific mechanism for
-   * locking utxos, which is the createTxProposal/sendTxProposal, that is very
-   * tightly coupled to the regular send transaction method.
-   */
   // eslint-disable-next-line class-methods-use-this
   async markUtxoSelected(): Promise<void> {
-    // TODO: Currently a no-op... We currently have a very specific mechanism for
+    // XXX: Currently a no-op... We currently have a very specific mechanism for
     // locking utxos, which is the createTxProposal/sendTxProposal, that is very
     // tightly coupled to the regular send transaction method.
   }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -2552,12 +2552,12 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
             return transaction.getSignatureForTx(tx, receiver, pinCode);
           };
         }
-        
+
         if (prop === 'getTx') {
           return async (txId: string) => {
             try {
               const fullTxResponse = await this.getFullTxById(txId);
-              
+
               // Convert FullNodeTxResponse to IHistoryTx format
               const { tx, meta } = fullTxResponse;
               const historyTx = {
@@ -2566,7 +2566,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
                 version: tx.version,
                 weight: tx.weight,
                 timestamp: tx.timestamp,
-                is_voided: (meta as any).is_voided ?? (meta.voided_by.length > 0),
+                is_voided: (meta as any).is_voided ?? meta.voided_by.length > 0,
                 nonce: Number.parseInt(tx.nonce ?? '0', 10),
                 inputs: tx.inputs,
                 outputs: tx.outputs,
@@ -2577,14 +2577,13 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
                 token_name: tx.token_name ?? undefined,
                 token_symbol: tx.token_symbol ?? undefined,
               };
-              
+
               return historyTx;
             } catch (error) {
               return null;
             }
           };
         }
-
 
         // For all other properties, use the original behavior
         const value = Reflect.get(target, prop, receiver);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1317,17 +1317,22 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     return this.getCurrentAddress();
   }
 
-  /* eslint-disable class-methods-use-this -- Methods are not yet implemented */
-  getAddressIndex(address: string): number | undefined {
-    // Check all saved addresses to find the index matching this address
-    for (const addressInfo of this.newAddresses) {
-      if (addressInfo.address === address) {
-        return addressInfo.index;
-      }
-    }
+  /**
+   * Get the address index of a base58 address
+   *
+   * @param {string} address Address to check
+   * @returns {number | undefined} The address index or undefined
+   */
+  async getAddressIndex(address: string): Promise<number | undefined> {
+    try {
+      const addressDetails = await this.getAddressDetails(address);
+      const addressIndex = addressDetails?.index;
 
-    // Return undefined if the address is not found
-    return undefined;
+      return addressIndex;
+    } catch (_e) {
+      // Return undefined if the address is not found
+      return undefined;
+    }
   }
 
   /**
@@ -1360,7 +1365,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     }
 
     // First get the address index
-    const addressIndex = this.getAddressIndex(address);
+    const addressIndex = await this.getAddressIndex(address);
     if (addressIndex === undefined) {
       throw new WalletError(`Address ${address} does not belong to this wallet`);
     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1380,6 +1380,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async getNanoHeaderSeqnum(address: string): Promise<number> {
     const addressInfo = await walletApi.getAddressDetails(this, address);
+
     return addressInfo.data.seqnum + 1;
   }
 
@@ -2412,7 +2413,6 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     data: CreateNanoTxData,
     options: { pinCode?: string } = {}
   ): Promise<SendTransactionWalletService> {
-    
     this.failIfWalletNotReady();
 
     if (await this.storage.isReadonly()) {
@@ -2507,6 +2507,46 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   }
 
   /**
+   * Create and send a Create Token Transaction with nano header
+   *
+   * @param {string} method Method of nano contract to have the transaction created
+   * @param {string} address Address that will be used to sign the nano contract transaction
+   * @param {object} data Nano contract data (blueprintId, ncId, actions, args)
+   * @param {object} createTokenOptions Options for token creation (mint/melt authorities, NFT, etc)
+   * @param {object} options Options (pinCode)
+   *
+   * @returns {Promise<Transaction>}
+   */
+  async createAndSendNanoContractCreateTokenTransaction(
+    method: string,
+    address: string,
+    data: CreateNanoTxData,
+    createTokenOptions: Partial<NanoContractBuilderCreateTokenOptions> = {},
+    options: { pinCode?: string } = {}
+  ): Promise<Transaction> {
+    console.log('[createAndSendNanoContractCreateTokenTransaction] Called with:', {
+      method,
+      address,
+      data,
+      createTokenOptions,
+      options: { ...options, pinCode: options.pinCode ? '[REDACTED]' : undefined },
+    });
+
+    const sendTransaction = await this.createNanoContractCreateTokenTransaction(
+      method,
+      address,
+      data,
+      createTokenOptions,
+      options
+    );
+    const result = await sendTransaction.runFromMining();
+    if (!result) {
+      throw new Error('Failed to send nano contract create token transaction');
+    }
+    return result;
+  }
+
+  /**
    * Custom nano contract transaction preparation for wallet-service facade
    * Signs the nano contract transaction using the wallet's own key derivation logic
    *
@@ -2518,7 +2558,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async prepareNanoSendTransactionWalletService(
     tx: Transaction,
     address: string,
-    pinCode: string
+    pinCode: string,
+    storageProxy?: IStorage
   ): Promise<SendTransactionWalletService> {
     // Get the index for the address
     const addressDetails = await this.getAddressDetails(address);
@@ -2530,16 +2571,22 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       );
     }
 
-    // Create a proxy wrapper for storage to implement missing methods needed for nano contract signing
-    const storageProxyHelper = new WalletServiceStorageProxy(this, this.storage);
-    const storageProxy = storageProxyHelper.createProxy();
+    // Use provided storage proxy or create a new one
+    let finalStorageProxy = storageProxy;
+    if (!finalStorageProxy) {
+      const storageProxyHelper = new WalletServiceStorageProxy(this, this.storage);
+      finalStorageProxy = storageProxyHelper.createProxy();
+    }
 
-    await transaction.signTransaction(tx, storageProxy, pinCode);
-    
+    await transaction.signTransaction(tx, finalStorageProxy, pinCode);
+
     // Finalize the transaction
     tx.prepareToSend();
-    
-    const sendTransaction = new SendTransactionWalletService(this, { transaction: tx, pin: pinCode });
+
+    const sendTransaction = new SendTransactionWalletService(this, {
+      transaction: tx,
+      pin: pinCode,
+    });
     return sendTransaction;
   }
 
@@ -2561,6 +2608,14 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     createTokenOptions: Partial<NanoContractBuilderCreateTokenOptions> = {},
     options: { pinCode?: string } = {}
   ): Promise<SendTransactionWalletService> {
+    console.log('[createNanoContractCreateTokenTransaction] Called with:', {
+      method,
+      address,
+      data,
+      createTokenOptions,
+      options: { ...options, pinCode: options.pinCode ? '[REDACTED]' : undefined },
+    });
+
     this.failIfWalletNotReady();
     if (await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('createNanoContractCreateTokenTransaction');
@@ -2571,7 +2626,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       throw new PinRequiredError('Pin is required.');
     }
     // Validate address belongs to wallet and get its index
-    const addressIndex = this.getAddressIndex(address);
+    const addressDetails = await this.getAddressDetails(address);
+    const addressIndex = addressDetails?.index;
     if (addressIndex === undefined) {
       throw new Error(
         `Address used to sign the transaction (${address}) does not belong to the wallet.`
@@ -2602,9 +2658,24 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       }
       return arg;
     });
+    // Validate required createTokenOptions fields
+    if (createTokenOptions.amount === undefined || createTokenOptions.amount === null) {
+      throw new Error('createTokenOptions.amount is required and cannot be null or undefined');
+    }
+    if (createTokenOptions.name === undefined || createTokenOptions.name === null) {
+      throw new Error('createTokenOptions.name is required and cannot be null or undefined');
+    }
+    if (createTokenOptions.symbol === undefined || createTokenOptions.symbol === null) {
+      throw new Error('createTokenOptions.symbol is required and cannot be null or undefined');
+    }
+    // If mintAddress is not provided, use the address from the nano contract caller
+    if (!createTokenOptions.mintAddress) {
+      createTokenOptions.mintAddress = address;
+    }
+
     // Defaults below match wallet.js (see lines 3077-3087)
     const mergedCreateTokenOptions: NanoContractBuilderCreateTokenOptions = {
-      mintAddress: null,
+      mintAddress: createTokenOptions.mintAddress,
       changeAddress: null,
       createMint: true,
       mintAuthorityAddress: null,
@@ -2616,6 +2687,16 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       isCreateNFT: false,
       ...createTokenOptions,
     } as NanoContractBuilderCreateTokenOptions;
+
+    console.log('[createNanoContractCreateTokenTransaction] Building transaction with:', {
+      method,
+      blueprintId: data.blueprintId,
+      ncId: data.ncId,
+      actions,
+      processedArgs,
+      vertexType: 'CREATE_TOKEN_TRANSACTION',
+      mergedCreateTokenOptions,
+    });
 
     const builder = new NanoContractTransactionBuilder()
       .setMethod(method)
@@ -2629,7 +2710,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     const tx = await builder.build();
 
-    return this.prepareNanoSendTransactionWalletService(tx, address, pin);
+    console.log('[createNanoContractCreateTokenTransaction] Built transaction successfully');
+
+    return this.prepareNanoSendTransactionWalletService(tx, address, pin, storageProxy);
   }
 }
 

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -56,6 +56,10 @@ export class WalletServiceStorageProxy {
       return this.getSpentTxs.bind(this);
     }
 
+    if (prop === 'getCurrentAddress') {
+      return this.getCurrentAddress.bind(this);
+    }
+
     // For all other properties, use the original behavior
     const value = Reflect.get(target, prop, receiver);
 
@@ -124,6 +128,19 @@ export class WalletServiceStorageProxy {
       return result;
     } catch (error) {
       return null;
+    }
+  }
+
+  /**
+   * Get current address from wallet service
+   * Uses the wallet's getCurrentAddress method which fetches from the API
+   */
+  private async getCurrentAddress(markAsUsed?: boolean): Promise<string> {
+    try {
+      const currentAddress = await this.wallet.getCurrentAddress({ markAsUsed });
+      return currentAddress.address; // Return just the address string for utils compatibility
+    } catch (error) {
+      throw new Error('Current address is not loaded');
     }
   }
 

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -40,6 +40,14 @@ export class WalletServiceStorageProxy {
     });
   }
 
+  /**
+   * Proxy handler that intercepts property access on the storage object.
+   *
+   * @param target - The original IStorage object being proxied
+   * @param prop - The property name being accessed (can be string or Symbol for JS property keys)
+   * @param receiver - The proxy itself (not the target), used to maintain correct 'this' context
+   * @returns The intercepted method or the original property value
+   */
   private proxyHandler(target: IStorage, prop: string | symbol, receiver: IStorage): unknown {
     if (prop === 'getAddressInfo') {
       return this.getAddressInfo.bind(this);

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -158,7 +158,8 @@ export class WalletServiceStorageProxy {
    */
   private async getCurrentAddress(markAsUsed?: boolean): Promise<string> {
     try {
-      const currentAddress = this.wallet.getCurrentAddress({ markAsUsed });
+      const currentAddress = await this.wallet.getCurrentAddress({ markAsUsed });
+
       return currentAddress.address; // Return just the address string for utils compatibility
     } catch (error) {
       throw new Error('Current address is not loaded');

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -1,0 +1,148 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { IStorage, IHistoryTx } from '../types';
+import Transaction from '../models/transaction';
+import HathorWalletServiceWallet from './wallet';
+import { FullNodeTxResponse } from './types';
+
+/**
+ * Storage proxy that implements missing storage methods for wallet service
+ * by delegating to wallet service API calls.
+ *
+ * This proxy enables nano contract transaction signing by providing:
+ * - getAddressInfo: Maps addresses to BIP32 indices
+ * - getTx: Fetches transaction data from full node API
+ * - getTxSignatures: Delegates to transaction signing utilities
+ */
+export class WalletServiceStorageProxy {
+  private wallet: HathorWalletServiceWallet;
+
+  private originalStorage: IStorage;
+
+  constructor(wallet: HathorWalletServiceWallet, originalStorage: IStorage) {
+    this.wallet = wallet;
+    this.originalStorage = originalStorage;
+  }
+
+  /**
+   * Creates a proxy that wraps the original storage with additional methods
+   * needed for nano contract transaction signing.
+   */
+  createProxy(): IStorage {
+    return new Proxy(this.originalStorage, {
+      get: this.proxyHandler.bind(this),
+    });
+  }
+
+  private proxyHandler(target: IStorage, prop: string | symbol, receiver: IStorage): unknown {
+    if (prop === 'getAddressInfo') {
+      return this.getAddressInfo.bind(this);
+    }
+
+    if (prop === 'getTxSignatures') {
+      return this.getTxSignatures.bind(this, receiver);
+    }
+
+    if (prop === 'getTx') {
+      return this.getTx.bind(this);
+    }
+
+    // For all other properties, use the original behavior
+    const value = Reflect.get(target, prop, receiver);
+
+    // Bind methods to maintain correct 'this' context
+    if (typeof value === 'function') {
+      return value.bind(target);
+    }
+
+    return value;
+  }
+
+  /**
+   * Get address information including BIP32 index
+   * First tries local wallet cache, then falls back to API
+   */
+  private async getAddressInfo(address: string) {
+    const addressIndex = this.wallet.getAddressIndex(address);
+    if (addressIndex !== undefined) {
+      return {
+        bip32AddressIndex: addressIndex,
+      };
+    }
+
+    // Address not in local cache, try API
+    try {
+      const addressDetails = await this.wallet.getAddressDetails(address);
+      return {
+        bip32AddressIndex: addressDetails.index,
+      };
+    } catch (error) {
+      return null; // Address doesn't belong to this wallet
+    }
+  }
+
+  /**
+   * Get transaction signatures using the transaction utility
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private async getTxSignatures(receiver: IStorage, tx: Transaction, pinCode: string) {
+    const transaction = await import('../utils/transaction');
+    return transaction.default.getSignatureForTx(tx, receiver, pinCode);
+  }
+
+  /**
+   * Get transaction data by fetching from full node and converting format
+   */
+  private async getTx(txId: string) {
+    try {
+      const fullTxResponse = await this.wallet.getFullTxById(txId);
+      return this.convertFullNodeToHistoryTx(fullTxResponse);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  /**
+   * Convert FullNodeTxResponse to IHistoryTx format
+   * This bridges the gap between full node API format and wallet storage format
+   */
+  // eslint-disable-next-line class-methods-use-this
+  private convertFullNodeToHistoryTx(fullTxResponse: FullNodeTxResponse): IHistoryTx {
+    const { tx, meta } = fullTxResponse;
+
+    return {
+      tx_id: tx.hash,
+      signalBits: 0, // Default value since fullnode tx doesn't include signal bits
+      version: tx.version,
+      weight: tx.weight,
+      timestamp: tx.timestamp,
+      is_voided: meta.voided_by.length > 0,
+      nonce: Number.parseInt(tx.nonce ?? '0', 10),
+      inputs: tx.inputs.map(input => ({
+        ...input,
+        decoded: {
+          ...input.decoded,
+          type: input.decoded.type ?? undefined,
+        },
+      })) as IHistoryTx['inputs'],
+      outputs: tx.outputs.map(output => ({
+        ...output,
+        decoded: {
+          ...output.decoded,
+          type: output.decoded.type ?? undefined,
+        },
+      })) as IHistoryTx['outputs'],
+      parents: tx.parents,
+      tokens: tx.tokens.map(token => token.uid),
+      height: meta.height,
+      first_block: meta.first_block,
+      token_name: tx.token_name ?? undefined,
+      token_symbol: tx.token_symbol ?? undefined,
+    };
+  }
+}

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -74,12 +74,18 @@ export class WalletServiceStorageProxy {
 
   /**
    * Get address information including BIP32 index
-   * First tries local wallet cache, then falls back to API
    */
   private async getAddressInfo(address: string) {
-    const addressIndex = await this.wallet.getAddressIndex(address);
+    const addressDetails = await this.wallet.getAddressDetails(address);
 
-    return addressIndex;
+    if (!addressDetails) {
+      return null;
+    }
+
+    return {
+      bip32AddressIndex: addressDetails.index,
+      address: addressDetails.address,
+    };
   }
 
   /**

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IStorage, IHistoryTx } from '../types';
+import { IStorage, IHistoryTx, IAddressInfo, IAddressMetadata } from '../types';
 import Transaction from '../models/transaction';
 import HathorWalletServiceWallet from './wallet';
 import { FullNodeTxResponse } from './types';
@@ -75,7 +75,9 @@ export class WalletServiceStorageProxy {
   /**
    * Get address information including BIP32 index
    */
-  private async getAddressInfo(address: string) {
+  private async getAddressInfo(
+    address: string
+  ): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number }) | null> {
     const addressDetails = await this.wallet.getAddressDetails(address);
 
     if (!addressDetails) {
@@ -84,7 +86,13 @@ export class WalletServiceStorageProxy {
 
     return {
       bip32AddressIndex: addressDetails.index,
-      address: addressDetails.address,
+      base58: addressDetails.address,
+      seqnum: addressDetails.seqnum,
+      numTransactions: addressDetails.transactions,
+      // TODO: This balance is not used by any of the nano contract methods
+      // but in order to be 100% compatible with the old facade method, we need
+      // to implement an API to fetch the balance for all tokens given an address
+      balance: new Map(),
     };
   }
 


### PR DESCRIPTION
## Acceptance Criteria
- Update schemas for the proxy methods with nano contract responses
- Added missing `createAndSendNanoContractCreateTokenTransaction` method
- Created a `storage` proxy, to override util methods so they're compatible the the wallet-service