### PR TITLE
chore: bump to v3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "2.18.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hathor/wallet-lib",
-      "version": "2.18.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "axios": "1.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hathor/wallet-lib",
-      "version": "2.17.0",
+      "version": "2.18.0",
       "license": "MIT",
       "dependencies": {
         "axios": "1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "2.18.0",
+  "version": "3.0.0",
   "description": "Library used by Hathor Wallet",
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Library used by Hathor Wallet",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
### Acceptance Criteria
- Bump package to v3.0.0

### Breaking Changes

From **#1034 - feat: export all types and utils from public API**:

The following types have been renamed at their source. External consumers importing the old names will need to update:

| Old Name | New Name | Source File |
|---|---|---|
| `Balance` | `WalletServiceBalance` | `src/wallet/types.ts` |
| `Authority` | `WalletServiceAuthority` | `src/wallet/types.ts` |
| `DelegateAuthorityOptions` | `WalletServiceDelegateAuthorityOptions` | `src/wallet/types.ts` |
| `DestroyAuthorityOptions` | `WalletServiceDestroyAuthorityOptions` | `src/wallet/types.ts` |
| `CreateNanoTxData` | `FullnodeCreateNanoTxData` | `src/new/types.ts` |

> **Note:** The `models/types.ts` versions (`Balance`, `Authority`) and `nano_contracts/types.ts` version (`CreateNanoTxData`) keep their original names. Only the duplicates in `wallet/types.ts` and `new/types.ts` were renamed.

From **#1038 - feat: single address policy**:

#### `HathorWallet` default scan policy changed to `SINGLE_ADDRESS`

The constructor now defaults to `{ policy: SCANNING_POLICY.SINGLE_ADDRESS }` when no `scanPolicy` is provided. Previously, omitting `scanPolicy` resulted in `GAP_LIMIT` behavior.

Consumers that relied on the default gap-limit behavior must now explicitly pass a scan policy:
```ts
new HathorWallet({
  // ...
  scanPolicy: { policy: SCANNING_POLICY.GAP_LIMIT, gapLimit: GAP_LIMIT },
});
```

#### `HathorWallet` first-connection auto-detection of address mode

On the first WebSocket connection, `HathorWallet` now automatically:
1. Checks the stored scanning policy.
2. If `SINGLE_ADDRESS`, attempts `enableSingleAddressMode()`.
3. If the wallet has transactions on addresses beyond index 0, catches `HasTxOutsideFirstAddressError` and falls back to `GAP_LIMIT`.

This behavior did not exist in v2.x.

#### `HathorWallet.changeServer()` is now async

The method signature changed from `changeServer(newServer: string): void` to `async changeServer(newServer: string): Promise<void>`. TypeScript consumers that type-check the return value will need to update.

#### `changeServer()` added to `IHathorWallet` interface

The `changeServer(newServer: string): Promise<void>` method was added to the `IHathorWallet` interface. Consumers that implement this interface directly will need to add this method.

#### `HathorWallet.getAddressAtIndex()` no longer persists derived addresses

Previously, calling `getAddressAtIndex()` for an index not yet in storage would derive the address **and** save it via `this.storage.saveAddress(address)`. It now derives and returns the address without persisting it.

### What's included

| PR | Type | Title |
|---|---|---|
| #1034 | feat | export all types and utils from public API |
| #1038 | feat | single address policy |
| #1054 | fix | native token version defaulting to DEPOSIT |
| #1056 | fix | precalculated wallet address derivation bug |
| #1046 | refact | move fee test suite to the right folder |
| #1032 | test | Shared tests for `start` |
| #1047 | test | Shared tests for internal wallet methods |
| #1048 | test | add new fee template integration tests |
| #1049 | chore | improve CI integration test logs |

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.