### PR TITLE
fix(bigint): remove engine-specific error message checks

### DIFF
--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -42,11 +42,7 @@ export const JSONBigInt = {
       // Otherwise, we can keep it as a Number.
       return value;
     } catch (e) {
-      if (
-        e instanceof SyntaxError &&
-        (e.message === `Cannot convert ${context.source} to a BigInt` ||
-          e.message === `invalid BigInt syntax`)
-      ) {
+      if (e instanceof SyntaxError) {
         // When this error happens, it means the number cannot be converted to a BigInt,
         // so it's a double, for example '123.456' or '1e2'.
         return value;


### PR DESCRIPTION
This PR addresses #1018 where `JSONBigInt.bigIntReviver` crashes on non-V8 engines (like Bun/JavaScriptCore) due to checking for V8-specific `SyntaxError` messages.

**Changes:**
- Removed the strict string matching on the error message (`Cannot convert ... to a BigInt` and `invalid BigInt syntax`).
- Any `SyntaxError` thrown by `BigInt()` when given `context.source` guarantees it's an unparseable float/scientific-notation number, so catching `SyntaxError` directly handles all JS engines without failing.

Fixes #1018

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for numeric conversions to provide more consistent and graceful fallback behavior across different input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->