### PR TITLE
fix(bigint): make SyntaxError check in bigIntReviver engine-agnostic

### DIFF
--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -42,11 +42,7 @@ export const JSONBigInt = {
       // Otherwise, we can keep it as a Number.
       return value;
     } catch (e) {
-      if (
-        e instanceof SyntaxError &&
-        (e.message === `Cannot convert ${context.source} to a BigInt` ||
-          e.message === `invalid BigInt syntax`)
-      ) {
+      if (e instanceof SyntaxError) {
         // When this error happens, it means the number cannot be converted to a BigInt,
         // so it's a double, for example '123.456' or '1e2'.
         return value;


### PR DESCRIPTION
Resolves #1018

**Root Cause:**
`JSONBigInt.bigIntReviver` was checking for V8-specific error strings when failing to parse BigInt from float values (like '1.5' or '1e2'). This causes an unhandled crash in non-V8 Javascript engines (Bun, Safari/JavaScriptCore, Firefox) where the string for a SyntaxError is different (`Failed to parse String to BigInt` instead of `Cannot convert... to a BigInt`).

**Fix:**
Since `BigInt()` only ever throws a `SyntaxError` when the string cannot be parsed into an integer (e.g. floats, decimals), checking for `e instanceof SyntaxError` accurately handles this without binding the logic to a specific engine's exact error string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced BigInt parsing error handling to gracefully recover from more conversion failure scenarios, improving reliability when processing numeric data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->