### PR TITLE
fix: timestamp in nano nc_context is now optional

### DIFF
--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 
   fullnode:
     image:
-      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:v0.65.0-alpha.3}
+      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:nightly-8f23d021}
     command: [
       "run_node",
       "--listen", "tcp:40404",

--- a/__tests__/integration/hathorwallet_others.test.ts
+++ b/__tests__/integration/hathorwallet_others.test.ts
@@ -1660,7 +1660,7 @@ describe('internal methods', () => {
     // GetVersionData fetching from the live fullnode server
     expect(await gWallet.getVersionData()).toMatchObject({
       timestamp: expect.any(Number),
-      version: expect.stringMatching(/^\d+\.\d+\.\d+.*$/),
+      version: expect.any(String),
       network: FULLNODE_NETWORK_NAME,
       minWeight: expect.any(Number),
       minTxWeight: expect.any(Number),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -138,7 +138,7 @@ export const IHistoryNanoContractContextSchema = z
   .object({
     actions: IHistoryNanoContractActionSchema.array(),
     caller_id: z.string(),
-    timestamp: z.number(),
+    timestamp: z.number().nullish(),
   })
   .passthrough();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,7 +143,7 @@ export type IHistoryNanoContractAction =
 export interface IHistoryNanoContractContext {
   actions: IHistoryNanoContractAction[];
   caller_id: string;
-  timestamp: number;
+  timestamp?: number | null;
 }
 
 export interface IHistoryTx {

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -309,7 +309,7 @@ export const ncActionSchema = z.object({
 export const ncContextSchema = z.object({
   actions: z.array(ncActionSchema),
   caller_id: AddressSchema,
-  timestamp: z.number(),
+  timestamp: z.number().nullish(),
 });
 
 /**

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -709,7 +709,7 @@ export interface FullNodeTx {
       melt?: boolean;
     }>;
     caller_id: string;
-    timestamp: number;
+    timestamp?: number | null;
   };
 }
 


### PR DESCRIPTION
### Acceptance Criteria
- Make timestamp of `nc_context` optional in the types and schemas
- Update docker image for integration tests to use the master latest commit


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
