### PR TITLE
fix: poll token index after createToken; add integration test retries

### DIFF
--- a/__tests__/integration/adapters/service.adapter.ts
+++ b/__tests__/integration/adapters/service.adapter.ts
@@ -14,6 +14,7 @@ import {
   buildWalletInstance,
   initializeServiceGlobalConfigs,
   pollForTx,
+  pollForTokenDetails,
   pollUntilCondition,
 } from '../helpers/service-facade.helper';
 import { GenesisWalletServiceHelper } from '../helpers/genesis-wallet.helper';
@@ -239,6 +240,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
       throw new Error('createToken: transaction had no hash');
     }
     await pollForTx(sw, response.hash);
+    await pollForTokenDetails(sw, response.hash);
     return { hash: response.hash };
   }
 

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -23,6 +23,9 @@ import Transaction from './src/models/transaction';
 
 config.setTxMiningUrl(TX_MINING_URL);
 
+// Retry flaky tests up to 2 times before marking them as failed
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
 // Mock calculateWeight to always return 1 for faster mining in integration tests
 Transaction.prototype.calculateWeight = function () {
   return 1;


### PR DESCRIPTION
## Summary
- Fix: poll token index after `createToken` in the service adapter, ensuring the new token is indexed before returning.
- CI: add `jest.retryTimes(2)` to integration test setup, retrying flaky test cases up to 2 extra times before failing.

### Why the retry on all tests, and not on specific ones?
The flakiness is not on a single test, but on the test infrastructure itself. PRs like #1033 , #1056 , #1058 , #1063 , #1069 and https://github.com/HathorNetwork/rfcs/pull/103 are attempting to fix the underlying issues, but this PR would remove the immediate pain with the constant blocking we're having with the Wallet Lib CI.

### Will we lose the failure data?
*No, we're not.* The failures are still catalogued in the CI output, which was greatly improved by #1049 . We can ask AI agents to look into the CI logs regularly to find more flaky tests, but without the great cost this is imposing on the speed of development on the Wallet Lib.

## Acceptance Criteria
- `createToken` via service adapter correctly polls the token index before resolving.
- Flaky integration tests get up to 2 retry attempts, with errors logged on each retry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced token-creation test to verify an additional post-transaction polling step.
  * Integration test setup now automatically retries failing tests up to two times and logs errors before each retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->