### PR TITLE
test: Wallet Service infrastructure

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   itest:
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     strategy:
       matrix:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -105,9 +105,7 @@ services:
       retries: 5
 
   ws-migrator:
-    build:
-      context: '../../../../wallet-service/'
-      dockerfile: 'db/Dockerfile'
+    image: hathornetwork/hathor-wallet-service-migrator
     restart: "no"  # Critical: don't restart migration service
     depends_on:
       mysql:
@@ -122,9 +120,7 @@ services:
       - hathor-privnet
 
   ws-daemon:
-    build:
-      context: '../../../../wallet-service/'
-      dockerfile: 'packages/daemon/Dockerfile'
+    image: hathornetwork/hathor-wallet-service-sync-daemon
     depends_on:
       ws-migrator:
         condition: service_completed_successfully

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -104,7 +104,7 @@ services:
 
   ws-migrator:
     build:
-      context: '/home/tulio/code/wallet-service/'
+      context: '../../../../wallet-service/'
       dockerfile: 'db/Dockerfile'
       args:
         DB_ENDPOINT: "mysql"
@@ -128,7 +128,7 @@ services:
 
   ws-daemon:
     build:
-      context: '/home/tulio/code/wallet-service/'
+      context: '../../../../wallet-service/'
       dockerfile: Dockerfile
     depends_on:
       ws-migrator:
@@ -171,7 +171,7 @@ services:
 
   ws-serverless:
     build:
-      context: '/home/tulio/code/wallet-service/'
+      context: '../../../../wallet-service/'
       dockerfile: 'packages/wallet-service/Dockerfile'
     depends_on:
       ws-daemon:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       MYSQL_DEFAULT_AUTHENTICATION_PLUGIN: mysql_native_password
     ports:
       - "3380:3306"
+    healthcheck:
+        test: ["CMD", "mysql", "-h", "mysql", "-u", "wallet_service_user", "-ppassword", "-e", "SELECT 1", "wallet_service"]
 
   redis:
     image: redis:6.2
@@ -99,14 +101,40 @@ services:
       timeout: 5s
       retries: 5
 
+  ws-migrator:
+    build:
+      context: '/home/tulio/code/wallet-service/'
+      dockerfile: 'db/Dockerfile'
+      args:
+        DB_ENDPOINT: "mysql"
+        DB_NAME: "wallet_service"
+        DB_USER: "wallet_service_user"
+        DB_PASS: "password"
+        DB_PORT: 3306
+    restart: "no"  # Critical: don't restart migration service
+    command: ["/bin/sh", "migrate.sh"]
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      DB_ENDPOINT: "mysql"
+      DB_NAME: "wallet_service"
+      DB_USER: "wallet_service_user"
+      DB_PASS: "password"
+      DB_PORT: 3306
+    networks:
+      - hathor-privnet
+
   ws-daemon:
     build:
-      context: '/Users/tuliomir/code/wallet-service/'
+      context: '/home/tulio/code/wallet-service/'
       dockerfile: Dockerfile
-      args:
-        MIGRATE_ON_BUILD: "true"
     depends_on:
+      ws-migrator:
+        condition: service_completed_successfully
       fullnode:
+        condition: service_healthy
+      mysql:
         condition: service_healthy
     environment:
       FULLNODE_HOST: "http://fullnode:8080"

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -102,11 +102,30 @@ services:
       timeout: 5s
       retries: 5
 
+  ws-migrator:
+    build:
+      context: '../../../../wallet-service/'
+      dockerfile: 'db/Dockerfile'
+    restart: "no"  # Critical: don't restart migration service
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      DB_ENDPOINT: "mysql"
+      DB_NAME: "wallet_service"
+      DB_USER: "wallet_service_user"
+      DB_PASS: "password"
+      DB_PORT: 3306
+    networks:
+      - hathor-privnet
+
   ws-daemon:
     build:
       context: '../../../../wallet-service/'
       dockerfile: 'packages/daemon/Dockerfile'
     depends_on:
+      ws-migrator:
+        condition: service_completed_successfully
       fullnode:
         condition: service_healthy
       mysql:
@@ -151,6 +170,10 @@ services:
       context: '../../../../wallet-service/'
       dockerfile: 'packages/wallet-service/Dockerfile'
     depends_on:
+      fullnode:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
       ws-daemon:
         condition: service_started # TODO: Implement healthcheck
     environment:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -169,5 +169,66 @@ services:
     networks:
       - hathor-privnet
 
+  ws-serverless:
+    build:
+      context: '/home/tulio/code/wallet-service/packages/wallet-service'
+      dockerfile: Dockerfile
+    depends_on:
+      ws-daemon:
+        condition: service_started # TODO: Implement healthcheck
+    environment:
+      STAGE: local
+      NETWORK: testnet
+      SERVICE_NAME: hathor-wallet-service
+      MAX_ADDRESS_GAP: 10
+      VOIDED_TX_OFFSET: 5
+      BLOCK_REWARD_LOCK: 300
+      CONFIRM_FIRST_ADDRESS: false
+      WS_DOMAIN: http://localhost:3002
+      DEFAULT_SERVER: fullnode
+      DB_ENDPOINT: mysql
+      DB_NAME: wallet_service
+      DB_USER: wallet_service_user
+      DB_PASS: password
+      DB_PORT: 3306
+      REDIS_URL: redis
+      REDIS_PORT: 6379
+      AUTH_SECRET: foobar
+      EXPLORER_SERVICE_LAMBDA_ENDPOINT: http://localhost:3001
+      WALLET_SERVICE_LAMBDA_ENDPOINT: http://localhost:3000
+      PUSH_NOTIFICATION: false
+      NODE_ENV: test
+      DEV_DB: mysql
+      FIREBASE_PROJECT_ID: ""
+      FIREBASE_PRIVATE_KEY_ID: ""
+      FIREBASE_PRIVATE_KEY: ""
+      FIREBASE_CLIENT_EMAIL: ""
+      FIREBASE_CLIENT_ID: ""
+      FIREBASE_AUTH_URI: ""
+      FIREBASE_TOKEN_URI: ""
+      FIREBASE_AUTH_PROVIDER_X509_CERT_URL: ""
+      FIREBASE_CLIENT_X509_CERT_URL: ""
+      APPLICATION_NAME: "hathor-wallet-service"
+      ACCOUNT_ID: 1234
+      ALERT_MANAGER_REGION: us-east-1
+      ALERT_MANAGER_TOPIC: alert-topic
+      PUSH_ALLOWED_PROVIDERS: ""
+      REDIS_PASSWORD: ""
+      IS_OFFLINE: 'true'
+      ALERT_MANAGER_ACCOUNT_ID: ""
+      AWS_VPC_DEFAULT_SG_ID: "1"
+      AWS_SUBNET_ID_1: "2"
+      AWS_SUBNET_ID_2: "3"
+      AWS_SUBNET_ID_3: "4"
+      NFT_AUTO_REVIEW_ENABLED: "false"
+      TX_HISTORY_MAX_COUNT: ""
+      PUSH_NOTIFICATION_ENABLED: "false"
+      LOG_LEVEL: "debug"
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+    networks:
+      - hathor-privnet
+
 networks:
   hathor-privnet:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -144,12 +144,12 @@ services:
 
       # Other env vars. Some of them may not be necessary and could be removed in the future
       USE_SSL: "false"
-      NEW_TX_SQS: ""
+      NEW_TX_SQS: "" # Mocked AWS
       PUSH_NOTIFICATION_ENABLED: "false"
-      WALLET_SERVICE_LAMBDA_ENDPOINT: "" # XXX: Confirm if this is really not used
-      ACCOUNT_ID: 1234
+      WALLET_SERVICE_LAMBDA_ENDPOINT: "" # Mocked AWS
+      ACCOUNT_ID: 1234 # Mocked AWS
       ALERT_MANAGER_TOPIC: "alert-topic"
-      ALERT_MANAGER_REGION: "us-east-1"
+      ALERT_MANAGER_REGION: "us-east-1" # Mocked AWS
       APPLICATION_NAME: "hathor-wallet-service"
       NODE_ENV: "test-privnet"
       STAGE: "local"
@@ -175,10 +175,10 @@ services:
       STAGE: local
       NETWORK: "privatenet"
       SERVICE_NAME: hathor-wallet-service
-      MAX_ADDRESS_GAP: 10
+      MAX_ADDRESS_GAP: 10 # Different from default 20 to facilitate tests
       VOIDED_TX_OFFSET: 5
       BLOCK_REWARD_LOCK: 300
-      CONFIRM_FIRST_ADDRESS: false
+      CONFIRM_FIRST_ADDRESS: false # Disabled security in a private network
       WS_DOMAIN: http://fakehost:3002
       DEFAULT_SERVER: http://fullnode:8080/v1a/
       DB_ENDPOINT: mysql
@@ -204,19 +204,19 @@ services:
       FIREBASE_AUTH_PROVIDER_X509_CERT_URL: "fake_auth_provider_x509_cert_url"
       FIREBASE_CLIENT_X509_CERT_URL: "fake_client_x509_cert_url"
       APPLICATION_NAME: "hathor-wallet-service"
-      ACCOUNT_ID: 1234
+      ACCOUNT_ID: 1234 # Mocked AWS
       ALERT_MANAGER_REGION: us-east-1
       ALERT_MANAGER_TOPIC: alert-topic
       PUSH_ALLOWED_PROVIDERS: "fake_provider"
       REDIS_PASSWORD: ""
-      IS_OFFLINE: true
+      IS_OFFLINE: true # Necessary to run the serverless-offline framework
       MOCK_AWS: true # Necessary to avoid calls to AWS on this private network
       ALERT_MANAGER_ACCOUNT_ID: "fake_account_id"
       AWS_VPC_DEFAULT_SG_ID: "1"
       AWS_SUBNET_ID_1: "2"
       AWS_SUBNET_ID_2: "3"
       AWS_SUBNET_ID_3: "4"
-      NFT_AUTO_REVIEW_ENABLED: "false"
+      NFT_AUTO_REVIEW_ENABLED: "false" # Should be enabled when this feature is ready for testing
       TX_HISTORY_MAX_COUNT: ""
       PUSH_NOTIFICATION_ENABLED: "false"
       LOG_LEVEL: "debug"

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -1,8 +1,10 @@
-version: "3.9"
 services:
 
+  # Private Network section
+  # All the following services are related to the core of the Private Network
   # For more information on these configs, refer to:
   # https://github.com/HathorNetwork/rfcs/blob/master/text/0033-private-network-guide.md
+  # Fullnode on 8080 , tx mining service on 8035, cpuminer stratum on 8034
 
   fullnode:
     image:
@@ -64,6 +66,50 @@ services:
       "--retry-pause", "5", # 5 seconds between retries
       "-t", "1" # Number of threads used to mine
     ]
+    networks:
+      - hathor-privnet
+
+
+  # Wallet Service section
+  # All the following services are related to the Wallet Service
+  # Redis on 6379, MySQL on 3380, Wallet Service Daemon on 8081 and Daemon Websocket on 8082
+
+  mysql:
+    image: mysql
+    networks:
+      - hathor-privnet
+    environment:
+      MYSQL_ROOT_PASSWORD: hathor
+    ports:
+      - "3380:3306"
+
+  redis:
+    image: redis:6.2
+    networks:
+      - hathor-privnet
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  ws-daemon:
+    build:
+      context: '/Users/tuliomir/code/wallet-service/'
+      dockerfile: Dockerfile
+    depends_on:
+      fullnode:
+        condition: service_healthy
+    command: [
+      "--port", "8081",
+      "--fullnode-url", "http://fullnode:8080",
+      "--ws-port", "8082"
+    ]
+    ports:
+      - "8081:8081"
+      - "8082:8082"
     networks:
       - hathor-privnet
 

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -73,7 +73,9 @@ services:
 
   # Wallet Service section
   # All the following services are related to the Wallet Service
-  # Redis on 6379, MySQL on 3380, Wallet Service Daemon on 8081 and Daemon Websocket on 8082
+  # Redis on 6379, MySQL on 3306
+  # Wallet Service Daemon on 8081 and Daemon Websocket on 8082
+  # Wallet Service API Lambda on 3000 and Wallet Service Websocket Lambda on 3001
 
   mysql:
     image: centos/mysql-80-centos7 # Necessary to use specific authentication protocol
@@ -133,7 +135,6 @@ services:
     environment:
       # Those two variables are used to set all the necessary dynamic env variables for this pristine environment
       FETCH_FULLNODE_IDS: true
-      MIGRATE_DB: true
 
       # Connection to other services in this private network
       FULLNODE_HOST: "fullnode:8080"

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       "--unsafe-mode", "nano-testnet-bravo",
       "--data", "./tmp",
       "--nc-indexes",
+      "--enable-event-queue",
       "--nc-exec-logs", "all",
     ]
     environment:
@@ -137,8 +138,8 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      FULLNODE_HOST: "http://fullnode:8080"
-      FULLNODE_NETWORK: "privatenet"
+      FULLNODE_HOST: "fullnode:8080"
+      FULLNODE_NETWORK: "nano-testnet-alpha"
       USE_SSL: "false"
       NEW_TX_SQS: ""
       PUSH_NOTIFICATION_ENABLED: "false"
@@ -152,13 +153,13 @@ services:
       DB_USER: "wallet_service_user"
       DB_PASS: "password"
       DB_PORT: 3306
-      STREAM_ID: "f7d9157c-9906-4bd2-bc84-cfb9f5b607d1"
-      FULLNODE_PEER_ID: "bdf4fa876f5cdba84be0cab53b21fc9eb45fe4b3d6ede99f493119d37df4e560"
+      STREAM_ID: "4a0407fc-6a11-4d4a-9f6a-f25cfac8cc1f"
+      FULLNODE_PEER_ID: "c00cbc3624aca6defcae0c908da66291e3774ab5a855c123267c1dd5ca6a2196"
 
       NODE_ENV: "test-privnet"
       STAGE: "local"
       MAX_ADDRESS_GAP: 10
-      NETWORK: "nano-testnet-alpha"
+      NETWORK: "privatenet"
 #      BLOCK_REWARD_LOCK: 1
       REDIS_URL: redis://redis:6379
     ports:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -105,7 +105,7 @@ services:
       retries: 5
 
   ws-migrator:
-    image: hathornetwork/hathor-wallet-service-migrator
+    image: hathornetwork/hathor-wallet-service-migrator:dev
     restart: "no"  # Critical: don't restart migration service
     depends_on:
       mysql:
@@ -120,7 +120,7 @@ services:
       - hathor-privnet
 
   ws-daemon:
-    image: hathornetwork/hathor-wallet-service-sync-daemon
+    image: hathornetwork/hathor-wallet-service-sync-daemon:dev
     depends_on:
       ws-migrator:
         condition: service_completed_successfully
@@ -163,7 +163,7 @@ services:
       - hathor-privnet
 
   ws-serverless:
-    image: hathornetwork/hathor-wallet-service-service
+    image: hathornetwork/hathor-wallet-service-lambdas:dev
     depends_on:
       fullnode:
         condition: service_healthy

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -185,7 +185,7 @@ services:
       BLOCK_REWARD_LOCK: 300
       CONFIRM_FIRST_ADDRESS: false
       WS_DOMAIN: http://fakehost:3002
-      DEFAULT_SERVER: fullnode
+      DEFAULT_SERVER: "fullnode:8080"
       DB_ENDPOINT: mysql
       DB_NAME: wallet_service
       DB_USER: wallet_service_user

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -103,6 +103,8 @@ services:
     build:
       context: '/Users/tuliomir/code/wallet-service/'
       dockerfile: Dockerfile
+      args:
+        MIGRATE_ON_BUILD: "true"
     depends_on:
       fullnode:
         condition: service_healthy

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -114,10 +114,6 @@ services:
         DB_PORT: 3306
         FETCH_IDENTIFIERS_FROM_FULLNODE: true
     restart: "no"  # Critical: don't restart migration service
-#    entrypoint: ["/app/migration-entrypoint.sh"]
-#    command: ["/bin/sh", "-c", "node scripts/fetch-fullnode-ids.js && /bin/sh scripts/migrate.sh"]
-    volumes:
-      - shared-config:/shared
     depends_on:
       mysql:
         condition: service_healthy
@@ -134,8 +130,6 @@ services:
     build:
       context: '/home/tulio/code/wallet-service/'
       dockerfile: Dockerfile
-    volumes:
-      - shared-config:/shared
     depends_on:
       ws-migrator:
         condition: service_completed_successfully
@@ -144,7 +138,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      FETCH_SHARED_ENV: true
+      FETCH_FULLNODE_IDS: true
       FULLNODE_HOST: "fullnode:8080"
       FULLNODE_NETWORK: "nano-testnet-alpha"
       USE_SSL: "false"
@@ -175,7 +169,5 @@ services:
     networks:
       - hathor-privnet
 
-volumes:
-    shared-config:
 networks:
   hathor-privnet:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -80,6 +80,10 @@ services:
       - hathor-privnet
     environment:
       MYSQL_ROOT_PASSWORD: hathor
+      MYSQL_DATABASE: wallet_service
+      MYSQL_USER: wallet_service_user
+      MYSQL_PASSWORD: password
+      MYSQL_DEFAULT_AUTHENTICATION_PLUGIN: mysql_native_password
     ports:
       - "3380:3306"
 
@@ -102,11 +106,31 @@ services:
     depends_on:
       fullnode:
         condition: service_healthy
-    command: [
-      "--port", "8081",
-      "--fullnode-url", "http://fullnode:8080",
-      "--ws-port", "8082"
-    ]
+    environment:
+      FULLNODE_HOST: "http://fullnode:8080"
+      FULLNODE_NETWORK: "privatenet"
+      USE_SSL: "false"
+      NEW_TX_SQS: ""
+      PUSH_NOTIFICATION_ENABLED: "false"
+      WALLET_SERVICE_LAMBDA_ENDPOINT: ""
+      ACCOUNT_ID: 1234
+      ALERT_MANAGER_TOPIC: "alert-topic"
+      ALERT_MANAGER_REGION: "us-east-1"
+      APPLICATION_NAME: "hathor-wallet-service"
+      DB_ENDPOINT: "mysql"
+      DB_NAME: "wallet_service"
+      DB_USER: "wallet_service_user"
+      DB_PASS: "password"
+      DB_PORT: 3306
+      STREAM_ID: "f7d9157c-9906-4bd2-bc84-cfb9f5b607d1"
+      FULLNODE_PEER_ID: "bdf4fa876f5cdba84be0cab53b21fc9eb45fe4b3d6ede99f493119d37df4e560"
+
+      NODE_ENV: "test-privnet"
+      STAGE: "local"
+      MAX_ADDRESS_GAP: 10
+      NETWORK: "nano-testnet-alpha"
+#      BLOCK_REWARD_LOCK: 1
+      REDIS_URL: redis://redis:6379
     ports:
       - "8081:8081"
       - "8082:8082"

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -112,12 +112,16 @@ services:
         DB_USER: "wallet_service_user"
         DB_PASS: "password"
         DB_PORT: 3306
+        FETCH_IDENTIFIERS_FROM_FULLNODE: true
     restart: "no"  # Critical: don't restart migration service
-    command: ["/bin/sh", "migrate.sh"]
+#    entrypoint: ["/app/migration-entrypoint.sh"]
+#    command: ["/bin/sh", "-c", "node scripts/fetch-fullnode-ids.js && /bin/sh scripts/migrate.sh"]
+    volumes:
+      - shared-config:/shared
     depends_on:
       mysql:
         condition: service_healthy
-    environment:
+    environment: # TODO: Remove this section
       DB_ENDPOINT: "mysql"
       DB_NAME: "wallet_service"
       DB_USER: "wallet_service_user"
@@ -130,6 +134,8 @@ services:
     build:
       context: '/home/tulio/code/wallet-service/'
       dockerfile: Dockerfile
+    volumes:
+      - shared-config:/shared
     depends_on:
       ws-migrator:
         condition: service_completed_successfully
@@ -138,6 +144,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
+      FETCH_SHARED_ENV: true
       FULLNODE_HOST: "fullnode:8080"
       FULLNODE_NETWORK: "nano-testnet-alpha"
       USE_SSL: "false"
@@ -153,8 +160,8 @@ services:
       DB_USER: "wallet_service_user"
       DB_PASS: "password"
       DB_PORT: 3306
-      STREAM_ID: "4a0407fc-6a11-4d4a-9f6a-f25cfac8cc1f"
-      FULLNODE_PEER_ID: "c00cbc3624aca6defcae0c908da66291e3774ab5a855c123267c1dd5ca6a2196"
+#      STREAM_ID: "4a0407fc-6a11-4d4a-9f6a-f25cfac8cc1f"
+#      FULLNODE_PEER_ID: "c00cbc3624aca6defcae0c908da66291e3774ab5a855c123267c1dd5ca6a2196"
 
       NODE_ENV: "test-privnet"
       STAGE: "local"
@@ -168,6 +175,7 @@ services:
     networks:
       - hathor-privnet
 
+volumes:
+    shared-config:
 networks:
   hathor-privnet:
-

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -76,7 +76,7 @@ services:
   # Redis on 6379, MySQL on 3380, Wallet Service Daemon on 8081 and Daemon Websocket on 8082
 
   mysql:
-    image: mysql
+    image: centos/mysql-80-centos7 # Necessary to use specific authentication protocol
     networks:
       - hathor-privnet
     environment:
@@ -171,8 +171,8 @@ services:
 
   ws-serverless:
     build:
-      context: '/home/tulio/code/wallet-service/packages/wallet-service'
-      dockerfile: Dockerfile
+      context: '/home/tulio/code/wallet-service/'
+      dockerfile: 'packages/wallet-service/Dockerfile'
     depends_on:
       ws-daemon:
         condition: service_started # TODO: Implement healthcheck
@@ -184,7 +184,7 @@ services:
       VOIDED_TX_OFFSET: 5
       BLOCK_REWARD_LOCK: 300
       CONFIRM_FIRST_ADDRESS: false
-      WS_DOMAIN: http://localhost:3002
+      WS_DOMAIN: http://fakehost:3002
       DEFAULT_SERVER: fullnode
       DB_ENDPOINT: mysql
       DB_NAME: wallet_service
@@ -194,28 +194,29 @@ services:
       REDIS_URL: redis
       REDIS_PORT: 6379
       AUTH_SECRET: foobar
-      EXPLORER_SERVICE_LAMBDA_ENDPOINT: http://localhost:3001
-      WALLET_SERVICE_LAMBDA_ENDPOINT: http://localhost:3000
+      EXPLORER_SERVICE_LAMBDA_ENDPOINT: http://fakehost:3001
+      WALLET_SERVICE_LAMBDA_ENDPOINT: http://fakehost:3000
       PUSH_NOTIFICATION: false
       NODE_ENV: test
       DEV_DB: mysql
-      FIREBASE_PROJECT_ID: ""
-      FIREBASE_PRIVATE_KEY_ID: ""
-      FIREBASE_PRIVATE_KEY: ""
-      FIREBASE_CLIENT_EMAIL: ""
-      FIREBASE_CLIENT_ID: ""
-      FIREBASE_AUTH_URI: ""
-      FIREBASE_TOKEN_URI: ""
-      FIREBASE_AUTH_PROVIDER_X509_CERT_URL: ""
-      FIREBASE_CLIENT_X509_CERT_URL: ""
+      FIREBASE_PROJECT_ID: "fake_project_id"
+      FIREBASE_PRIVATE_KEY_ID: "fake_private_key_id"
+      FIREBASE_PRIVATE_KEY: "fake_private_key"
+      FIREBASE_CLIENT_EMAIL: "fake@client_email.com"
+      FIREBASE_CLIENT_ID: "fake_client_id"
+      FIREBASE_AUTH_URI: "fake_auth_uri"
+      FIREBASE_TOKEN_URI: "fake_token_uri"
+      FIREBASE_AUTH_PROVIDER_X509_CERT_URL: "fake_auth_provider_x509_cert_url"
+      FIREBASE_CLIENT_X509_CERT_URL: "fake_client_x509_cert_url"
       APPLICATION_NAME: "hathor-wallet-service"
       ACCOUNT_ID: 1234
       ALERT_MANAGER_REGION: us-east-1
       ALERT_MANAGER_TOPIC: alert-topic
-      PUSH_ALLOWED_PROVIDERS: ""
+      PUSH_ALLOWED_PROVIDERS: "fake_provider"
       REDIS_PASSWORD: ""
-      IS_OFFLINE: 'true'
-      ALERT_MANAGER_ACCOUNT_ID: ""
+      IS_OFFLINE: true
+      MOCK_AWS: true # Necessary to avoid calls to AWS on this private network
+      ALERT_MANAGER_ACCOUNT_ID: "fake_account_id"
       AWS_VPC_DEFAULT_SG_ID: "1"
       AWS_SUBNET_ID_1: "2"
       AWS_SUBNET_ID_2: "3"
@@ -224,6 +225,11 @@ services:
       TX_HISTORY_MAX_COUNT: ""
       PUSH_NOTIFICATION_ENABLED: "false"
       LOG_LEVEL: "debug"
+      AWS_ACCESS_KEY_ID: fake-access-key-id
+      AWS_SECRET_ACCESS_KEY: fake-secret-access-key
+      AWS_REGION: us-east-1
+      AWS_SHARED_CREDENTIALS_FILE: ".aws/credentials" # Credentials for mocked AWS
+      AWS_CONFIG_FILE: ".aws/config" # Config for mocked AWS
     ports:
       - "3000:3000"
       - "3001:3001"

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -134,7 +134,7 @@ services:
 
       # Connection to other services in this private network
       FULLNODE_HOST: "fullnode:8080"
-      FULLNODE_NETWORK: "nano-testnet-alpha"
+      FULLNODE_NETWORK: "nano-testnet-bravo"
       REDIS_URL: redis://redis:6379
       DB_ENDPOINT: "mysql"
       DB_NAME: "wallet_service"
@@ -180,7 +180,7 @@ services:
       BLOCK_REWARD_LOCK: 300
       CONFIRM_FIRST_ADDRESS: false
       WS_DOMAIN: http://fakehost:3002
-      DEFAULT_SERVER: "fullnode:8080"
+      DEFAULT_SERVER: http://fullnode:8080/v1a/
       DB_ENDPOINT: mysql
       DB_NAME: wallet_service
       DB_USER: wallet_service_user

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       mysql:
         condition: service_healthy
     environment:
-      # Those two variables are used to set all the necessary dynamic env variables for this pristine environment
+      # This  variable is used to set all the necessary dynamic env variables for this pristine environment
       FETCH_FULLNODE_IDS: true
 
       # Connection to other services in this private network
@@ -172,15 +172,15 @@ services:
       ws-daemon:
         condition: service_started # TODO: Implement healthcheck
     environment:
-      STAGE: local
-      NETWORK: "privatenet"
-      SERVICE_NAME: hathor-wallet-service
-      MAX_ADDRESS_GAP: 10 # Different from default 20 to facilitate tests
-      VOIDED_TX_OFFSET: 5
-      BLOCK_REWARD_LOCK: 300
-      CONFIRM_FIRST_ADDRESS: false # Disabled security in a private network
-      WS_DOMAIN: http://fakehost:3002
+      # Local environment configuration
       DEFAULT_SERVER: http://fullnode:8080/v1a/
+      IS_OFFLINE: true # Necessary to run the serverless-offline framework
+      MOCK_AWS: true # Necessary to avoid calls to AWS on this private network
+      NODE_ENV: test
+      LOG_LEVEL: "debug"
+
+      # Database config
+      DEV_DB: mysql
       DB_ENDPOINT: mysql
       DB_NAME: wallet_service
       DB_USER: wallet_service_user
@@ -188,12 +188,27 @@ services:
       DB_PORT: 3306
       REDIS_URL: redis
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ""
+
+      # Application configs
+      STAGE: local
+      NETWORK: "privatenet"
+      SERVICE_NAME: hathor-wallet-service
+      APPLICATION_NAME: "hathor-wallet-service"
+      MAX_ADDRESS_GAP: 10 # Different from default 20 to facilitate tests
+      VOIDED_TX_OFFSET: 5
+      BLOCK_REWARD_LOCK: 300
+      CONFIRM_FIRST_ADDRESS: false # Disabled security in a private network
+      WS_DOMAIN: http://fakehost:3002
       AUTH_SECRET: foobar
       EXPLORER_SERVICE_LAMBDA_ENDPOINT: http://fakehost:3001
       WALLET_SERVICE_LAMBDA_ENDPOINT: http://fakehost:3000
+      NFT_AUTO_REVIEW_ENABLED: "false" # Should be enabled when this feature is ready for testing
+      TX_HISTORY_MAX_COUNT: ""
+
+      # Push Notification settings
       PUSH_NOTIFICATION: false
-      NODE_ENV: test
-      DEV_DB: mysql
+      PUSH_NOTIFICATION_ENABLED: "false"
       FIREBASE_PROJECT_ID: "fake_project_id"
       FIREBASE_PRIVATE_KEY_ID: "fake_private_key_id"
       FIREBASE_PRIVATE_KEY: "fake_private_key"
@@ -203,23 +218,17 @@ services:
       FIREBASE_TOKEN_URI: "fake_token_uri"
       FIREBASE_AUTH_PROVIDER_X509_CERT_URL: "fake_auth_provider_x509_cert_url"
       FIREBASE_CLIENT_X509_CERT_URL: "fake_client_x509_cert_url"
-      APPLICATION_NAME: "hathor-wallet-service"
+      PUSH_ALLOWED_PROVIDERS: "fake_provider"
+
+      # AWS Configs
       ACCOUNT_ID: 1234 # Mocked AWS
       ALERT_MANAGER_REGION: us-east-1
       ALERT_MANAGER_TOPIC: alert-topic
-      PUSH_ALLOWED_PROVIDERS: "fake_provider"
-      REDIS_PASSWORD: ""
-      IS_OFFLINE: true # Necessary to run the serverless-offline framework
-      MOCK_AWS: true # Necessary to avoid calls to AWS on this private network
       ALERT_MANAGER_ACCOUNT_ID: "fake_account_id"
       AWS_VPC_DEFAULT_SG_ID: "1"
       AWS_SUBNET_ID_1: "2"
       AWS_SUBNET_ID_2: "3"
       AWS_SUBNET_ID_3: "4"
-      NFT_AUTO_REVIEW_ENABLED: "false" # Should be enabled when this feature is ready for testing
-      TX_HISTORY_MAX_COUNT: ""
-      PUSH_NOTIFICATION_ENABLED: "false"
-      LOG_LEVEL: "debug"
       AWS_ACCESS_KEY_ID: fake-access-key-id
       AWS_SECRET_ACCESS_KEY: fake-secret-access-key
       AWS_REGION: us-east-1

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -102,67 +102,44 @@ services:
       timeout: 5s
       retries: 5
 
-  ws-migrator:
-    build:
-      context: '../../../../wallet-service/'
-      dockerfile: 'db/Dockerfile'
-      args:
-        DB_ENDPOINT: "mysql"
-        DB_NAME: "wallet_service"
-        DB_USER: "wallet_service_user"
-        DB_PASS: "password"
-        DB_PORT: 3306
-        FETCH_IDENTIFIERS_FROM_FULLNODE: true
-    restart: "no"  # Critical: don't restart migration service
-    depends_on:
-      mysql:
-        condition: service_healthy
-    environment: # TODO: Remove this section
-      DB_ENDPOINT: "mysql"
-      DB_NAME: "wallet_service"
-      DB_USER: "wallet_service_user"
-      DB_PASS: "password"
-      DB_PORT: 3306
-    networks:
-      - hathor-privnet
-
   ws-daemon:
     build:
       context: '../../../../wallet-service/'
-      dockerfile: Dockerfile
+      dockerfile: 'packages/daemon/Dockerfile'
     depends_on:
-      ws-migrator:
-        condition: service_completed_successfully
       fullnode:
         condition: service_healthy
       mysql:
         condition: service_healthy
     environment:
+      # Those two variables are used to set all the necessary dynamic env variables for this pristine environment
       FETCH_FULLNODE_IDS: true
+      MIGRATE_DB: true
+
+      # Connection to other services in this private network
       FULLNODE_HOST: "fullnode:8080"
       FULLNODE_NETWORK: "nano-testnet-alpha"
-      USE_SSL: "false"
-      NEW_TX_SQS: ""
-      PUSH_NOTIFICATION_ENABLED: "false"
-      WALLET_SERVICE_LAMBDA_ENDPOINT: ""
-      ACCOUNT_ID: 1234
-      ALERT_MANAGER_TOPIC: "alert-topic"
-      ALERT_MANAGER_REGION: "us-east-1"
-      APPLICATION_NAME: "hathor-wallet-service"
+      REDIS_URL: redis://redis:6379
       DB_ENDPOINT: "mysql"
       DB_NAME: "wallet_service"
       DB_USER: "wallet_service_user"
       DB_PASS: "password"
       DB_PORT: 3306
-#      STREAM_ID: "4a0407fc-6a11-4d4a-9f6a-f25cfac8cc1f"
-#      FULLNODE_PEER_ID: "c00cbc3624aca6defcae0c908da66291e3774ab5a855c123267c1dd5ca6a2196"
 
+      # Other env vars. Some of them may not be necessary and could be removed in the future
+      USE_SSL: "false"
+      NEW_TX_SQS: ""
+      PUSH_NOTIFICATION_ENABLED: "false"
+      WALLET_SERVICE_LAMBDA_ENDPOINT: "" # XXX: Confirm if this is really not used
+      ACCOUNT_ID: 1234
+      ALERT_MANAGER_TOPIC: "alert-topic"
+      ALERT_MANAGER_REGION: "us-east-1"
+      APPLICATION_NAME: "hathor-wallet-service"
       NODE_ENV: "test-privnet"
       STAGE: "local"
       MAX_ADDRESS_GAP: 10
       NETWORK: "privatenet"
 #      BLOCK_REWARD_LOCK: 1
-      REDIS_URL: redis://redis:6379
     ports:
       - "8081:8081"
       - "8082:8082"
@@ -178,7 +155,7 @@ services:
         condition: service_started # TODO: Implement healthcheck
     environment:
       STAGE: local
-      NETWORK: testnet
+      NETWORK: "privatenet"
       SERVICE_NAME: hathor-wallet-service
       MAX_ADDRESS_GAP: 10
       VOIDED_TX_OFFSET: 5

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -163,9 +163,7 @@ services:
       - hathor-privnet
 
   ws-serverless:
-    build:
-      context: '../../../../wallet-service/'
-      dockerfile: 'packages/wallet-service/Dockerfile'
+    image: hathornetwork/hathor-wallet-service-service
     depends_on:
       fullnode:
         condition: service_healthy

--- a/__tests__/integration/walletservice_facade.test.ts
+++ b/__tests__/integration/walletservice_facade.test.ts
@@ -5,26 +5,7 @@ import walletUtils from '../../src/utils/wallet';
 import { WALLET_CONSTANTS } from './configuration/test-constants';
 import HathorWalletServiceWallet from '../../src/wallet/wallet';
 import config from '../../src/config';
-
-/**
- * Log relevant request data for debugging purposes
- * TODO: Remove this when the axios requests are working correctly
- * @param axiosConfig
- */
-const logRequest = (axiosConfig: InternalAxiosRequestConfig) => ({
-  url: axiosConfig.url,
-  baseURL: axiosConfig.baseURL || axios.defaults.baseURL,
-  method: axiosConfig.method,
-  headers: axiosConfig.headers,
-  timeout: axiosConfig.timeout,
-  fullURL: `${axiosConfig.baseURL || axios.defaults.baseURL || ''}${axiosConfig.url}`,
-});
-
-// Adds a debugging interceptor to all axios requests
-axios.interceptors.request.use(axiosConfig => {
-  console.log('Request axiosConfig:', logRequest(axiosConfig));
-  return axiosConfig;
-});
+import { loggers } from './utils/logger.util';
 
 // Set base URL for the wallet service API inside the privatenet test container
 config.setWalletServiceBaseUrl('http://localhost:3000/dev/');
@@ -33,12 +14,14 @@ config.setWalletServiceBaseWsUrl('ws://localhost:3001/dev/');
 describe('version', () => {
   it('should retrieve the version data', async () => {
     const response = await axios
-      .get('http://localhost:3000/version', {
+      .get('version', {
+        baseURL: config.getWalletServiceBaseUrl(),
         headers: {
           'Content-Type': 'application/json',
         },
       })
       .catch(e => {
+        loggers.test.log(`Received an error on /version: ${e}`);
         if (e.response) {
           return e.response;
         }

--- a/__tests__/integration/walletservice_facade.test.ts
+++ b/__tests__/integration/walletservice_facade.test.ts
@@ -1,9 +1,4 @@
-import axios, { InternalAxiosRequestConfig } from 'axios';
-import Network from '../../src/models/network';
-import { MemoryStore, Storage } from '../../src';
-import walletUtils from '../../src/utils/wallet';
-import { WALLET_CONSTANTS } from './configuration/test-constants';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
+import axios from 'axios';
 import config from '../../src/config';
 import { loggers } from './utils/logger.util';
 
@@ -29,38 +24,5 @@ describe('version', () => {
       });
     expect(response.status).toBe(200);
     expect(response.data?.success).toBe(true);
-  });
-});
-
-const defaultPinPass = '1234';
-describe('start', () => {
-  it.skip('should start the wallet service facade without errors', async () => {
-    const requestPassword = jest.fn();
-    const network = new Network('privatenet');
-    const seed = WALLET_CONSTANTS.genesis.words;
-    const store = new MemoryStore();
-    const storage = new Storage(store);
-    const accessData = walletUtils.generateAccessDataFromSeed(seed, {
-      networkName: 'privatenet',
-      password: defaultPinPass,
-      pin: defaultPinPass,
-    });
-
-    // Create an instance of the WalletServiceFacade
-    const wallet = new HathorWalletServiceWallet({
-      requestPassword,
-      seed,
-      network,
-      storage,
-    });
-
-    // Call the start method and assert no errors are thrown
-    await expect(wallet.start()).rejects.toThrow('Pin code');
-
-    // Call the start method with pin and password and assert no errors are thrown
-    await wallet.start({ pinCode: defaultPinPass, password: defaultPinPass });
-    await expect(wallet.storage.getAccessData()).resolves.toMatchObject({
-      xpubkey: accessData.xpubkey,
-    });
   });
 });

--- a/__tests__/integration/walletservice_facade.test.ts
+++ b/__tests__/integration/walletservice_facade.test.ts
@@ -1,0 +1,83 @@
+import axios, { InternalAxiosRequestConfig } from 'axios';
+import Network from '../../src/models/network';
+import { MemoryStore, Storage } from '../../src';
+import walletUtils from '../../src/utils/wallet';
+import { WALLET_CONSTANTS } from './configuration/test-constants';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
+import config from '../../src/config';
+
+/**
+ * Log relevant request data for debugging purposes
+ * TODO: Remove this when the axios requests are working correctly
+ * @param axiosConfig
+ */
+const logRequest = (axiosConfig: InternalAxiosRequestConfig) => ({
+  url: axiosConfig.url,
+  baseURL: axiosConfig.baseURL || axios.defaults.baseURL,
+  method: axiosConfig.method,
+  headers: axiosConfig.headers,
+  timeout: axiosConfig.timeout,
+  fullURL: `${axiosConfig.baseURL || axios.defaults.baseURL || ''}${axiosConfig.url}`,
+});
+
+// Adds a debugging interceptor to all axios requests
+axios.interceptors.request.use(axiosConfig => {
+  console.log('Request axiosConfig:', logRequest(axiosConfig));
+  return axiosConfig;
+});
+
+// Set base URL for the wallet service API inside the privatenet test container
+config.setWalletServiceBaseUrl('http://localhost:3000/dev/');
+config.setWalletServiceBaseWsUrl('ws://localhost:3001/dev/');
+
+describe('version', () => {
+  it('should retrieve the version data', async () => {
+    const response = await axios
+      .get('http://localhost:3000/version', {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      .catch(e => {
+        if (e.response) {
+          return e.response;
+        }
+        throw e;
+      });
+    expect(response.status).toBe(200);
+    expect(response.data?.success).toBe(true);
+  });
+});
+
+const defaultPinPass = '1234';
+describe('start', () => {
+  it.skip('should start the wallet service facade without errors', async () => {
+    const requestPassword = jest.fn();
+    const network = new Network('privatenet');
+    const seed = WALLET_CONSTANTS.genesis.words;
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const accessData = walletUtils.generateAccessDataFromSeed(seed, {
+      networkName: 'privatenet',
+      password: defaultPinPass,
+      pin: defaultPinPass,
+    });
+
+    // Create an instance of the WalletServiceFacade
+    const wallet = new HathorWalletServiceWallet({
+      requestPassword,
+      seed,
+      network,
+      storage,
+    });
+
+    // Call the start method and assert no errors are thrown
+    await expect(wallet.start()).rejects.toThrow('Pin code');
+
+    // Call the start method with pin and password and assert no errors are thrown
+    await wallet.start({ pinCode: defaultPinPass, password: defaultPinPass });
+    await expect(wallet.storage.getAccessData()).resolves.toMatchObject({
+      xpubkey: accessData.xpubkey,
+    });
+  });
+});


### PR DESCRIPTION
### Acceptance Criteria
- We should have the infrastructure in place to test the Wallet Service facade
- We should have one green test in the suite: a `200` response from the `/version` endpoint

> [!NOTE]
> The Wallet Service repository has only recently implemented the Docker images, a feature needed by this PR.
> This was done by https://github.com/HathorNetwork/hathor-wallet-service/pull/283 .

### Other development notes
To avoid unnecessary block validation delays in this early stage of development, comment out the [block waiting commands](https://github.com/HathorNetwork/hathor-wallet-lib/blob/cdd6620a9df605f0d474c2afc52f0392916ca0f4/setupTests-integration.js#L58-L71)  in the setup tests and run the tests only in the new file by using the `SPECIFIC_INTEGRATION_TEST_FILE=walletservice_facade` environment variable.

### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
