### PR TITLE
tests: use core v0.67.0 docker image for the integration tests

### DIFF
--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -8,7 +8,7 @@ services:
 
   fullnode:
     image:
-      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:v0.67.0-rc.3}
+      ${HATHOR_LIB_INTEGRATION_TESTS_FULLNODE_IMAGE:-hathornetwork/hathor-core:v0.67.0}
     command: [
       "run_node",
       "--listen", "tcp:40404",


### PR DESCRIPTION
### Acceptance Criteria
- Use hathor core v0.67.0 docker image for the integration tests


### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
