### PR TITLE
fix: seqnum storage should be in a separate metadata map

### DIFF
--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -632,9 +632,9 @@ describe('full cycle of bet nano contract', () => {
     // Even if the tx is voided, if it has first_block, the seqnum should increase. This
     // case the tx became voided after getting a first_block and the nano execution failed
     // but the number of transactions should still be the same
-    const address2Meta3 = await wallet.storage.store.getAddressMeta(address2);
-    expect(address2Meta3.seqnum).toBe(2);
-    expect(address2Meta3.numTransactions).toBe(2);
+    const address2Info = await wallet.storage.getAddressInfo(address2);
+    expect(address2Info.numTransactions).toBe(2);
+    expect(address2Info.seqnum).toBe(2);
   };
 
   const checkErrorsWithBlueprintId = async blueprintId => {

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -939,6 +939,7 @@ export class MemoryStore implements IStore {
       this.addresses = new Map<string, IAddressInfo>();
       this.addressIndexes = new Map<number, string>();
       this.addressesMetadata = new Map<string, IAddressMetadata>();
+      this.seqnumMetadata = new Map<string, number>();
       this.walletData = { ...this.walletData, ...DEFAULT_ADDRESSES_WALLET_DATA };
     }
 

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -106,6 +106,13 @@ export class MemoryStore implements IStore {
   addressesMetadata: Map<string, IAddressMetadata>;
 
   /**
+   * Map<base58, number>
+   * where base58 is the address in base58
+   * and the number is the current seqnum of the address
+   */
+  seqnumMetadata: Map<string, number>;
+
+  /**
    * Map<uid, ITokenData>
    * where uid is the token uid in hex
    */
@@ -169,6 +176,7 @@ export class MemoryStore implements IStore {
     this.addresses = new Map<string, IAddressInfo>();
     this.addressIndexes = new Map<number, string>();
     this.addressesMetadata = new Map<string, IAddressMetadata>();
+    this.seqnumMetadata = new Map<string, number>();
     this.tokens = new Map<string, ITokenData>();
     this.tokensMetadata = new Map<string, ITokenMetadata>();
     this.registeredTokens = new Map<string, ITokenData>();
@@ -229,6 +237,17 @@ export class MemoryStore implements IStore {
    */
   async getAddressMeta(base58: string): Promise<IAddressMetadata | null> {
     return this.addressesMetadata.get(base58) || null;
+  }
+
+  /**
+   * Get the seqnum for an address if it exists.
+   *
+   * @param {string} base58 Address in base58 to search the seqnum
+   * @async
+   * @returns {Promise<number | null>} A promise with the address seqnum or null if not in storage
+   */
+  async getSeqnumMeta(base58: string): Promise<number | null> {
+    return this.seqnumMetadata.get(base58) || null;
   }
 
   /**
@@ -331,6 +350,16 @@ export class MemoryStore implements IStore {
    */
   async editAddressMeta(base58: string, meta: IAddressMetadata): Promise<void> {
     this.addressesMetadata.set(base58, meta);
+  }
+
+  /**
+   * Edit address seqnum.
+   *
+   * @param {string} base58 The address in base58 format
+   * @param {number} seqnum The seqnum to save
+   */
+  async editSeqnumMeta(base58: string, seqnum: number): Promise<void> {
+    this.seqnumMetadata.set(base58, seqnum);
   }
 
   /* TRANSACTIONS */

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -247,7 +247,7 @@ export class MemoryStore implements IStore {
    * @returns {Promise<number | null>} A promise with the address seqnum or null if not in storage
    */
   async getSeqnumMeta(base58: string): Promise<number | null> {
-    return this.seqnumMetadata.get(base58) || null;
+    return this.seqnumMetadata.get(base58) ?? null;
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -210,9 +210,9 @@ export class Storage implements IStorage {
    *
    * @param {string} base58 The base58 address to fetch
    * @async
-   * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & number)|null>} The address info or null if not found
+   * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & { seqnum: number | null })|null>} The address info or null if not found
    */
-  async getAddressInfo(base58: string): Promise<(IAddressInfo & IAddressMetadata) | null> {
+  async getAddressInfo(base58: string): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number | null }) | null> {
     const address = await this.store.getAddress(base58);
     if (address === null) {
       return null;

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -220,7 +220,7 @@ export class Storage implements IStorage {
       return null;
     }
     const meta = await this.store.getAddressMeta(base58);
-    const seqnum = await this.store.getSeqnumMeta(base58) ?? -1;
+    const seqnum = (await this.store.getSeqnumMeta(base58)) ?? -1;
     return { ...address, ...DEFAULT_ADDRESS_META, ...meta, seqnum };
   }
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -212,7 +212,9 @@ export class Storage implements IStorage {
    * @async
    * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & { seqnum: number | null })|null>} The address info or null if not found
    */
-  async getAddressInfo(base58: string): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number | null }) | null> {
+  async getAddressInfo(
+    base58: string
+  ): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number | null }) | null> {
     const address = await this.store.getAddress(base58);
     if (address === null) {
       return null;

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -210,17 +210,17 @@ export class Storage implements IStorage {
    *
    * @param {string} base58 The base58 address to fetch
    * @async
-   * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & { seqnum: number | null })|null>} The address info or null if not found
+   * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & { seqnum: number })|null>} The address info or null if not found
    */
   async getAddressInfo(
     base58: string
-  ): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number | null }) | null> {
+  ): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number }) | null> {
     const address = await this.store.getAddress(base58);
     if (address === null) {
       return null;
     }
     const meta = await this.store.getAddressMeta(base58);
-    const seqnum = await this.store.getSeqnumMeta(base58);
+    const seqnum = await this.store.getSeqnumMeta(base58) ?? -1;
     return { ...address, ...DEFAULT_ADDRESS_META, ...meta, seqnum };
   }
 

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -64,7 +64,6 @@ import Transaction from '../models/transaction';
 export const DEFAULT_ADDRESS_META: IAddressMetadata = {
   numTransactions: 0,
   balance: new Map<string, IBalance>(),
-  seqnum: -1,
 };
 
 export class Storage implements IStorage {
@@ -211,7 +210,7 @@ export class Storage implements IStorage {
    *
    * @param {string} base58 The base58 address to fetch
    * @async
-   * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata>)|null>} The address info or null if not found
+   * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & number)|null>} The address info or null if not found
    */
   async getAddressInfo(base58: string): Promise<(IAddressInfo & IAddressMetadata) | null> {
     const address = await this.store.getAddress(base58);
@@ -219,7 +218,8 @@ export class Storage implements IStorage {
       return null;
     }
     const meta = await this.store.getAddressMeta(base58);
-    return { ...address, ...DEFAULT_ADDRESS_META, ...meta };
+    const seqnum = await this.store.getSeqnumMeta(base58);
+    return { ...address, ...DEFAULT_ADDRESS_META, ...meta, seqnum };
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,15 +75,11 @@ export interface IAddressInfo {
 export interface IAddressMetadata {
   numTransactions: number;
   balance: Map<string, IBalance>;
-  // Sequential number used when creating nano header in a transaction
-  // each address has this sequence and we get the next number of the caller
-  seqnum: number;
 }
 
 export interface IAddressMetadataAsRecord {
   numTransactions: number;
   balance: Record<string, IBalance>;
-  seqnum: number;
 }
 
 export interface ITokenData {
@@ -444,11 +440,13 @@ export interface IStore {
   addressIter(): AsyncGenerator<IAddressInfo>;
   getAddress(base58: string): Promise<IAddressInfo | null>;
   getAddressMeta(base58: string): Promise<IAddressMetadata | null>;
+  getSeqnumMeta(base58: string): Promise<number | null>;
   getAddressAtIndex(index: number): Promise<IAddressInfo | null>;
   saveAddress(info: IAddressInfo): Promise<void>;
   addressExists(base58: string): Promise<boolean>;
   addressCount(): Promise<number>;
   editAddressMeta(base58: string, meta: IAddressMetadata): Promise<void>;
+  editSeqnumMeta(base58: string, seqnum: number): Promise<void>;
 
   // tx history methods
   historyIter(tokenUid?: string): AsyncGenerator<IHistoryTx>;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -646,7 +646,7 @@ export async function processNewTx(
     if (callerAddressInfo) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
-      if (seqnumMeta != null) {
+      if (seqnumMeta === null) {
         seqnumMeta = -1;
       }
 
@@ -842,7 +842,7 @@ export async function processNewTx(
     if (callerAddressInfo && tx.nc_id && tx.nc_seqnum != null) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
-      if (seqnumMeta != null) {
+      if (seqnumMeta === null) {
         seqnumMeta = -1;
       }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -650,8 +650,8 @@ export async function processNewTx(
         seqnumMeta = -1;
       }
 
-      if (tx.nc_seqnum! > seqnumMeta) {
-        seqnumMeta = tx.nc_seqnum!;
+      if (tx.nc_seqnum > seqnumMeta) {
+        seqnumMeta = tx.nc_seqnum;
       }
       await store.editSeqnumMeta(caller, seqnumMeta);
     }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -634,7 +634,7 @@ export async function processNewTx(
 
   const { store } = storage;
 
-  if (tx.is_voided && tx.nc_id && tx.first_block && tx.seqnum != null) {
+  if (tx.is_voided && tx.nc_id && tx.first_block && tx.nc_seqnum != null) {
     // If a nano transaction is voided but has first block
     // we need to increase the seqnum of the caller address
     if (!tx.nc_address) {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -646,7 +646,7 @@ export async function processNewTx(
     if (callerAddressInfo) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
-      if (seqnumMeta === null) {
+      if (seqnumMeta == null) {
         seqnumMeta = -1;
       }
 
@@ -842,7 +842,7 @@ export async function processNewTx(
     if (callerAddressInfo && tx.nc_id && tx.nc_seqnum != null) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
-      if (seqnumMeta === null) {
+      if (seqnumMeta == null) {
         seqnumMeta = -1;
       }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -839,14 +839,14 @@ export async function processNewTx(
     }
     const callerAddressInfo = await store.getAddress(caller);
     // if address is not in wallet, ignore
-    if (callerAddressInfo) {
+    if (callerAddressInfo && tx.nc_id && tx.nc_seqnum != null) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
       if (seqnumMeta != null) {
         seqnumMeta = -1;
       }
 
-      if (tx.nc_id && tx.nc_seqnum != null && tx.nc_seqnum > seqnumMeta) {
+      if (tx.nc_seqnum > seqnumMeta) {
         seqnumMeta = tx.nc_seqnum;
       }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -854,7 +854,7 @@ export async function processNewTx(
 
     if (callerAddressInfo && tx.nc_id && tx.nc_seqnum != null) {
       // update seqnum metadata if it's bigger
-      let seqnumMeta = await store.getSeqnumMeta(caller) ?? -1;
+      const seqnumMeta = (await store.getSeqnumMeta(caller)) ?? -1;
       if (tx.nc_seqnum > seqnumMeta) {
         await store.editSeqnumMeta(caller, tx.nc_seqnum);
       }

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -646,7 +646,7 @@ export async function processNewTx(
     if (callerAddressInfo) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
-      if (!seqnumMeta) {
+      if (seqnumMeta != null) {
         seqnumMeta = -1;
       }
 
@@ -842,7 +842,7 @@ export async function processNewTx(
     if (callerAddressInfo) {
       // create metadata for address if it does not exist
       let seqnumMeta = await store.getSeqnumMeta(caller);
-      if (!seqnumMeta) {
+      if (seqnumMeta != null) {
         seqnumMeta = -1;
       }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -634,7 +634,7 @@ export async function processNewTx(
 
   const { store } = storage;
 
-  if (tx.is_voided && tx.nc_id && tx.first_block) {
+  if (tx.is_voided && tx.nc_id && tx.first_block && tx.seqnum != null) {
     // If a nano transaction is voided but has first block
     // we need to increase the seqnum of the caller address
     if (!tx.nc_address) {
@@ -645,15 +645,15 @@ export async function processNewTx(
     // if address is not in wallet, ignore
     if (callerAddressInfo) {
       // create metadata for address if it does not exist
-      let addressMeta = await store.getAddressMeta(caller);
-      if (!addressMeta) {
-        addressMeta = { ...DEFAULT_ADDRESS_META };
+      let seqnumMeta = await store.getSeqnumMeta(caller);
+      if (!seqnumMeta) {
+        seqnumMeta = -1;
       }
 
-      if (tx.nc_seqnum! > addressMeta.seqnum) {
-        addressMeta.seqnum = tx.nc_seqnum!;
+      if (tx.nc_seqnum! > seqnumMeta) {
+        seqnumMeta = tx.nc_seqnum!;
       }
-      await store.editAddressMeta(caller, addressMeta);
+      await store.editSeqnumMeta(caller, seqnumMeta);
     }
   }
 
@@ -841,18 +841,17 @@ export async function processNewTx(
     // if address is not in wallet, ignore
     if (callerAddressInfo) {
       // create metadata for address if it does not exist
-      let addressMeta = await store.getAddressMeta(caller);
-      if (!addressMeta) {
-        addressMeta = { ...DEFAULT_ADDRESS_META };
+      let seqnumMeta = await store.getSeqnumMeta(caller);
+      if (!seqnumMeta) {
+        seqnumMeta = -1;
       }
 
-      if (tx.nc_id) {
-        if (tx.nc_seqnum! > addressMeta.seqnum) {
-          addressMeta.seqnum = tx.nc_seqnum!;
-        }
+      if (tx.nc_id && tx.nc_seqnum != null && tx.nc_seqnum > seqnumMeta) {
+        seqnumMeta = tx.nc_seqnum;
       }
 
-      await store.editAddressMeta(caller, addressMeta);
+      await store.editSeqnumMeta(caller, seqnumMeta);
+
       txAddresses.add(caller);
     }
   }


### PR DESCRIPTION
### Motivation

When we receive a new tx and it's voided, we run a full history processing, clearing everything in the storage. If we were to create a new nano tx in the meanwhile, we would be getting an outdated seqnum. 

The seqnum data is not affected by voided txs (in our integration), so I decided to move this to a different metadata, which is not emptied on this full history processing.

### Acceptance Criteria
- Move seqnum storage to a different metadata map, so it doesn't get emptied on metadata clear


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
