### PR TITLE
fix: set walletid before token renew

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -421,6 +421,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       const acctKey = decryptData(accessData.acctPathKey, pinCode);
       const privKeyAccountPath = bitcore.HDPrivateKey(acctKey);
       const walletId = HathorWalletServiceWallet.getWalletIdFromXPub(privKeyAccountPath.xpubkey);
+      this.walletId = walletId;
       renewPromise = this._validateAndRenewAuthToken(walletId, pinCode);
     }
 
@@ -438,6 +439,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       // we need to start the process to renew the auth token If for any reason we had to
       // derive the account path xpubkey on the method above.
       const walletId = HathorWalletServiceWallet.getWalletIdFromXPub(xpub);
+      this.walletId = walletId;
       renewPromise = this._validateAndRenewAuthToken(walletId, pinCode);
     }
 
@@ -488,6 +490,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       // now that the wallet was created and before it is ready.
       this.authToken = null;
       const walletId = HathorWalletServiceWallet.getWalletIdFromXPub(xpub);
+      this.walletId = walletId;
       renewPromise2 = this._validateAndRenewAuthToken(walletId, pinCode);
     }
 


### PR DESCRIPTION
### Description

The walletApi method to request a new auth token ignores the wallet-id from the arguments and uses the `instance.walletId` which is not set during the initial request for an auth token.

This would make the first calls to the auth token api fail even if the request was valid.

### Acceptance Criteria

- We should set the walletId before calling the auth token api


### Security Checklist
- [ ] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
