### PR TITLE
fix: pin from arg must have precedence over object pin

### DIFF
--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -529,7 +529,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     }
     this.emit('sign-tx-start');
     const dataToSignHash = this.transaction.getDataToSignHash();
-    const pinToUse = this.pin ?? pin ?? '';
+    const pinToUse = pin ?? this.pin ?? '';
     const xprivkey = await this.wallet.storage.getMainXPrivKey(pinToUse);
 
     for (const [idx, inputObj] of this.transaction.inputs.entries()) {


### PR DESCRIPTION
### Acceptance Criteria
- Pin from method argument must have precedence over object pin

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
