### PR TITLE
fix(utils): make bigIntReviver engine-agnostic by checking SyntaxError

### DIFF
--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -42,13 +42,10 @@ export const JSONBigInt = {
       // Otherwise, we can keep it as a Number.
       return value;
     } catch (e) {
-      if (
-        e instanceof SyntaxError &&
-        (e.message === `Cannot convert ${context.source} to a BigInt` ||
-          e.message === `invalid BigInt syntax`)
-      ) {
+      if (e instanceof SyntaxError) {
         // When this error happens, it means the number cannot be converted to a BigInt,
         // so it's a double, for example '123.456' or '1e2'.
+        // We catch any SyntaxError to be engine-agnostic (V8 vs JavaScriptCore vs SpiderMonkey).
         return value;
       }
       // This should never happen, any other error thrown by BigInt() is unexpected.


### PR DESCRIPTION
Fixes #1018

### Description
`JSONBigInt.bigIntReviver` currently relies on matching specific string messages for `SyntaxError`s when parsing floats (like `1.5` or `1e2`). Since V8, JavaScriptCore (Bun/Safari), and SpiderMonkey throw different error messages, this breaks the reviver on non-Node/Chrome runtimes (like Bun).

By simply catching `e instanceof SyntaxError`, the code becomes engine-agnostic while still preserving the original logic of keeping the value as a number if it cannot be converted to a `BigInt` (i.e. if it's a float/scientific notation).

### Changes
- Replaced the string-matching `e.message === ...` logic with a simple `e instanceof SyntaxError` check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of BigInt conversion error handling to work consistently across all JavaScript engines, ensuring decimal and exponential number formats are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->