### PR TITLE
feat(errors): type WalletRequestError.cause as a discriminated union

### DIFF
--- a/__tests__/wallet/api/walletApi.test.ts
+++ b/__tests__/wallet/api/walletApi.test.ts
@@ -716,6 +716,27 @@ describe('walletApi', () => {
     );
   });
 
+  test('createAuthToken attaches { status, data } to cause on non-2xx', async () => {
+    const errorBody = { success: false, error: 'invalid-signature' };
+
+    mockAxiosInstance.post.mockResolvedValueOnce({
+      status: 400,
+      data: errorBody,
+    } as AxiosResponse);
+
+    let caught: unknown;
+    try {
+      await walletApi.createAuthToken(wallet, 1234, 'xpub-stub', 'sig-stub');
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(WalletRequestError);
+    const err = caught as WalletRequestError;
+    expect(err.message).toBe('Error requesting auth token.');
+    expect(err.cause).toEqual({ status: 400, data: errorBody });
+  });
+
   test('deleteTxProposal', async () => {
     const txProposalId = 'proposal-id';
     const mockResponse = {

--- a/__tests__/wallet/readOnlyWallet.test.ts
+++ b/__tests__/wallet/readOnlyWallet.test.ts
@@ -281,9 +281,10 @@ describe('Read-Only Wallet Access', () => {
         const error = await caught;
         expect(error).toBeInstanceOf(WalletRequestError);
         expect(error.message).toContain('Read-only wallet startup timed out');
-        // The root cause should be preserved
-        expect(error.cause).toBeInstanceOf(WalletRequestError);
-        expect((error.cause as Error).message).toBe('Wallet not ready');
+        // The root cause should be preserved under cause.source
+        const cause = (error as WalletRequestError).cause as { source: WalletRequestError };
+        expect(cause.source).toBeInstanceOf(WalletRequestError);
+        expect(cause.source.message).toBe('Wallet not ready');
       } finally {
         jest.useRealTimers();
       }

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -3698,8 +3698,9 @@ describe('pollForWalletStatus', () => {
       const error = await caught;
       expect(error).toBeInstanceOf(WalletRequestError);
       expect(error.message).toContain('Wallet status polling timed out');
-      expect(error.cause).toBeInstanceOf(WalletRequestError);
-      expect((error.cause as Error).message).toBe('Persistent server error');
+      const cause = (error as WalletRequestError).cause as { source: WalletRequestError };
+      expect(cause.source).toBeInstanceOf(WalletRequestError);
+      expect(cause.source.message).toBe('Persistent server error');
     } finally {
       jest.useRealTimers();
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -176,15 +176,42 @@ export class WalletError extends Error {
 }
 
 /**
- * Error thrown when executing wallet requests
+ * Diagnostic context attached to a {@link WalletRequestError}. Three variants
+ * capture the kinds of evidence a wallet request failure can produce:
+ *
+ *   - `{ status, data }` — HTTP failure: status code and body from an axios
+ *     response.
+ *   - `{ state }`       — App-level rejection: the HTTP call succeeded but
+ *     the response indicates the wallet is in a non-success state.
+ *   - `{ source }`      — Chained failure: this error wraps a prior
+ *     {@link WalletRequestError} (e.g. a polling loop that exhausted retries
+ *     after multiple transient errors).
+ *
+ * Variants are mutually exclusive: each has a unique required field, so the
+ * type system rejects accidental combinations like `{ status, source }`.
+ */
+export type WalletRequestErrorCause =
+  | { status: number; data: unknown }
+  | { state: unknown }
+  | { source: WalletRequestError };
+
+/**
+ * Error thrown when executing wallet requests.
+ *
+ * The {@link cause} is currently optional to permit incremental adoption: not
+ * every throw site populates it yet. A follow-up PR will make `cause`
+ * mandatory once every throw site has been swept.
  *
  * @memberof Errors
  * @inner
  */
 export class WalletRequestError extends WalletError {
-  cause: unknown = null;
+  cause: WalletRequestErrorCause | undefined = undefined;
 
-  constructor(message: string, errorData: { cause: unknown } = { cause: null }) {
+  constructor(
+    message: string,
+    errorData: { cause: WalletRequestErrorCause | undefined } = { cause: undefined }
+  ) {
     super(message);
     this.cause = errorData.cause;
   }

--- a/src/pushNotification.ts
+++ b/src/pushNotification.ts
@@ -61,7 +61,7 @@ const walletServiceClient = {
       return response.data;
     }
     throw new WalletRequestError('Error registering device for push notification.', {
-      cause: response.data,
+      cause: { status: response.status, data: response.data },
     });
   },
 
@@ -75,7 +75,7 @@ const walletServiceClient = {
       return response.data;
     }
     throw new WalletRequestError('Error updating push notification settings for device.', {
-      cause: response.data,
+      cause: { status: response.status, data: response.data },
     });
   },
 
@@ -89,7 +89,7 @@ const walletServiceClient = {
       return response.data;
     }
     throw new WalletRequestError('Error unregistering wallet from push notifications.', {
-      cause: response.data,
+      cause: { status: response.status, data: response.data },
     });
   },
 };

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -330,7 +330,7 @@ const walletApi = {
       if (!response.data.success) {
         walletApi._txNotFoundGuard(response.data);
         throw new WalletRequestError('Error getting transaction by its id.', {
-          cause: response.data,
+          cause: { status: response.status, data: response.data },
         });
       }
       return parseSchema(response.data, txByIdResponseSchema);
@@ -343,7 +343,7 @@ const walletApi = {
     }
 
     throw new WalletRequestError('Error getting transaction by its id.', {
-      cause: response.data,
+      cause: { status: response.status, data: response.data },
     });
   },
 
@@ -372,7 +372,7 @@ const walletApi = {
     walletApi._txNotFoundGuard(response.data);
 
     throw new WalletRequestError('Error getting transaction by its id from the proxied fullnode.', {
-      cause: response.data,
+      cause: { status: response.status, data: response.data },
     });
   },
 
@@ -391,7 +391,7 @@ const walletApi = {
     throw new WalletRequestError(
       'Error getting transaction confirmation data by its id from the proxied fullnode.',
       {
-        cause: response.data,
+        cause: { status: response.status, data: response.data },
       }
     );
   },
@@ -418,7 +418,7 @@ const walletApi = {
         throw new WalletRequestError(
           `Error getting neighbors data for ${txId} from the proxied fullnode.`,
           {
-            cause: response.data.message,
+            cause: { status: response.status, data: response.data },
           }
         );
       }
@@ -429,7 +429,7 @@ const walletApi = {
     throw new WalletRequestError(
       `Error getting neighbors data for ${txId} from the proxied fullnode.`,
       {
-        cause: response.data,
+        cause: { status: response.status, data: response.data },
       }
     );
   },

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -498,7 +498,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       // At this stage, if the wallet is not 'ready' or 'creating' we should
       // throw an error as there are only three states: 'ready', 'creating' or 'error'
       throw new WalletRequestError(ErrorMessages.WALLET_STATUS_ERROR, {
-        cause: data.status,
+        cause: { state: data.status },
       });
     }
 
@@ -731,7 +731,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   async pollForWalletStatus(): Promise<void> {
-    let lastError: Error | null = null;
+    let lastError: WalletRequestError | undefined;
+    let lastState: unknown;
     for (let attempt = 0; attempt < MAX_WALLET_STATUS_POLL_ATTEMPTS; attempt++) {
       let data;
       try {
@@ -748,20 +749,23 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         continue;
       }
 
-      lastError = null;
+      lastError = undefined;
+      lastState = data.status;
       if (data.status.status === WS_STATUS_READY) {
         return;
       }
       // Only possible states are 'ready', 'creating' and 'error'. If status
       // is not ready or creating, we should throw an error.
       if (data.status.status !== WS_STATUS_CREATING) {
-        throw new WalletRequestError('Error getting wallet status.', { cause: data.status });
+        throw new WalletRequestError('Error getting wallet status.', {
+          cause: { state: data.status },
+        });
       }
 
       await helpers.sleep(WALLET_STATUS_POLLING_INTERVAL);
     }
     throw new WalletRequestError('Wallet status polling timed out.', {
-      cause: lastError ?? undefined,
+      cause: lastError ? { source: lastError } : { state: lastState },
     });
   }
 
@@ -1246,11 +1250,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     // returns 400 while the wallet is still 'creating'. We retry WalletRequestError
     // (server responded but said no) until it succeeds or we time out.
     // Non-WalletRequestError (network failures, timeouts) propagate immediately.
-    let lastError: Error | null = null;
+    let lastError: WalletRequestError | undefined;
     for (let attempt = 0; attempt < MAX_WALLET_STATUS_POLL_ATTEMPTS; attempt++) {
       try {
         await this.getReadOnlyAuthToken();
-        lastError = null;
+        lastError = undefined;
         break;
       } catch (err) {
         if (!(err instanceof WalletRequestError)) {
@@ -1258,8 +1262,8 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         }
         // Only retry on HTTP 400 (wallet may still be creating).
         // Other status codes (401, 403, 404, etc.) are permanent failures.
-        const cause = err.cause as { status?: number } | undefined;
-        if (cause && typeof cause.status === 'number' && cause.status !== 400) {
+        const { cause } = err;
+        if (cause && 'status' in cause && cause.status !== 400) {
           throw err;
         }
         lastError = err;
@@ -1269,7 +1273,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     if (lastError) {
       throw new WalletRequestError(
         'Read-only wallet startup timed out. The wallet may not be initialized or is in an error state.',
-        { cause: lastError }
+        { cause: { source: lastError } }
       );
     }
     await this.onWalletReady(skipAddressFetch);


### PR DESCRIPTION
## Summary

Builds on HathorNetwork/hathor-wallet-lib#1058 (currently the base branch — will retarget to `master` once the parent PR lands). Addresses three of the four review threads on the parent PR: the typed cause shape, the missing `data` field on two `wallet.ts` throws, and the missing `createAuthToken` cause-shape test.

This change defines the type contract for `WalletRequestError.cause` and sweeps every site that *already* passes a cause to fit it. A follow-up PR (tracked by HathorNetwork/hathor-wallet-lib#1075) will populate the remaining ~15 currently-bare `walletApi.ts` throw sites and narrow `cause` from optional to mandatory at the type level.

### What changed
- New discriminated union `WalletRequestErrorCause` in `src/errors.ts` with three mutually exclusive variants:
  - `{ status: number; data: unknown }` — HTTP failure (axios response)
  - `{ state: unknown }` — app-level rejection (HTTP succeeded, wallet reported a non-success state)
  - `{ source: WalletRequestError }` — chained failure wrapping a prior error (e.g. polling timeouts)
- Every existing cause-passing site swept to fit one of the variants: `walletApi.ts` (6 sites), `pushNotification.ts` (3 sites), `wallet.ts` (4 sites).
- `pollForWalletStatus` now tracks `lastState` alongside `lastError` so the timeout site always has either a `source` or a `state` to attach (no silent `cause: undefined` on timeout).
- Cleaned up a redundant `as { status?: number }` cast in `startReadOnly` — `'status' in cause` now narrows correctly via the new union.
- New `createAuthToken` unit test asserts the cause shape on a 400 response.
- Two pre-existing tests (`wallet.test.ts` polling-timeout, `readOnlyWallet.test.ts` startup-timeout) updated to match the new `{ source }` shape.

### Next steps (deferred to a follow-up PR)
- Populate the remaining ~15 bare `throw new WalletRequestError(...)` sites in `walletApi.ts` with appropriate `{ status, data }` causes.
- Narrow `WalletRequestError.cause` from `WalletRequestErrorCause | undefined` to `WalletRequestErrorCause` (mandatory) once every throw site has been covered.

### Breaking changes

`WalletRequestError.cause` is no longer typed as `unknown`. It is now `WalletRequestErrorCause | undefined`, a discriminated union with three mutually exclusive variants. Consumer code that reads fields off `err.cause` will not compile and/or will read `undefined` at runtime until updated.

**Migration required for any code that catches `WalletRequestError` and inspects `err.cause`.**

1. **Narrow on a discriminant before reading variant fields.** TypeScript will no longer let you read `err.cause.status`, `err.cause.data`, or `err.cause.state` without first checking which variant you have.

   ```ts
   // Before
   if (err instanceof WalletRequestError) {
     const status = (err.cause as any)?.status;
     const body = (err.cause as any)?.data;
   }

   // After
   if (err instanceof WalletRequestError && err.cause) {
     if ('status' in err.cause) {
       const status = err.cause.status;        // number
       const body = err.cause.data;            // unknown
     } else if ('state' in err.cause) {
       const state = err.cause.state;          // unknown — wallet-reported failure state
     } else if ('source' in err.cause) {
       const inner = err.cause.source;         // WalletRequestError — chained failure
     }
   }
   ```

2. **Chained errors are no longer the inner error directly — they are wrapped in `{ source }`.** Previously, sites like `pollForWalletStatus` timeouts assigned the prior `WalletRequestError` straight into `cause`. They now wrap it.

   ```ts
   // Before
   const inner = err.cause as WalletRequestError;
   console.log(inner.message);

   // After
   if (err.cause && 'source' in err.cause) {
     console.log(err.cause.source.message);
   }
   ```

3. **`cause` may still be `undefined`** until the follow-up PR (HathorNetwork/hathor-wallet-lib#1075) covers the remaining bare throw sites in `walletApi.ts`. Always guard with a truthiness check before narrowing.

No runtime behavior changed beyond the polling-timeout site, which now consistently attaches either `{ source }` (last seen error) or `{ state }` (last seen wallet state) instead of occasionally producing `cause: undefined`.

## Acceptance criteria
- `WalletRequestError.cause` is typed; every site that already passed a cause now uses one of three variants.
- New unit test asserts `createAuthToken` attaches `{ status, data }` on non-2xx responses.

## Test plan
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (842 passing, 0 failing)
- [ ] Integration tests — happy path is behaviorally unchanged; will run if requested before merge.