### PR TITLE
refactor: falling back to regex replace on getLocaleString + toString with radix

### DIFF
--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -61,7 +61,7 @@ export const JSONBigInt = {
   bigIntReplacer(_key: string, value_: any): any {
     // If the value is a BigInt, we simply return its string representation.
     // @ts-expect-error TypeScript hasn't been updated with the `rawJSON` function from Node v22.
-    return typeof value_ === 'bigint' ? JSON.rawJSON(value_.toString()) : value_;
+    return typeof value_ === 'bigint' ? JSON.rawJSON(value_.toString(10)) : value_;
   },
   /* eslint-enable @typescript-eslint/no-explicit-any */
 };

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,56 +1,63 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import { DECIMAL_PLACES } from '../constants';
 
 const formatter = new Intl.NumberFormat('en-US');
 
 /**
- * Get the formatted integer value with thousand separators
+ * Get the formatted integer value with thousand separators.
  *
- * Hermes does not have support for Intl.NumberFormat format method
- * with bigint values, and we use it in the Android for a better performance.
- * The iOS app runs with JSC, which doesn't work with bigint and toLocaleString.
- * Then I have this method that tries both options to format the integer value.
+ * Hermes does not support Intl.NumberFormat.format with BigInt, and we use it
+ * on Android for performance. iOS uses JSC, which also doesn’t support BigInt
+ * with toLocaleString. This method tries Intl first, then falls back to a
+ * manual formatter that works with BigInt.
  *
  * @param value Amount to be formatted
- *
  * @return {string} Formatted value
- *
- * @inner
  */
-function getLocaleString(value: bigint): string {
-  try {
+function getLocaleString(value: bigint | number): string {
+  if (typeof value === 'number' && Number.isFinite(value)) {
     return formatter.format(value);
-  } catch (e) {
-    return value.toLocaleString('en-US');
   }
+  const s = value.toString(10);
+  const isNeg = s[0] === '-';
+  const digits = isNeg ? s.slice(1) : s;
+  return (isNeg ? '-' : '') + digits.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
 /**
- * Get the formatted value with decimal places and thousand separators
+ * Get the formatted value with decimal places and thousand separators.
+ *
+ * Accepts a fixed-point integer stored as BigInt, splits into integer and
+ * fractional parts, formats them with grouping, and reattaches the sign.
  *
  * @param inputValue Amount to be formatted
- * @param [decimalPlaces=DECIMAL_PLACES] Number of decimal places
- *
- * @return {string} Formatted value
- *
- * @inner
+ * @param decimalPlaces Number of decimal places (>= 0)
+ * @return {string} Formatted decimal string
  */
 export function prettyValue(
   inputValue: bigint | number | string,
-  decimalPlaces = DECIMAL_PLACES
+  decimalPlaces: number = DECIMAL_PLACES
 ): string {
   const value = BigInt(inputValue);
-  if (typeof value !== 'bigint') {
-    throw Error(`value ${value} should be a bigint`);
-  }
+
   if (decimalPlaces === 0) {
     return getLocaleString(value);
   }
-  const absValue = value >= 0 ? value : -value;
+
+  const absValue = value >= 0n ? value : -value;
   const decimalDivisor = 10n ** BigInt(decimalPlaces);
   const integerPart = absValue / decimalDivisor;
   const decimalPart = absValue % decimalDivisor;
-  const signal = value < 0 ? '-' : '';
+  const signal = value < 0n ? '-' : '';
+
   const integerString = getLocaleString(integerPart);
-  const decimalString = decimalPart.toString().padStart(decimalPlaces, '0');
+  const decimalString = decimalPart.toString(10).padStart(decimalPlaces, '0');
+
   return `${signal}${integerString}.${decimalString}`;
 }


### PR DESCRIPTION
## Motivation

When using SES (Secure ECMAScript), some methods that rely on implicit defaults can be flagged as unsafe. In our particular case, calling `.toString()` on a `Number` or `BigInt` without specifying the radix causes SES to throw an error (RangeError: radix out-of-range in BigInt.prototype.toString).

### Acceptance Criteria
- All uses of `.toString()` with numeric or BigInt values must explicitly specify the radix (`.toString(10)`).
- `prettyValue` and `getLocaleString` must handle both `Number` and `BigInt` correctly, even in SES environments.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.