### PR TITLE
fix: native token version defaulting to DEPOSIT

### DIFF
--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -33,6 +33,7 @@ import {
   OutputValueType,
   WALLET_FLAGS,
   TokenVersion,
+  ApiVersion,
 } from '../../src/types';
 
 describe('handleStop', () => {
@@ -218,17 +219,39 @@ describe('config version', () => {
   it('should get native token from version', async () => {
     const store = new MemoryStore();
     const storage = new Storage(store);
+    // No version set: should use DEFAULT_NATIVE_TOKEN_CONFIG
     expect(storage.getNativeTokenData()).toEqual({
       ...DEFAULT_NATIVE_TOKEN_CONFIG,
       uid: NATIVE_TOKEN_UID,
     });
+
+    // Fullnode provides native_token without version field: should default to NATIVE
     const version = { native_token: { name: 'Native', symbol: 'N' } };
     storage.setApiVersion(version);
     expect(storage.getNativeTokenData()).toEqual({
+      version: TokenVersion.NATIVE,
       name: 'Native',
       symbol: 'N',
       uid: NATIVE_TOKEN_UID,
     });
+
+    // Fullnode explicitly provides version: should preserve it
+    storage.setApiVersion({
+      native_token: { name: 'Hathor', symbol: 'HTR', version: TokenVersion.NATIVE },
+    } as ApiVersion);
+    expect(storage.getNativeTokenData().version).toBe(TokenVersion.NATIVE);
+
+    // Fullnode provides an unknown version: should forward it as-is
+    storage.setApiVersion({
+      native_token: { name: 'Hathor', symbol: 'HTR', version: 99 as number },
+    } as ApiVersion);
+    expect(storage.getNativeTokenData().version).toBe(99);
+
+    // native_token is null: should fall back to DEFAULT_NATIVE_TOKEN_CONFIG
+    storage.setApiVersion({ native_token: null } as ApiVersion);
+    expect(storage.getNativeTokenData().version).toBe(TokenVersion.NATIVE);
+
+    // Version reset to null: should fall back to DEFAULT_NATIVE_TOKEN_CONFIG
     storage.setApiVersion(null);
     expect(storage.getNativeTokenData()).toEqual({
       ...DEFAULT_NATIVE_TOKEN_CONFIG,
@@ -247,16 +270,19 @@ describe('config version', () => {
     });
   });
 
-  it('should save native token from version', async () => {
+  it('should save native token from version with version NATIVE', async () => {
     const store = new MemoryStore();
     const storage = new Storage(store);
     await expect(storage.getToken(NATIVE_TOKEN_UID)).resolves.toEqual(null);
+    // Fullnode response without version field
     const version = { native_token: { name: 'Native', symbol: 'N' } };
     storage.setApiVersion(version);
     await storage.saveNativeToken();
-    await expect(storage.getToken(NATIVE_TOKEN_UID)).resolves.toMatchObject({
+    const saved = await storage.getToken(NATIVE_TOKEN_UID);
+    expect(saved).toMatchObject({
       name: 'Native',
       symbol: 'N',
+      version: TokenVersion.NATIVE,
       uid: NATIVE_TOKEN_UID,
     });
   });

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -39,6 +39,7 @@ import {
   ILogger,
   getDefaultLogger,
   AuthorityType,
+  TokenVersion,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import {
@@ -140,8 +141,7 @@ export class Storage implements IStorage {
    */
   getNativeTokenData(): ITokenData {
     const nativeToken = this.version?.native_token ?? DEFAULT_NATIVE_TOKEN_CONFIG;
-
-    return { ...nativeToken, uid: NATIVE_TOKEN_UID };
+    return { version: TokenVersion.NATIVE, ...nativeToken, uid: NATIVE_TOKEN_UID };
   }
 
   /**


### PR DESCRIPTION
## Motivation

When the fullnode's `/version` endpoint returns `native_token` without a `version` field (e.g. `{ "name": "Hathor", "symbol": "HTR" }`), `getNativeTokenData()` was producing an object with no `version` property. When this was later passed to `memory_store.saveToken()`, its default spread (`{ version: TokenVersion.DEPOSIT, ...tokenConfig }`) kicked in, incorrectly tagging HTR as `DEPOSIT` (1) instead of `NATIVE` (0).

### Acceptance Criteria
- `getNativeTokenData()` always returns `version: TokenVersion.NATIVE` when the fullnode omits the version field
- `getNativeTokenData()` forwards the fullnode-provided version as-is (including unknown values like `99`)
- `getNativeTokenData()` falls back to `DEFAULT_NATIVE_TOKEN_CONFIG` when `native_token` is null or version is not set
- `saveNativeToken()` round-trip through `MemoryStore` persists `version: NATIVE`, not `DEPOSIT`
- Custom tokens still default to `TokenVersion.DEPOSIT` in `saveToken()` (no regression)

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for native token version handling scenarios, including cases with missing, unknown, or null version values.

* **Bug Fixes**
  * Ensured native tokens now explicitly include version information when retrieved from storage, with proper fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->