### PR TITLE
chore: renew auth token on the bg during startup

### DIFF
--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -2495,6 +2495,7 @@ describe('HathorWalletServiceWallet start method error conditions', () => {
 
   it('should throw error if wallet status is not ready after creation', async () => {
     jest.spyOn(wallet.storage, 'getAccessData').mockRejectedValue(new UninitializedWalletError());
+    jest.spyOn(wallet, 'renewAuthToken').mockImplementation(() => Promise.resolve(undefined));
     jest.spyOn(walletApi, 'createWallet').mockResolvedValue({
       success: true,
       status: {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -486,6 +486,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     } catch (err) {
       // If the wallet was being created the api would fail, but we will try to request a new token
       // now that the wallet was created and before it is ready.
+      this.authToken = null;
       const walletId = HathorWalletServiceWallet.getWalletIdFromXPub(xpub);
       renewPromise2 = this._validateAndRenewAuthToken(walletId, pinCode);
     }


### PR DESCRIPTION
### Acceptance Criteria
- Start the process to acquire the auth token as soon as possible in the background during wallet startup
- Decrease polling interval for wallet status

### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
