### PR TITLE
refactor: Enum for AuthorityType

### DIFF
--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -41,7 +41,7 @@ import { MemoryStore, Storage } from '../../src/storage';
 import walletApi from '../../src/wallet/api/walletApi';
 import walletUtils from '../../src/utils/wallet';
 import { decryptData, verifyMessage } from '../../src/utils/crypto';
-import { IHistoryTx, IWalletAccessData, TokenVersion } from '../../src/types';
+import { AuthorityType, IHistoryTx, IWalletAccessData, TokenVersion } from '../../src/types';
 import { mockGetToken } from '../__mock_helpers__/get-token.mock';
 import { Fee } from '../../src/utils/fee';
 
@@ -168,7 +168,7 @@ const setupFeeTokenMocks = {
     seed: string,
     network: Network,
     tokenId: string,
-    authorityType: 'mint' | 'melt',
+    authorityType: AuthorityType,
     addresses: string[],
     tokenName = 'Fee Token',
     tokenSymbol = 'FBT'
@@ -231,7 +231,7 @@ const setupFeeTokenMocks = {
     seed: string,
     network: Network,
     tokenId: string,
-    authorityType: 'mint' | 'melt',
+    authorityType: AuthorityType,
     addresses: string[]
   ) => {
     const authorityMask = authorityType === 'mint' ? TOKEN_MINT_MASK : TOKEN_MELT_MASK;

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -34,7 +34,7 @@ import {
   mapActionToActionHeader,
   validateAndParseBlueprintMethodArgs,
 } from './utils';
-import { IDataInput, IDataOutput } from '../types';
+import { AuthorityType, IDataInput, IDataOutput } from '../types';
 import NanoContractHeader from './header';
 import Address from '../models/address';
 import leb128 from '../utils/leb128';
@@ -414,7 +414,7 @@ class NanoContractTransactionBuilder {
     // Get the utxos with the authority of the action and create the input
     const utxos = await this.wallet.getAuthorityUtxo(
       action.token,
-      action.authority as 'mint' | 'melt',
+      action.authority as AuthorityType,
       {
         many: false,
         only_available_utxos: true,

--- a/src/new/wallet.ts
+++ b/src/new/wallet.ts
@@ -29,9 +29,9 @@ import bitcore, { HDPrivateKey } from 'bitcore-lib';
 import EventEmitter from 'events';
 import {
   NATIVE_TOKEN_UID,
-  P2SH_ACCT_PATH,
-  P2PKH_ACCT_PATH,
   ON_CHAIN_BLUEPRINTS_VERSION,
+  P2PKH_ACCT_PATH,
+  P2SH_ACCT_PATH,
 } from '../constants';
 import tokenUtils from '../utils/tokens';
 import walletApi from '../api/wallet';
@@ -55,33 +55,34 @@ import {
 import { ErrorMessages } from '../errorMessages';
 import P2SHSignature from '../models/p2sh_signature';
 import {
-  SCANNING_POLICY,
-  TxHistoryProcessingStatus,
-  WalletType,
-  HistorySyncMode,
-  WalletState,
-  getDefaultLogger,
-  IStorage,
-  ILogger,
   AddressScanPolicyData,
-  ITokenData,
-  TokenVersion,
+  AuthorityType,
   FullNodeVersionData,
-  IIndexLimitAddressScanPolicy,
+  getDefaultLogger,
+  HistorySyncMode,
   IHistoryTx,
-  IWalletAccessData,
+  IIndexLimitAddressScanPolicy,
+  ILogger,
   IMultisigData,
+  IStorage,
+  ITokenData,
   IUtxo,
+  IWalletAccessData,
   OutputValueType,
+  SCANNING_POLICY,
+  TokenVersion,
+  TxHistoryProcessingStatus,
+  WalletState,
+  WalletType,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import Queue from '../models/queue';
 import {
-  scanPolicyStartAddresses,
   checkScanningPolicy,
   getHistorySyncMethod,
   getSupportedSyncMode,
   processMetadataChanged,
+  scanPolicyStartAddresses,
 } from '../utils/storage';
 import txApi from '../api/txApi';
 import { MemoryStore, Storage } from '../storage';
@@ -92,25 +93,25 @@ import OnChainBlueprint, { Code, CodeKind } from '../nano_contracts/on_chain_blu
 import { NanoContractVertexType } from '../nano_contracts/types';
 import { IHistoryTxSchema } from '../schemas';
 import GLL from '../sync/gll';
-import { WalletTxTemplateInterpreter, TransactionTemplate } from '../template/transaction';
+import { TransactionTemplate, WalletTxTemplateInterpreter } from '../template/transaction';
 import Address from '../models/address';
 import Transaction from '../models/transaction';
 import {
-  IWalletInputInfo,
-  ISignature,
+  CreateNFTOptions,
+  CreateTokenOptions,
   GeneralTokenInfoSchema,
+  GetAuthorityOptions,
   GetAvailableUtxosOptions,
   GetBalanceFullnodeFacadeReturnType,
-  GetTxHistoryFullnodeFacadeReturnType,
   GetTokenDetailsFullnodeFacadeReturnType,
   GetTxByIdFullnodeFacadeReturnType,
+  GetTxHistoryFullnodeFacadeReturnType,
   GetUtxosForAmountOptions,
   HathorWalletConstructorParams,
-  GetAuthorityOptions,
-  SendManyOutputsOptions,
+  ISignature,
+  IWalletInputInfo,
   ProposedOutput,
-  CreateTokenOptions,
-  CreateNFTOptions,
+  SendManyOutputsOptions,
   UtxoDetails,
   UtxoOptions,
 } from './types';
@@ -1888,7 +1889,7 @@ class HathorWallet extends EventEmitter {
    *       Returns an empty array in case there are no tx_outupts for this type.
    * */
   async getMintAuthority(tokenUid: string, options: GetAuthorityOptions = {}): Promise<IUtxo[]> {
-    return this.getAuthorityUtxo(tokenUid, 'mint', options);
+    return this.getAuthorityUtxo(tokenUid, AuthorityType.MINT, options);
   }
 
   /**
@@ -1905,7 +1906,7 @@ class HathorWallet extends EventEmitter {
    *       Returns an empty array in case there are no tx_outupts for this type.
    * */
   async getMeltAuthority(tokenUid: string, options: GetAuthorityOptions = {}): Promise<IUtxo[]> {
-    return this.getAuthorityUtxo(tokenUid, 'melt', options);
+    return this.getAuthorityUtxo(tokenUid, AuthorityType.MELT, options);
   }
 
   /**
@@ -1924,13 +1925,13 @@ class HathorWallet extends EventEmitter {
    * */
   async getAuthorityUtxo(
     tokenUid: string,
-    authority: 'mint' | 'melt',
+    authority: AuthorityType,
     options: GetAuthorityOptions = {}
   ): Promise<IUtxo[]> {
     let authorityValue: bigint;
-    if (authority === 'mint') {
+    if (authority === AuthorityType.MINT) {
       authorityValue = 1n;
-    } else if (authority === 'melt') {
+    } else if (authority === AuthorityType.MELT) {
       authorityValue = 2n;
     } else {
       throw new Error('Invalid authority value.');
@@ -2454,11 +2455,11 @@ class HathorWallet extends EventEmitter {
    *
    * @return Array of the authority outputs.
    * */
-  async getAuthorityUtxos(tokenUid: string, type: 'mint' | 'melt'): Promise<IUtxo[]> {
-    if (type === 'mint') {
+  async getAuthorityUtxos(tokenUid: string, type: AuthorityType): Promise<IUtxo[]> {
+    if (type === AuthorityType.MINT) {
       return this.getMintAuthority(tokenUid, { many: true });
     }
-    if (type === 'melt') {
+    if (type === AuthorityType.MELT) {
       return this.getMeltAuthority(tokenUid, { many: true });
     }
     throw new Error('This should never happen.');

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -38,6 +38,7 @@ import {
   OutputValueType,
   ILogger,
   getDefaultLogger,
+  AuthorityType,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import {
@@ -622,7 +623,7 @@ export class Storage implements IStorage {
    */
   async matchTokenBalance(
     token: string,
-    balance: Record<'funds' | 'mint' | 'melt', OutputValueType>,
+    balance: Record<'funds' | AuthorityType, OutputValueType>,
     { changeAddress, skipAuthorities = true, chooseInputs = true }: IFillTxOptions = {}
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     const addressForChange = changeAddress || (await this.getCurrentAddress());

--- a/src/template/transaction/context.ts
+++ b/src/template/transaction/context.ts
@@ -7,7 +7,14 @@
 /* eslint max-classes-per-file: ["error", 3] */
 
 import { z } from 'zod';
-import { TokenVersion, IHistoryTx, ILogger, OutputValueType, getDefaultLogger } from '../../types';
+import {
+  TokenVersion,
+  IHistoryTx,
+  ILogger,
+  OutputValueType,
+  getDefaultLogger,
+  AuthorityType,
+} from '../../types';
 import Input from '../../models/input';
 import Output from '../../models/output';
 import transactionUtils from '../../utils/transaction';
@@ -181,12 +188,12 @@ export class TxBalance {
    * @param token - The token UID
    * @param authority - The authority type ('mint' or 'melt')
    */
-  addOutputAuthority(count: number, token: string, authority: 'mint' | 'melt') {
+  addOutputAuthority(count: number, token: string, authority: AuthorityType) {
     const balance = this.getTokenBalance(token);
-    if (authority === 'mint') {
+    if (authority === AuthorityType.MINT) {
       balance.mint_authorities -= count;
     }
-    if (authority === 'melt') {
+    if (authority === AuthorityType.MELT) {
       balance.melt_authorities -= count;
     }
     this.setTokenBalance(token, balance);
@@ -197,14 +204,14 @@ export class TxBalance {
    */
   addCreatedTokenOutputAuthority(
     count: number,
-    authority: 'mint' | 'melt',
+    authority: AuthorityType,
     tokenVersion: TokenVersion
   ) {
     const balance = this.getCreatedTokenBalance(tokenVersion);
-    if (authority === 'mint') {
+    if (authority === AuthorityType.MINT) {
       balance.mint_authorities -= count;
     }
-    if (authority === 'melt') {
+    if (authority === AuthorityType.MELT) {
       balance.melt_authorities -= count;
     }
     this.setCreatedTokenBalance(balance);

--- a/src/template/transaction/executor.ts
+++ b/src/template/transaction/executor.ts
@@ -14,6 +14,7 @@ import {
   ConfigInstruction,
   DataOutputInstruction,
   FeeInstruction,
+  getVariable,
   NanoAcquireAuthorityAction,
   NanoAction,
   NanoDepositAction,
@@ -31,10 +32,9 @@ import {
   TokenOutputInstruction,
   TxTemplateInstruction,
   UtxoSelectInstruction,
-  getVariable,
 } from './instructions';
 import { TxTemplateContext } from './context';
-import { ITxTemplateInterpreter, IGetUtxosOptions } from './types';
+import { IGetUtxosOptions, ITxTemplateInterpreter } from './types';
 import Input from '../../models/input';
 import Output from '../../models/output';
 import {
@@ -53,7 +53,7 @@ import {
   getWalletBalance,
 } from './setvarcommands';
 import { selectAuthorities, selectTokens } from './utils';
-import { TokenVersion, OutputValueType } from '../../types';
+import { AuthorityType, isAuthorityType, OutputValueType, TokenVersion } from '../../types';
 
 /**
  * Find and run the executor function for the instruction.
@@ -258,6 +258,9 @@ export async function execRawOutputInstruction(
   ctx.log(`amount(${amount}) timelock(${timelock}) script(${script}) token(${token})`);
   if (!(authority || amount)) {
     throw new Error('Raw token output missing amount');
+  }
+  if (!isAuthorityType(authority)) {
+    throw new Error('Invalid authority type');
   }
 
   // get tokenData and update token balance on the context
@@ -670,7 +673,7 @@ export async function execCompleteTxInstruction(
       ctx.log(`Creating ${count} mint outputs / ${tokenUid}`);
       // Need to create a token output
       // Add balance to the ctx.balance
-      ctx.balance.addOutputAuthority(count, tokenUid, 'mint');
+      ctx.balance.addOutputAuthority(count, tokenUid, AuthorityType.MINT);
 
       // Creates an output with the value of the outstanding balance
       const output = new Output(TOKEN_MINT_MASK, changeScript, {
@@ -709,7 +712,7 @@ export async function execCompleteTxInstruction(
       ctx.log(`Creating ${count} melt outputs / ${tokenUid}`);
       // Need to create a token output
       // Add balance to the ctx.balance
-      ctx.balance.addOutputAuthority(count, tokenUid, 'melt');
+      ctx.balance.addOutputAuthority(count, tokenUid, AuthorityType.MELT);
 
       // Creates an output with the value of the outstanding balance
       const output = new Output(TOKEN_MELT_MASK, changeScript, {

--- a/src/template/transaction/instructions.ts
+++ b/src/template/transaction/instructions.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import { NATIVE_TOKEN_UID } from '../../constants';
-import { TokenVersion } from '../../types';
+import { AuthorityType, TokenVersion } from '../../types';
 
 const TEMPLATE_REFERENCE_NAME_RE = /[\w\d]+/;
 const TEMPLATE_REFERENCE_RE = /\{([\w\d]+)\}/;
@@ -111,7 +111,7 @@ export const UtxoSelectInstruction = z.object({
 export const AuthoritySelectInstruction = z.object({
   type: z.literal('input/authority'),
   position: z.number().default(-1),
-  authority: z.enum(['mint', 'melt']),
+  authority: z.nativeEnum(AuthorityType),
   token: TemplateRef.or(CustomTokenSchema),
   count: TemplateRef.or(CountSchema.default(1)),
   address: TemplateRef.or(AddressSchema.optional()),
@@ -124,7 +124,7 @@ export const RawOutputInstruction = z.object({
   script: TemplateRef.or(z.string().regex(/^([a-fA-F0-9]{2})+$/)),
   token: TemplateRef.or(TokenSchema.default(NATIVE_TOKEN_UID)),
   timelock: TemplateRef.or(z.number().gte(0).optional()),
-  authority: z.enum(['mint', 'melt']).optional(),
+  authority: TemplateRef.or(z.nativeEnum(AuthorityType).optional()),
   useCreatedToken: z.boolean().default(false),
 });
 
@@ -144,7 +144,7 @@ export const AuthorityOutputInstruction = z.object({
   position: z.number().default(-1),
   count: TemplateRef.or(CountSchema.default(1)),
   token: TemplateRef.or(CustomTokenSchema.optional()),
-  authority: z.enum(['mint', 'melt']),
+  authority: z.nativeEnum(AuthorityType),
   address: TemplateRef.or(AddressSchema),
   timelock: TemplateRef.or(z.number().gte(0).optional()),
   checkAddress: z.boolean().optional(),
@@ -207,7 +207,7 @@ export const SetVarGetOracleSignedDataOpts = z.object({
 export const SetVarGetWalletBalanceOpts = z.object({
   method: z.literal('get_wallet_balance'),
   token: TemplateRef.or(TokenSchema.default('00')),
-  authority: z.enum(['mint', 'melt']).optional(),
+  authority: z.nativeEnum(AuthorityType).optional(),
 });
 
 export const SetVarCallArgs = z.discriminatedUnion('method', [
@@ -247,7 +247,7 @@ export const NanoGrantAuthorityAction = z.object({
   action: z.literal('grant_authority'),
   token: TemplateRef.or(CustomTokenSchema),
   useCreatedToken: z.boolean().default(false),
-  authority: z.enum(['mint', 'melt']),
+  authority: z.nativeEnum(AuthorityType),
   address: TemplateRef.or(AddressSchema.optional()),
   createAnotherTo: TemplateRef.or(AddressSchema.optional()),
   skipSelection: z.boolean().default(false),
@@ -256,7 +256,7 @@ export const NanoGrantAuthorityAction = z.object({
 export const NanoAcquireAuthorityAction = z.object({
   action: z.literal('acquire_authority'),
   token: TemplateRef.or(CustomTokenSchema),
-  authority: z.enum(['mint', 'melt']),
+  authority: z.nativeEnum(AuthorityType),
   address: TemplateRef.or(AddressSchema.optional()),
   skipOutputs: z.boolean().default(false),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -286,7 +286,7 @@ export function isDataOutputAddress(output: IDataOutput): output is IDataOutputA
 
 // This is for create token transactions, where we dont have a token uid yet
 export interface IDataOutputCreateToken {
-  type: 'mint' | 'melt';
+  type: AuthorityType;
   value: OutputValueType;
   address: string;
   timelock: number | null;
@@ -294,7 +294,7 @@ export interface IDataOutputCreateToken {
 }
 
 export function isDataOutputCreateToken(output: IDataOutput): output is IDataOutputCreateToken {
-  return ['mint', 'melt'].includes(output.type);
+  return output.type === AuthorityType.MINT || output.type === AuthorityType.MELT;
 }
 
 export interface IDataOutputOptionals {
@@ -688,4 +688,13 @@ export interface INcData {
   address: string;
   blueprintId: string;
   blueprintName: string;
+}
+
+export enum AuthorityType {
+  MINT = 'mint',
+  MELT = 'melt',
+}
+
+export function isAuthorityType(value?: string): value is AuthorityType {
+  return Object.values(AuthorityType).includes(value as AuthorityType);
 }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -12,12 +12,13 @@ import {
   CREATE_TOKEN_TX_VERSION,
   NATIVE_TOKEN_UID,
   TOKEN_DEPOSIT_PERCENTAGE,
+  TOKEN_INDEX_MASK,
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
-  TOKEN_INDEX_MASK,
 } from '../constants';
 import helpers from './helpers';
 import {
+  AuthorityType,
   IDataInput,
   IDataOutput,
   IDataOutputWithToken,
@@ -25,8 +26,8 @@ import {
   IStorage,
   ITokenData,
   OutputValueType,
-  UtxoSelectionAlgorithm,
   TokenVersion,
+  UtxoSelectionAlgorithm,
 } from '../types';
 import { getAddressType } from './address';
 import {
@@ -423,7 +424,7 @@ const tokens = {
 
     // Add output to mint tokens
     outputs.push({
-      type: 'mint',
+      type: AuthorityType.MINT,
       address,
       value: amount,
       timelock: null,
@@ -433,7 +434,7 @@ const tokens = {
     if (createAnotherMint) {
       const newAddress = mintAuthorityAddress || (await storage.getCurrentAddress());
       outputs.push({
-        type: 'mint',
+        type: AuthorityType.MELT,
         address: newAddress,
         value: TOKEN_MINT_MASK,
         timelock: null,

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -42,6 +42,7 @@ import {
   ITxSignatureData,
   OutputValueType,
   IHistoryInput,
+  AuthorityType,
 } from '../types';
 import Address from '../models/address';
 import P2PKH from '../models/p2pkh';
@@ -471,7 +472,7 @@ const transaction = {
   async calculateTxBalanceToFillTx(
     token: string,
     tx: IDataTx
-  ): Promise<Record<'funds' | 'mint' | 'melt', OutputValueType>> {
+  ): Promise<Record<'funds' | AuthorityType, OutputValueType>> {
     const balance = { funds: 0n, mint: 0n, melt: 0n };
     for (const output of tx.outputs) {
       if (isDataOutputCreateToken(output)) {


### PR DESCRIPTION
### Acceptance Criteria
- Creates an enum for the `AuthorityType` instead of literals `'mint' | 'melt'`


### Security Checklist
- [X] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
