### PR TITLE
chore: enforce import order via eslint+prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,17 @@ module.exports = {
     'arrow-parens': ['error', 'as-needed'],
     'import/no-named-as-default': 0,
     'import/prefer-default-export': 0,
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        'newlines-between': 'always',
+        alphabetize: { order: 'asc', caseInsensitive: true },
+      },
+    ],
+    'import/first': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-duplicates': 'error',
     quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
     'comma-dangle': 0,
     'object-curly-newline': 'off', // This rule is better handled by prettier

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# Commits in this file are skipped by `git blame` so they don't obscure
+# real authorship. Enable per-clone with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub's web blame view honors this file automatically.
+
+# Bulk import-order + trailing-comma reformat
+0188a36c320563525d22fe7435e715e0bc9d8412

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
   "useTabs": false,
   "semi": true,
   "singleQuote": true,
-  "trailingComma": "es5",
+  "trailingComma": "all",
   "bracketSpacing": true,
   "arrowParens": "avoid"
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,29 @@ const hathorLib = require('@hathor/wallet-lib');
 hathorLib.storage.setStore(storageFactory);
 ```
 
+## Contributing
+
+### Pre-commit hooks
+
+The repository uses `husky` + `lint-staged` to run `eslint --fix` and
+`prettier --write` on staged JS/TS files before each commit. Setup is
+automatic — running `npm install` triggers the `prepare` script which
+wires the hooks. To skip the hook for a one-off commit, use
+`git commit --no-verify`.
+
+### Bulk reformat history
+
+Import ordering and trailing-comma style were rolled out in a single
+mass-reformat commit recorded in `.git-blame-ignore-revs`. To make
+local `git blame` skip that commit and surface real authors, run once
+per clone:
+
+```sh
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+GitHub's web blame view honors this file automatically.
+
 ## Release Process (Claude Code)
 
 This project includes a Claude Code skill for managing releases. Available commands:

--- a/__tests__/__mock_helpers__/get-token.mock.ts
+++ b/__tests__/__mock_helpers__/get-token.mock.ts
@@ -2,7 +2,7 @@ import { NATIVE_TOKEN_UID } from '../../src/constants';
 import { TokenVersion, ITokenData, ITokenMetadata } from '../../src/types';
 
 export const mockGetToken = async (
-  tokenUid: string
+  tokenUid: string,
 ): Promise<ITokenData & Partial<ITokenMetadata>> => {
   const tokenMap: Record<string, ITokenData> = {
     [NATIVE_TOKEN_UID]: {

--- a/__tests__/__mock_helpers__/wallet-service.fixtures.ts
+++ b/__tests__/__mock_helpers__/wallet-service.fixtures.ts
@@ -1,6 +1,6 @@
 import Network from '../../src/models/network';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
 import { JSONBigInt } from '../../src/utils/bigint';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
 
 export const defaultWalletSeed =
   'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff';

--- a/__tests__/api/health.test.ts
+++ b/__tests__/api/health.test.ts
@@ -1,5 +1,6 @@
-import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
 import healthApi from '../../src/api/health';
 
 describe('healthApi', () => {

--- a/__tests__/api/metadata.test.ts
+++ b/__tests__/api/metadata.test.ts
@@ -1,5 +1,6 @@
-import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
 import metadataApi from '../../src/api/metadataApi';
 
 describe('getDagMetadata', () => {

--- a/__tests__/api/txMining.test.ts
+++ b/__tests__/api/txMining.test.ts
@@ -1,5 +1,6 @@
-import MockAdapter from 'axios-mock-adapter';
 import axios, { AxiosError } from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
 import txMiningApi from '../../src/api/txMining';
 
 describe('txMiningApi', () => {
@@ -132,7 +133,7 @@ describe('txMiningApi', () => {
           propagate: true,
           add_parents: true,
           timeout: 10,
-        })
+        }),
       );
     });
 

--- a/__tests__/api/txMiningAxios.test.ts
+++ b/__tests__/api/txMiningAxios.test.ts
@@ -1,6 +1,6 @@
 import txMiningRequestClient from '../../src/api/txMiningAxios';
-import networkIntance from '../../src/network';
 import config from '../../src/config';
+import networkIntance from '../../src/network';
 
 let previousNetwork;
 

--- a/__tests__/api/version.test.ts
+++ b/__tests__/api/version.test.ts
@@ -1,5 +1,6 @@
-import MockAdapter from 'axios-mock-adapter';
 import axios, { AxiosError } from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
 import versionApi from '../../src/api/version';
 
 describe('versionApi', () => {

--- a/__tests__/exports.test.ts
+++ b/__tests__/exports.test.ts
@@ -506,10 +506,10 @@ describe('exported classes', () => {
 describe('exported nano contract schemas', () => {
   it('should export ActionTypeToActionHeaderType mapping', () => {
     expect(ActionTypeToActionHeaderType[NanoContractActionType.DEPOSIT]).toBe(
-      NanoContractHeaderActionType.DEPOSIT
+      NanoContractHeaderActionType.DEPOSIT,
     );
     expect(ActionTypeToActionHeaderType[NanoContractActionType.WITHDRAWAL]).toBe(
-      NanoContractHeaderActionType.WITHDRAWAL
+      NanoContractHeaderActionType.WITHDRAWAL,
     );
   });
 

--- a/__tests__/headers/fee.test.ts
+++ b/__tests__/headers/fee.test.ts
@@ -6,10 +6,10 @@
  */
 
 import FeeHeader from '../../src/headers/fee';
-import Transaction from '../../src/models/transaction';
-import Network from '../../src/models/network';
-import { IFeeEntry } from '../../src/types';
 import { VertexHeaderId, getVertexHeaderIdBuffer } from '../../src/headers/types';
+import Network from '../../src/models/network';
+import Transaction from '../../src/models/transaction';
+import { IFeeEntry } from '../../src/types';
 
 describe('FeeHeader', () => {
   const network = new Network('testnet');

--- a/__tests__/integration/adapters/fullnode.adapter.ts
+++ b/__tests__/integration/adapters/fullnode.adapter.ts
@@ -6,15 +6,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type Transaction from '../../../src/models/transaction';
+import type { WalletStopOptions } from '../../../src/new/types';
 import HathorWallet from '../../../src/new/wallet';
-import { WalletTracker } from '../utils/wallet-tracker.util';
 import {
   AddressScanPolicyData,
   AuthorityType,
   SCANNING_POLICY,
   WalletState,
 } from '../../../src/types';
-import type Transaction from '../../../src/models/transaction';
+import type { FullNodeTxResponse } from '../../../src/wallet/types';
+import { FULLNODE_URL, NETWORK_NAME } from '../configuration/test-constants';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
+import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
 import {
   generateConnection,
   waitForWalletReady,
@@ -23,11 +28,9 @@ import {
   DEFAULT_PASSWORD,
   DEFAULT_PIN_CODE,
 } from '../helpers/wallet.helper';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
-import type { WalletStopOptions } from '../../../src/new/types';
-import { FULLNODE_URL, NETWORK_NAME } from '../configuration/test-constants';
-import type { FullNodeTxResponse } from '../../../src/wallet/types';
+import { getGapLimitConfig } from '../utils/core.util';
+import { WalletTracker } from '../utils/wallet-tracker.util';
+
 import type {
   FuzzyWalletType,
   IWalletTestAdapter,
@@ -47,8 +50,6 @@ import type {
   DelegateAuthorityAdapterOptions,
   DelegateAuthorityResult,
 } from './types';
-import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
-import { getGapLimitConfig } from '../utils/core.util';
 
 /** Stop options shared between {@link stopWallet} and the {@link WalletTracker}. */
 const STOP_OPTIONS: WalletStopOptions = { cleanStorage: true, cleanAddresses: true };
@@ -147,7 +148,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
 
   async startWallet(
     wallet: FuzzyWalletType,
-    options?: { pinCode?: string; password?: string }
+    options?: { pinCode?: string; password?: string },
   ): Promise<void> {
     await this.concrete(wallet).start({
       pinCode: options?.pinCode,
@@ -172,7 +173,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
   async injectFunds(
     destWallet: FuzzyWalletType,
     address: string,
-    amount: bigint
+    amount: bigint,
   ): Promise<Transaction> {
     return GenesisWalletHelper.injectFunds(this.concrete(destWallet), address, amount);
   }
@@ -196,7 +197,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
   async waitForTx(
     wallet: FuzzyWalletType,
     txId: string,
-    recvWallet?: FuzzyWalletType
+    recvWallet?: FuzzyWalletType,
   ): Promise<void> {
     const hWallet = this.concrete(wallet);
     await waitForTxReceived(hWallet, txId);
@@ -215,7 +216,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
     wallet: FuzzyWalletType,
     address: string,
     amount: bigint,
-    options?: SendTransactionOptions
+    options?: SendTransactionOptions,
   ): Promise<SendTransactionResult> {
     const hWallet = this.concrete(wallet);
     const { recvWallet, ...txOptions } = options ?? {};
@@ -249,7 +250,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
     name: string,
     symbol: string,
     amount: bigint,
-    options?: CreateTokenOptions
+    options?: CreateTokenOptions,
   ): Promise<CreateTokenResult> {
     const hWallet = this.concrete(wallet);
     const result = await hWallet.createNewToken(name, symbol, amount, {
@@ -266,7 +267,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
 
   async getUtxos(
     wallet: FuzzyWalletType,
-    options?: GetUtxosAdapterOptions
+    options?: GetUtxosAdapterOptions,
   ): Promise<GetUtxosResult> {
     const result = await this.concrete(wallet).getUtxos(options);
     return {
@@ -279,7 +280,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
   async sendManyOutputsTransaction(
     wallet: FuzzyWalletType,
     outputs: AdapterOutput[],
-    options?: SendManyOutputsAdapterOptions
+    options?: SendManyOutputsAdapterOptions,
   ): Promise<SendTransactionResult> {
     const hWallet = this.concrete(wallet);
     const { recvWallet, ...txOptions } = options ?? {};
@@ -298,7 +299,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
     wallet: FuzzyWalletType,
     tokenUid: string,
     type: AuthorityType,
-    options?: GetAuthorityUtxosOptions
+    options?: GetAuthorityUtxosOptions,
   ): Promise<AuthorityUtxoResult[]> {
     const hWallet = this.concrete(wallet);
     const utxos = await hWallet.getAuthorityUtxo(tokenUid, type, {
@@ -318,7 +319,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
     tokenUid: string,
     type: AuthorityType,
     destinationAddress: string,
-    options?: DelegateAuthorityAdapterOptions
+    options?: DelegateAuthorityAdapterOptions,
   ): Promise<DelegateAuthorityResult> {
     const hWallet = this.concrete(wallet);
     const result = await hWallet.delegateAuthority(tokenUid, type, destinationAddress, {
@@ -358,7 +359,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
 
   private buildConfig(
     walletData: { words?: string; addresses?: string[] },
-    options?: CreateWalletOptions
+    options?: CreateWalletOptions,
   ) {
     // xpub/xpriv and seed are mutually exclusive in HathorWallet's constructor.
     // When both are provided (e.g. shared readonly tests pass seed for service

--- a/__tests__/integration/adapters/service.adapter.ts
+++ b/__tests__/integration/adapters/service.adapter.ts
@@ -7,10 +7,15 @@
  */
 
 import { HathorWalletServiceWallet } from '../../../src';
-import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import config from '../../../src/config';
-import { WalletTracker } from '../utils/wallet-tracker.util';
+import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import type Transaction from '../../../src/models/transaction';
+import type { WalletStopOptions } from '../../../src/new/types';
+import type { IHistoryTx } from '../../../src/types';
+import { AuthorityType } from '../../../src/types';
+import type { FullNodeTxResponse } from '../../../src/wallet/types';
+import { NETWORK_NAME } from '../configuration/test-constants';
+import { GenesisWalletServiceHelper } from '../helpers/genesis-wallet.helper';
 import {
   buildWalletInstance,
   initializeServiceGlobalConfigs,
@@ -18,13 +23,10 @@ import {
   pollForTokenDetails,
   pollUntilCondition,
 } from '../helpers/service-facade.helper';
-import { GenesisWalletServiceHelper } from '../helpers/genesis-wallet.helper';
 import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
-import type { WalletStopOptions } from '../../../src/new/types';
-import type { IHistoryTx } from '../../../src/types';
-import { AuthorityType } from '../../../src/types';
-import { NETWORK_NAME } from '../configuration/test-constants';
-import type { FullNodeTxResponse } from '../../../src/wallet/types';
+import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
+import { WalletTracker } from '../utils/wallet-tracker.util';
+
 import type {
   FuzzyWalletType,
   IWalletTestAdapter,
@@ -44,7 +46,6 @@ import type {
   DelegateAuthorityAdapterOptions,
   DelegateAuthorityResult,
 } from './types';
-import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
 
 const SERVICE_PIN = '123456';
 const SERVICE_PASSWORD = 'testpass';
@@ -168,7 +169,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
 
   async startWallet(
     wallet: FuzzyWalletType,
-    options?: { pinCode?: string; password?: string }
+    options?: { pinCode?: string; password?: string },
   ): Promise<void> {
     const sw = this.concrete(wallet);
 
@@ -204,7 +205,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
   async injectFunds(
     destWallet: FuzzyWalletType,
     address: string,
-    amount: bigint
+    amount: bigint,
   ): Promise<Transaction> {
     return GenesisWalletServiceHelper.injectFunds(address, amount, this.concrete(destWallet));
   }
@@ -228,7 +229,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
   async waitForTx(
     wallet: FuzzyWalletType,
     txId: string,
-    recvWallet?: FuzzyWalletType
+    recvWallet?: FuzzyWalletType,
   ): Promise<void> {
     await pollForTx(this.concrete(wallet), txId);
     if (recvWallet) {
@@ -244,7 +245,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
     wallet: FuzzyWalletType,
     address: string,
     amount: bigint,
-    options?: SendTransactionOptions
+    options?: SendTransactionOptions,
   ): Promise<SendTransactionResult> {
     const sw = this.concrete(wallet);
     const { recvWallet, ...txOptions } = options ?? {};
@@ -289,7 +290,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
     name: string,
     symbol: string,
     amount: bigint,
-    options?: CreateTokenOptions
+    options?: CreateTokenOptions,
   ): Promise<CreateTokenResult> {
     const sw = this.concrete(wallet);
     const result = await sw.createNewToken(name, symbol, amount, {
@@ -306,7 +307,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
 
   async getUtxos(
     wallet: FuzzyWalletType,
-    options?: GetUtxosAdapterOptions
+    options?: GetUtxosAdapterOptions,
   ): Promise<GetUtxosResult> {
     const result = await this.concrete(wallet).getUtxos(options);
     return {
@@ -319,7 +320,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
   async sendManyOutputsTransaction(
     wallet: FuzzyWalletType,
     outputs: AdapterOutput[],
-    options?: SendManyOutputsAdapterOptions
+    options?: SendManyOutputsAdapterOptions,
   ): Promise<SendTransactionResult> {
     const sw = this.concrete(wallet);
     const { recvWallet, ...txOptions } = options ?? {};
@@ -338,7 +339,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
     wallet: FuzzyWalletType,
     tokenUid: string,
     type: AuthorityType,
-    options?: GetAuthorityUtxosOptions
+    options?: GetAuthorityUtxosOptions,
   ): Promise<AuthorityUtxoResult[]> {
     const sw = this.concrete(wallet);
     const utxos = await sw.getAuthorityUtxo(tokenUid, type, {
@@ -359,7 +360,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
     tokenUid: string,
     type: AuthorityType,
     destinationAddress: string,
-    options?: DelegateAuthorityAdapterOptions
+    options?: DelegateAuthorityAdapterOptions,
   ): Promise<DelegateAuthorityResult> {
     const sw = this.concrete(wallet);
     const result = await sw.delegateAuthority(tokenUid, type, destinationAddress, {

--- a/__tests__/integration/adapters/types.ts
+++ b/__tests__/integration/adapters/types.ts
@@ -6,11 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { IHathorWallet, FullNodeTxResponse } from '../../../src/wallet/types';
-import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
+import { HathorWallet, HathorWalletServiceWallet } from '../../../src';
 import type Transaction from '../../../src/models/transaction';
 import type { IHistoryTx, IStorage, TokenVersion, AuthorityType } from '../../../src/types';
-import { HathorWallet, HathorWalletServiceWallet } from '../../../src';
+import type { IHathorWallet, FullNodeTxResponse } from '../../../src/wallet/types';
+import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
 
 /**
  * The codebase has three overlapping wallet types: the {@link IHathorWallet} interface
@@ -138,7 +138,7 @@ export interface IWalletTestAdapter {
    */
   startWallet(
     wallet: FuzzyWalletType,
-    options?: { pinCode?: string; password?: string }
+    options?: { pinCode?: string; password?: string },
   ): Promise<void>;
 
   /**
@@ -188,7 +188,7 @@ export interface IWalletTestAdapter {
     wallet: FuzzyWalletType,
     address: string,
     amount: bigint,
-    options?: SendTransactionOptions
+    options?: SendTransactionOptions,
   ): Promise<SendTransactionResult>;
 
   /**
@@ -214,7 +214,7 @@ export interface IWalletTestAdapter {
     name: string,
     symbol: string,
     amount: bigint,
-    options?: CreateTokenOptions
+    options?: CreateTokenOptions,
   ): Promise<CreateTokenResult>;
 
   // --- UTXO queries ---
@@ -234,7 +234,7 @@ export interface IWalletTestAdapter {
   sendManyOutputsTransaction(
     wallet: FuzzyWalletType,
     outputs: AdapterOutput[],
-    options?: SendManyOutputsAdapterOptions
+    options?: SendManyOutputsAdapterOptions,
   ): Promise<SendTransactionResult>;
 
   // --- Authority UTXOs ---
@@ -247,7 +247,7 @@ export interface IWalletTestAdapter {
     wallet: FuzzyWalletType,
     tokenUid: string,
     type: AuthorityType,
-    options?: GetAuthorityUtxosOptions
+    options?: GetAuthorityUtxosOptions,
   ): Promise<AuthorityUtxoResult[]>;
 
   // --- Authority delegation ---
@@ -261,7 +261,7 @@ export interface IWalletTestAdapter {
     tokenUid: string,
     type: AuthorityType,
     destinationAddress: string,
-    options?: DelegateAuthorityAdapterOptions
+    options?: DelegateAuthorityAdapterOptions,
   ): Promise<DelegateAuthorityResult>;
 }
 

--- a/__tests__/integration/api.test.ts
+++ b/__tests__/integration/api.test.ts
@@ -13,7 +13,7 @@ describe('Feature api', () => {
         expect.objectContaining({
           name: 'INCREASE_MAX_MERKLE_PATH_LENGTH',
         }),
-      ])
+      ]),
     );
   });
 

--- a/__tests__/integration/atomic_swap.test.ts
+++ b/__tests__/integration/atomic_swap.test.ts
@@ -1,3 +1,7 @@
+import { NATIVE_TOKEN_UID } from '../../src/constants';
+import SendTransaction from '../../src/new/sendTransaction';
+import PartialTxProposal from '../../src/wallet/partialTxProposal';
+
 import { GenesisWalletHelper } from './helpers/genesis-wallet.helper';
 import {
   createTokenHelper,
@@ -7,9 +11,6 @@ import {
   waitForTxReceived,
 } from './helpers/wallet.helper';
 import { loggers } from './utils/logger.util';
-import { NATIVE_TOKEN_UID } from '../../src/constants';
-import SendTransaction from '../../src/new/sendTransaction';
-import PartialTxProposal from '../../src/wallet/partialTxProposal';
 
 describe('partial tx proposal', () => {
   afterEach(async () => {

--- a/__tests__/integration/fullnode-specific/authority-utxos.test.ts
+++ b/__tests__/integration/fullnode-specific/authority-utxos.test.ts
@@ -15,6 +15,9 @@
  * Shared authority UTXO tests live in `shared/authority-utxos.test.ts`.
  */
 
+import { TOKEN_MINT_MASK, TOKEN_MELT_MASK } from '../../../src/constants';
+import HathorWallet from '../../../src/new/wallet';
+import { AuthorityType } from '../../../src/types';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import {
   createTokenHelper,
@@ -22,9 +25,6 @@ import {
   stopAllWallets,
   waitForTxReceived,
 } from '../helpers/wallet.helper';
-import { TOKEN_MINT_MASK, TOKEN_MELT_MASK } from '../../../src/constants';
-import HathorWallet from '../../../src/new/wallet';
-import { AuthorityType } from '../../../src/types';
 
 describe('[Fullnode] getAuthorityUtxos — fullnode-specific', () => {
   let hWallet: HathorWallet;
@@ -37,7 +37,7 @@ describe('[Fullnode] getAuthorityUtxos — fullnode-specific', () => {
       hWallet,
       'getAuthorityUtxos Token',
       'GAUT',
-      100n
+      100n,
     );
     tokenHash = tokenUid;
   });
@@ -77,7 +77,7 @@ describe('[Fullnode] getAuthorityUtxos — fullnode-specific', () => {
 
   it('should throw on invalid authority type', async () => {
     await expect(hWallet.getAuthorityUtxos(tokenHash, 'invalid' as AuthorityType)).rejects.toThrow(
-      'This should never happen.'
+      'This should never happen.',
     );
   });
 
@@ -88,7 +88,7 @@ describe('[Fullnode] getAuthorityUtxos — fullnode-specific', () => {
       tokenHash,
       AuthorityType.MELT,
       await hWallet.getAddressAtIndex(1),
-      { createAnother: true }
+      { createAnother: true },
     );
     await waitForTxReceived(hWallet, meltDelegationTx!.hash!);
 
@@ -115,7 +115,7 @@ describe('[Fullnode] getAuthorityUtxos — fullnode-specific', () => {
       tokenHash,
       AuthorityType.MINT,
       await hWallet.getAddressAtIndex(2),
-      { createAnother: true }
+      { createAnother: true },
     );
     await waitForTxReceived(hWallet, mintDelegationTx!.hash!);
 
@@ -150,12 +150,12 @@ describe('[Fullnode] authority utxo selection', () => {
       mintInput,
     ]);
     await expect(
-      hWallet.getMintAuthority(tokenUid, { many: false, only_available_utxos: false })
+      hWallet.getMintAuthority(tokenUid, { many: false, only_available_utxos: false }),
     ).resolves.toStrictEqual([mintInput]);
 
     // getMintAuthority should not return selected_as_input utxos if only_available_utxos is true
     await expect(
-      hWallet.getMintAuthority(tokenUid, { many: false, only_available_utxos: true })
+      hWallet.getMintAuthority(tokenUid, { many: false, only_available_utxos: true }),
     ).resolves.toStrictEqual([]);
   });
 
@@ -173,12 +173,12 @@ describe('[Fullnode] authority utxo selection', () => {
       meltInput,
     ]);
     await expect(
-      hWallet.getMeltAuthority(tokenUid, { many: false, only_available_utxos: false })
+      hWallet.getMeltAuthority(tokenUid, { many: false, only_available_utxos: false }),
     ).resolves.toStrictEqual([meltInput]);
 
     // getMeltAuthority should not return selected_as_input utxos if only_available_utxos is true
     await expect(
-      hWallet.getMeltAuthority(tokenUid, { many: false, only_available_utxos: true })
+      hWallet.getMeltAuthority(tokenUid, { many: false, only_available_utxos: true }),
     ).resolves.toStrictEqual([]);
   });
 });

--- a/__tests__/integration/fullnode-specific/get-balance.test.ts
+++ b/__tests__/integration/fullnode-specific/get-balance.test.ts
@@ -15,8 +15,8 @@
  */
 
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import { getRandomInt } from '../utils/core.util';
 import { createTokenHelper, generateWalletHelper, stopAllWallets } from '../helpers/wallet.helper';
+import { getRandomInt } from '../utils/core.util';
 
 const fakeTokenUid = '008a19f84f2ae284f19bf3d03386c878ddd15b8b0b604a3a3539aa9d714686e1';
 
@@ -51,7 +51,7 @@ describe('[Fullnode] getBalance', () => {
       hWallet,
       'BalanceToken',
       'BAT',
-      newTokenAmount
+      newTokenAmount,
     );
 
     const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();

--- a/__tests__/integration/fullnode-specific/nano_utxo_lock_unlock.test.ts
+++ b/__tests__/integration/fullnode-specific/nano_utxo_lock_unlock.test.ts
@@ -6,6 +6,11 @@
  */
 
 import { isEmpty } from 'lodash';
+
+import { SendTransaction } from '../../../src';
+import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+import { NanoContractTransactionError } from '../../../src/errors';
+import HathorWallet from '../../../src/new/wallet';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import {
   generateWalletHelper,
@@ -13,10 +18,6 @@ import {
   waitForTxReceived,
   waitTxConfirmed,
 } from '../helpers/wallet.helper';
-import HathorWallet from '../../../src/new/wallet';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
-import { NanoContractTransactionError } from '../../../src/errors';
-import { SendTransaction } from '../../../src';
 
 describe('Nano contract UTXO lock/unlock lifecycle', () => {
   let hWallet: HathorWallet;
@@ -52,7 +53,7 @@ describe('Nano contract UTXO lock/unlock lifecycle', () => {
             changeAddress: address,
           },
         ],
-      }
+      },
     );
     await checkTxValid(hWallet, initTx);
     contractId = initTx.hash!;
@@ -91,7 +92,7 @@ describe('Nano contract UTXO lock/unlock lifecycle', () => {
             },
           ],
         },
-        { signTx: false }
+        { signTx: false },
       );
       activeSendTx = sendTx1;
 
@@ -115,8 +116,8 @@ describe('Nano contract UTXO lock/unlock lifecycle', () => {
               },
             ],
           },
-          { signTx: false }
-        )
+          { signTx: false },
+        ),
       ).rejects.toThrow(NanoContractTransactionError);
 
       // Step 3: Release locked UTXOs
@@ -139,7 +140,7 @@ describe('Nano contract UTXO lock/unlock lifecycle', () => {
             },
           ],
         },
-        { signTx: false }
+        { signTx: false },
       );
       activeSendTx = sendTx3;
 

--- a/__tests__/integration/fullnode-specific/send-transaction.test.ts
+++ b/__tests__/integration/fullnode-specific/send-transaction.test.ts
@@ -23,6 +23,10 @@
  * indexed, making `numTransactions` assertions impossible.
  */
 
+import { NATIVE_TOKEN_UID } from '../../../src/constants';
+import SendTransaction from '../../../src/new/sendTransaction';
+import { TokenVersion } from '../../../src/types';
+import transaction from '../../../src/utils/transaction';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import {
   DEFAULT_PIN_CODE,
@@ -33,10 +37,6 @@ import {
   waitUntilNextTimestamp,
   createTokenHelper,
 } from '../helpers/wallet.helper';
-import { NATIVE_TOKEN_UID } from '../../../src/constants';
-import { TokenVersion } from '../../../src/types';
-import SendTransaction from '../../../src/new/sendTransaction';
-import transaction from '../../../src/utils/transaction';
 
 describe('[Fullnode] sendTransaction — address tracking', () => {
   afterEach(async () => {
@@ -64,19 +64,19 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(0))).toHaveProperty(
       'numTransactions',
-      2
+      2,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(1))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(2))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(3))).toHaveProperty(
       'numTransactions',
-      0
+      0,
     );
 
     const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
@@ -84,7 +84,7 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
     const { hash: tx2Hash } = await hWallet.sendTransaction(
       await gWallet.getAddressAtIndex(0),
       8n,
-      { changeAddress: await hWallet.getAddressAtIndex(5) }
+      { changeAddress: await hWallet.getAddressAtIndex(5) },
     );
     await waitForTxReceived(hWallet, tx2Hash);
 
@@ -93,11 +93,11 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(6))).toHaveProperty(
       'numTransactions',
-      0
+      0,
     );
   });
 
@@ -114,11 +114,11 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(6))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
 
     const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
@@ -126,20 +126,20 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
     const { hash: tx2Hash } = await hWallet.sendTransaction(
       await gWallet.getAddressAtIndex(0),
       80n,
-      { token: tokenUid, changeAddress: await hWallet.getAddressAtIndex(12) }
+      { token: tokenUid, changeAddress: await hWallet.getAddressAtIndex(12) },
     );
     await waitForTxReceived(hWallet, tx2Hash);
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(
       'numTransactions',
-      2
+      2,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(6))).toHaveProperty(
       'numTransactions',
-      2
+      2,
     );
     expect(
-      await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(12))
+      await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(12)),
     ).toHaveProperty('numTransactions', 1);
   });
 
@@ -158,11 +158,11 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(6))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
 
     const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
@@ -170,20 +170,20 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
     const { hash: tx2Hash } = await hWallet.sendTransaction(
       await gWallet.getAddressAtIndex(0),
       82n,
-      { token: tokenUid, changeAddress: await hWallet.getAddressAtIndex(12) }
+      { token: tokenUid, changeAddress: await hWallet.getAddressAtIndex(12) },
     );
     await waitForTxReceived(hWallet, tx2Hash);
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(
       'numTransactions',
-      1
+      1,
     );
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(6))).toHaveProperty(
       'numTransactions',
-      2
+      2,
     );
     expect(
-      await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(12))
+      await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(12)),
     ).toHaveProperty('numTransactions', 1);
   });
 });
@@ -214,7 +214,7 @@ describe('[Fullnode] sendTransaction — multisig', () => {
     });
     const tx = transaction.createTransactionFromData(
       { version: 1, ...(await sendTransaction.prepareTxData()) },
-      network
+      network,
     );
     const txHex = tx.toHex();
 

--- a/__tests__/integration/fullnode-specific/start.test.ts
+++ b/__tests__/integration/fullnode-specific/start.test.ts
@@ -15,16 +15,22 @@
  */
 
 import Mnemonic from 'bitcore-mnemonic/lib/mnemonic';
-import HathorWallet from '../../../src/new/wallet';
+
 import { NATIVE_TOKEN_UID, P2PKH_ACCT_PATH } from '../../../src/constants';
-import { ConnectionState } from '../../../src/wallet/types';
 import { WalletFromXPubGuard } from '../../../src/errors';
-import { AuthorityType, TokenVersion } from '../../../src/types';
 import Network from '../../../src/models/network';
+import WalletConnection from '../../../src/new/connection';
+import HathorWallet from '../../../src/new/wallet';
 import { MemoryStore, Storage } from '../../../src/storage';
-import { WalletTracker } from '../utils/wallet-tracker.util';
-import { deriveXpubFromSeed, getGapLimitConfig } from '../utils/core.util';
+import { AuthorityType, TokenVersion } from '../../../src/types';
+import { ConnectionState } from '../../../src/wallet/types';
+import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { WALLET_CONSTANTS } from '../configuration/test-constants';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import {
+  multisigWalletsData,
+  precalculationHelpers,
+} from '../helpers/wallet-precalculation.helper';
 import {
   createTokenHelper,
   DEFAULT_PASSWORD,
@@ -33,13 +39,8 @@ import {
   generateWalletHelper,
   waitForWalletReady,
 } from '../helpers/wallet.helper';
-import {
-  multisigWalletsData,
-  precalculationHelpers,
-} from '../helpers/wallet-precalculation.helper';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import WalletConnection from '../../../src/new/connection';
-import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
+import { deriveXpubFromSeed, getGapLimitConfig } from '../utils/core.util';
+import { WalletTracker } from '../utils/wallet-tracker.util';
 
 const fakeTokenUid = '008a19f84f2ae284f19bf3d03386c878ddd15b8b0b604a3a3539aa9d714686e1';
 
@@ -80,7 +81,7 @@ describe('[Fullnode-specific] start', () => {
           seed: walletData.words,
           password: DEFAULT_PASSWORD,
           pinCode: DEFAULT_PIN_CODE,
-        })
+        }),
     ).toThrow('provide a connection');
 
     // Missing seed/xpub/xpriv
@@ -90,7 +91,7 @@ describe('[Fullnode-specific] start', () => {
           connection,
           password: DEFAULT_PASSWORD,
           pinCode: DEFAULT_PIN_CODE,
-        })
+        }),
     ).toThrow('seed');
 
     // Both seed and xpriv
@@ -102,7 +103,7 @@ describe('[Fullnode-specific] start', () => {
           connection,
           password: DEFAULT_PASSWORD,
           pinCode: DEFAULT_PIN_CODE,
-        })
+        }),
     ).toThrow('seed and an xpriv');
 
     // xpriv with passphrase
@@ -113,7 +114,7 @@ describe('[Fullnode-specific] start', () => {
           connection,
           passphrase: DEFAULT_PASSWORD,
           pinCode: DEFAULT_PIN_CODE,
-        })
+        }),
     ).toThrow('xpriv with passphrase');
 
     // Already-connected connection
@@ -130,7 +131,7 @@ describe('[Fullnode-specific] start', () => {
           } as Partial<WalletConnection>,
           password: DEFAULT_PASSWORD,
           pinCode: DEFAULT_PIN_CODE,
-        })
+        }),
     ).toThrow('share connections');
 
     // Invalid multisig config (empty)
@@ -143,7 +144,7 @@ describe('[Fullnode-specific] start', () => {
           pinCode: DEFAULT_PIN_CODE,
           // @ts-expect-error -- Deliberately passing empty config to test rejection
           multisig: {},
-        })
+        }),
     ).toThrow('pubkeys and numSignatures');
 
     // Invalid multisig config (numSignatures > pubkeys.length)
@@ -155,7 +156,7 @@ describe('[Fullnode-specific] start', () => {
           password: DEFAULT_PASSWORD,
           pinCode: DEFAULT_PIN_CODE,
           multisig: { pubkeys: ['abc'], numSignatures: 2 },
-        })
+        }),
     ).toThrow('configuration invalid');
   });
 
@@ -242,7 +243,7 @@ describe('[Fullnode-specific] start', () => {
       hWallet,
       'Dedicated Wallet Token',
       'DWT',
-      100n
+      100n,
     );
 
     await hWallet.stop({ cleanStorage: true, cleanAddresses: true });
@@ -321,7 +322,7 @@ describe('[Fullnode-specific] start', () => {
     await expect(w.signTx()).rejects.toThrow(WalletFromXPubGuard);
     await expect(w.createAndSendNanoContractTransaction()).rejects.toThrow(WalletFromXPubGuard);
     await expect(w.createAndSendNanoContractCreateTokenTransaction()).rejects.toThrow(
-      WalletFromXPubGuard
+      WalletFromXPubGuard,
     );
     await expect(w.getPrivateKeyFromAddress()).rejects.toThrow(WalletFromXPubGuard);
     await expect(w.createOnChainBlueprintTransaction()).rejects.toThrow(WalletFromXPubGuard);
@@ -387,7 +388,7 @@ describe('[Fullnode-specific] start', () => {
     await expect(
       hWallet.sendManyOutputsTransaction([
         { address: await hWallet.getAddressAtIndex(1), value: 1n, token: NATIVE_TOKEN_UID },
-      ])
+      ]),
     ).rejects.toThrow('Pin');
 
     await expect(hWallet.createNewToken('Pinless Token', 'PTT', 100n)).rejects.toThrow('Pin');
@@ -400,12 +401,12 @@ describe('[Fullnode-specific] start', () => {
       hWallet.delegateAuthority(
         fakeTokenUid,
         AuthorityType.MINT,
-        await hWallet.getAddressAtIndex(1)
-      )
+        await hWallet.getAddressAtIndex(1),
+      ),
     ).rejects.toThrow('Pin');
 
     await expect(hWallet.destroyAuthority(fakeTokenUid, AuthorityType.MINT, 1)).rejects.toThrow(
-      'Pin'
+      'Pin',
     );
 
     await hWallet.stop({ cleanStorage: true, cleanAddresses: true });

--- a/__tests__/integration/hathorwallet_facade.test.ts
+++ b/__tests__/integration/hathorwallet_facade.test.ts
@@ -1,5 +1,22 @@
+import {
+  NATIVE_TOKEN_UID,
+  TOKEN_MELT_MASK,
+  TOKEN_MINT_MASK,
+  TOKEN_AUTHORITY_MASK,
+} from '../../src/constants';
+import { NftValidationError, TxNotFoundError } from '../../src/errors';
+import Header from '../../src/headers/base';
+import FeeHeader from '../../src/headers/fee';
+import CreateTokenTransaction from '../../src/models/create_token_transaction';
+import SendTransaction from '../../src/new/sendTransaction';
+import { TransactionTemplateBuilder } from '../../src/template/transaction';
+import { WalletType, TokenVersion } from '../../src/types';
+import { verifyMessage } from '../../src/utils/crypto';
+import { parseScriptData } from '../../src/utils/scripts';
+import transaction from '../../src/utils/transaction';
+
+import { TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test-constants';
 import { GenesisWalletHelper } from './helpers/genesis-wallet.helper';
-import { delay, getRandomInt } from './utils/core.util';
 import {
   createTokenHelper,
   DEFAULT_PIN_CODE,
@@ -10,23 +27,7 @@ import {
   waitForTxReceived,
   waitUntilNextTimestamp,
 } from './helpers/wallet.helper';
-import {
-  NATIVE_TOKEN_UID,
-  TOKEN_MELT_MASK,
-  TOKEN_MINT_MASK,
-  TOKEN_AUTHORITY_MASK,
-} from '../../src/constants';
-import { TOKEN_DATA, WALLET_CONSTANTS } from './configuration/test-constants';
-import { verifyMessage } from '../../src/utils/crypto';
-import { NftValidationError, TxNotFoundError } from '../../src/errors';
-import SendTransaction from '../../src/new/sendTransaction';
-import transaction from '../../src/utils/transaction';
-import { WalletType, TokenVersion } from '../../src/types';
-import { parseScriptData } from '../../src/utils/scripts';
-import { TransactionTemplateBuilder } from '../../src/template/transaction';
-import FeeHeader from '../../src/headers/fee';
-import Header from '../../src/headers/base';
-import CreateTokenTransaction from '../../src/models/create_token_transaction';
+import { delay, getRandomInt } from './utils/core.util';
 
 const fakeTokenUid = '008a19f84f2ae284f19bf3d03386c878ddd15b8b0b604a3a3539aa9d714686e1';
 const sampleNftData =
@@ -97,7 +98,7 @@ describe('template methods', () => {
           value: 9n,
           tokenData: 0,
         }),
-      ])
+      ]),
     );
   });
 });
@@ -183,7 +184,7 @@ describe('getTxById', () => {
     const firstTokenDetails = result.txTokens[0];
     const tokenDetailsKeys = Object.keys(firstTokenDetails);
     expect(tokenDetailsKeys.join(',')).toStrictEqual(
-      'txId,timestamp,version,voided,weight,tokenId,tokenName,tokenSymbol,balance'
+      'txId,timestamp,version,voided,weight,tokenId,tokenName,tokenSymbol,balance',
     );
 
     expect(firstTokenDetails.txId).toStrictEqual(tx1.hash);
@@ -206,7 +207,7 @@ describe('getTxById', () => {
       },
     });
     await expect(hWallet.getTxById(tx1.hash)).rejects.toThrow(
-      'Invalid token_data undefined, token not found in tokens list'
+      'Invalid token_data undefined, token not found in tokens list',
     );
     jest.spyOn(hWallet, 'getFullTxById').mockRestore();
 
@@ -215,7 +216,7 @@ describe('getTxById', () => {
       'unknown-token': 10n,
     });
     await expect(hWallet.getTxById(tx1.hash)).rejects.toThrow(
-      'Token unknown-token not found in tx'
+      'Token unknown-token not found in tx',
     );
     jest.spyOn(hWallet, 'getTxBalance').mockRestore();
   });
@@ -223,7 +224,7 @@ describe('getTxById', () => {
   it('should throw an error tx id is invalid', async () => {
     const hWallet = await generateWalletHelper();
     await expect(hWallet.getTxById('invalid-tx-hash')).rejects.toThrow(
-      'Invalid transaction invalid-tx-hash'
+      'Invalid transaction invalid-tx-hash',
     );
   });
 
@@ -252,7 +253,7 @@ describe('getTxById', () => {
       hWallet,
       'BalanceToken',
       'BAT',
-      newTokenAmount
+      newTokenAmount,
     );
     // Get the balance of the new token
     await delay(1000);
@@ -284,7 +285,7 @@ describe('getTxById', () => {
           tokenId: tokenUid,
           balance: newTokenAmount,
         }),
-      ])
+      ]),
     );
 
     // Test case: non-accessible token for another wallet (genesis)
@@ -394,7 +395,7 @@ describe('addresses methods', () => {
       const addressHDPrivKey = await hWallet.getAddressPrivKey(DEFAULT_PIN_CODE, i);
       // Validate that it's from the same address:
       expect(
-        addressHDPrivKey.privateKey.toAddress(hWallet.getNetworkObject().bitcoreNetwork).toString()
+        addressHDPrivKey.privateKey.toAddress(hWallet.getNetworkObject().bitcoreNetwork).toString(),
       ).toStrictEqual(await hWallet.getAddressAtIndex(i));
     }
   });
@@ -409,7 +410,7 @@ describe('addresses methods', () => {
       const signedMessage = await hWallet.signMessageWithAddress(
         messageToSign,
         i,
-        DEFAULT_PIN_CODE
+        DEFAULT_PIN_CODE,
       );
 
       expect(verifyMessage(messageToSign, signedMessage, address)).toStrictEqual(true);
@@ -421,12 +422,12 @@ describe('addresses methods', () => {
 
     // We will assume the wallet never received txs, which is to be expected for the addresses test
     expect((await mshWallet.getCurrentAddress()).address).toStrictEqual(
-      WALLET_CONSTANTS.multisig.addresses[0]
+      WALLET_CONSTANTS.multisig.addresses[0],
     );
 
     for (let i = 0; i < 21; ++i) {
       expect(await mshWallet.getAddressAtIndex(i)).toStrictEqual(
-        WALLET_CONSTANTS.multisig.addresses[i]
+        WALLET_CONSTANTS.multisig.addresses[i],
       );
     }
   });
@@ -474,7 +475,7 @@ describe('getFullHistory', () => {
     const { hash: fundTxId } = await GenesisWalletHelper.injectFunds(
       hWallet,
       fundDestinationAddress,
-      10n
+      10n,
     );
 
     // Validating the full history increased in one
@@ -618,7 +619,7 @@ describe('getTxBalance', () => {
     const { hash: tx1Hash } = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
 
     // Validating tx balance for a transaction with a single token (htr)
@@ -648,7 +649,7 @@ describe('getTxBalance', () => {
     const { hash: delegateTxHash } = await hWallet.delegateAuthority(
       tokenUid,
       'mint',
-      await hWallet.getAddressAtIndex(0)
+      await hWallet.getAddressAtIndex(0),
     );
 
     // By default this tx will not have a balance
@@ -703,7 +704,7 @@ describe('getFullTxById', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
 
     const fullTx = await hWallet.getFullTxById(tx1.hash);
@@ -718,13 +719,13 @@ describe('getFullTxById', () => {
 
   it('should throw an error if success is false on response', async () => {
     await expect(gWallet.getFullTxById('invalid-tx-hash')).rejects.toThrow(
-      `Invalid transaction invalid-tx-hash`
+      `Invalid transaction invalid-tx-hash`,
     );
   });
 
   it('should throw an error on valid but not found transaction', async () => {
     await expect(
-      gWallet.getFullTxById('0011371a7c07f7e8017c52c0a4f5293ccf30c865d96255d1b515f96f7a6a6299')
+      gWallet.getFullTxById('0011371a7c07f7e8017c52c0a4f5293ccf30c865d96255d1b515f96f7a6a6299'),
     ).rejects.toThrow(TxNotFoundError);
   });
 });
@@ -747,7 +748,7 @@ describe('getTxConfirmationData', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
 
     const confirmationData = await hWallet.getTxConfirmationData(tx1.hash);
@@ -763,15 +764,15 @@ describe('getTxConfirmationData', () => {
 
   it('should throw an error if success is false on response', async () => {
     await expect(gWallet.getTxConfirmationData('invalid-tx-hash')).rejects.toThrow(
-      `Invalid transaction invalid-tx-hash`
+      `Invalid transaction invalid-tx-hash`,
     );
   });
 
   it('should throw TxNotFoundError on valid hash but not found transaction', async () => {
     await expect(
       gWallet.getTxConfirmationData(
-        '000000000bc8c6fab1b3a5af184cc0e7ff7934c6ad982c8bea9ab5006ae1bafc'
-      )
+        '000000000bc8c6fab1b3a5af184cc0e7ff7934c6ad982c8bea9ab5006ae1bafc',
+      ),
     ).rejects.toThrow(TxNotFoundError);
   });
 });
@@ -793,7 +794,7 @@ describe('graphvizNeighborsQuery', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
     const neighborsData = await hWallet.graphvizNeighborsQuery(tx1.hash, 'funds', 1);
 
@@ -805,25 +806,25 @@ describe('graphvizNeighborsQuery', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
 
     await expect(hWallet.graphvizNeighborsQuery(tx1.hash)).rejects.toThrow(
-      'Request failed with status code 500'
+      'Request failed with status code 500',
     );
   });
 
   it('should throw an error if success is false on response', async () => {
     await expect(gWallet.graphvizNeighborsQuery('invalid-tx-hash')).rejects.toThrow(
-      `Invalid transaction invalid-tx-hash`
+      `Invalid transaction invalid-tx-hash`,
     );
   });
 
   it('should throw TxNotFoundError on valid but not found transaction', async () => {
     await expect(
       gWallet.graphvizNeighborsQuery(
-        '000000000bc8c6fab1b3a5af184cc0e7ff7934c6ad982c8bea9ab5006ae1bafc'
-      )
+        '000000000bc8c6fab1b3a5af184cc0e7ff7934c6ad982c8bea9ab5006ae1bafc',
+      ),
     ).rejects.toThrow(TxNotFoundError);
   });
 });
@@ -843,7 +844,7 @@ const validateFeeAmount = (headers: Header[], amount: bigint) => {
           amount,
         }),
       ]),
-    })
+    }),
   );
 };
 
@@ -983,15 +984,15 @@ describe('createNewToken', () => {
     const { utxos: utxosDbt } = await hWallet.getUtxos({ token: dbtUid });
     const { utxos: utxosFbt } = await hWallet.getUtxos({ token: fbtUid });
     expect(utxosDbt).toContainEqual(
-      expect.objectContaining({ address: destinationAddress, amount: 100n })
+      expect.objectContaining({ address: destinationAddress, amount: 100n }),
     );
     expect(utxosFbt).toContainEqual(
-      expect.objectContaining({ address: destinationAddress, amount: 8582n })
+      expect.objectContaining({ address: destinationAddress, amount: 8582n }),
     );
 
     const { utxos: utxosHtr } = await hWallet.getUtxos();
     expect(utxosHtr).toContainEqual(
-      expect.objectContaining({ address: changeAddress, amount: 8n })
+      expect.objectContaining({ address: changeAddress, amount: 8n }),
     );
   });
 
@@ -1056,11 +1057,11 @@ describe('createNewToken', () => {
 
     const validateAuthorityOutputs = async (
       response: CreateTokenTransaction,
-      expectedAmount: bigint
+      expectedAmount: bigint,
     ) => {
       // Validating a new mint authority was created by default
       const authorityOutputs = response.outputs.filter(o =>
-        transaction.isAuthorityOutput({ token_data: o.tokenData })
+        transaction.isAuthorityOutput({ token_data: o.tokenData }),
       );
       expect(authorityOutputs).toHaveLength(2);
       const mintOutput = authorityOutputs.filter(o => o.value === TOKEN_MINT_MASK);
@@ -1096,14 +1097,14 @@ describe('createNewToken', () => {
       hWallet.createNewToken('New Token', 'NTKN', 100n, {
         createMint: true,
         mintAuthorityAddress: addr2_0,
-      })
+      }),
     ).rejects.toThrow('must belong to your wallet');
 
     await expect(
       hWallet.createNewToken('New Token', 'NTKN', 100n, {
         createMelt: true,
         meltAuthorityAddress: addr2_1,
-      })
+      }),
     ).rejects.toThrow('must belong to your wallet');
 
     // Creating the new token allowing external address
@@ -1123,7 +1124,7 @@ describe('createNewToken', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(o => o.value === TOKEN_MINT_MASK);
@@ -1160,16 +1161,16 @@ describe('mintTokens', () => {
       'FeeBasedToken',
       'FBT',
       8582n,
-      options
+      options,
     );
     await waitForTxReceived(hWallet, fbtUid);
 
     // Should not mint more tokens than the HTR funds allow
     await expect(hWallet.mintTokens(tokenUid, 9000n)).rejects.toThrow(
-      /^Not enough HTR tokens for deposit or fee: 90 required, \d+ available$/
+      /^Not enough HTR tokens for deposit or fee: 90 required, \d+ available$/,
     );
     await expect(hWallet.mintTokens(fbtUid, 9000n)).rejects.toThrow(
-      /^Not enough HTR tokens for deposit or fee: 1 required, \d+ available$/
+      /^Not enough HTR tokens for deposit or fee: 1 required, \d+ available$/,
     );
 
     await GenesisWalletHelper.injectFunds(hWallet, await hWallet.getAddressAtIndex(0), 9n);
@@ -1186,7 +1187,7 @@ describe('mintTokens', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs = mintResponse.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs).toHaveLength(1);
     expect(authorityOutputs[0]).toHaveProperty('value', TOKEN_MINT_MASK);
@@ -1211,7 +1212,7 @@ describe('mintTokens', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs2 = mintResponse2.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs2).toHaveLength(1);
     const authorityOutput = authorityOutputs2[0];
@@ -1230,7 +1231,7 @@ describe('mintTokens', () => {
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
     await expect(
-      hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress })
+      hWallet.mintTokens(tokenUid, 100, { mintAuthorityAddress: externalAddress }),
     ).rejects.toThrow('must belong to your wallet');
 
     // Mint tokens with external address but allowing it
@@ -1248,7 +1249,7 @@ describe('mintTokens', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs4 = mintResponse4.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs4).toHaveLength(1);
     const authorityOutput4 = authorityOutputs4[0];
@@ -1380,7 +1381,7 @@ describe('mintTokens', () => {
           tokenData: TOKEN_AUTHORITY_MASK + 1,
           value: TOKEN_MINT_MASK,
         }),
-      ])
+      ]),
     );
     expect(mintResponse.headers).toEqual(
       expect.arrayContaining([
@@ -1392,7 +1393,7 @@ describe('mintTokens', () => {
             }),
           ]),
         }),
-      ])
+      ]),
     );
     await waitForTxReceived(hWallet, mintResponse.hash);
     expect(await getHtrBalance(hWallet)).toBe(expectedHtrFunds);
@@ -1411,7 +1412,7 @@ describe('mintTokens', () => {
           tokenData: TOKEN_AUTHORITY_MASK + 1,
           value: TOKEN_MINT_MASK,
         }),
-      ])
+      ]),
     );
     validateFeeAmount(mintResponse.headers, 1n);
     expectedHtrFunds -= 1n;
@@ -1435,7 +1436,7 @@ describe('meltTokens', () => {
 
     // Should not melt more than there is available
     await expect(hWallet.meltTokens(tokenUid, 999n)).rejects.toThrow(
-      'Not enough tokens to melt: 999 requested, 500 available'
+      'Not enough tokens to melt: 999 requested, 500 available',
     );
 
     // Melting some tokens
@@ -1457,7 +1458,7 @@ describe('meltTokens', () => {
 
     // Validating a new melt authority was created by default
     const authorityOutputs = meltResponse.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs).toHaveLength(1);
     const authorityOutput = authorityOutputs[0];
@@ -1476,7 +1477,7 @@ describe('meltTokens', () => {
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
     await expect(
-      hWallet.meltTokens(tokenUid, 100n, { meltAuthorityAddress: externalAddress })
+      hWallet.meltTokens(tokenUid, 100n, { meltAuthorityAddress: externalAddress }),
     ).rejects.toThrow('must belong to your wallet');
 
     // Melt tokens with external address but allowing it
@@ -1489,7 +1490,7 @@ describe('meltTokens', () => {
 
     // Validating a new melt authority was created by default
     const authorityOutputs3 = meltResponse3.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs3).toHaveLength(1);
     const authorityOutput3 = authorityOutputs3[0];
@@ -1553,7 +1554,7 @@ describe('meltTokens', () => {
     await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      expectedHtrAmount
+      expectedHtrAmount,
     );
 
     // Creating the token
@@ -1567,7 +1568,7 @@ describe('meltTokens', () => {
 
     // Should not melt more than there is available
     await expect(hWallet.meltTokens(fbtUid, 99999n)).rejects.toThrow(
-      'Not enough tokens to melt: 99999 requested, 8582 available'
+      'Not enough tokens to melt: 99999 requested, 8582 available',
     );
 
     htrBalance = await hWallet.getBalance(NATIVE_TOKEN_UID);
@@ -1602,7 +1603,7 @@ describe('meltTokens', () => {
 
     // Validating a new melt authority was created by default
     const authorityOutputs = meltResponse.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs).toHaveLength(1);
     const authorityOutput = authorityOutputs[0];
@@ -1621,7 +1622,7 @@ describe('meltTokens', () => {
     const externalAddress = await hWallet2.getAddressAtIndex(0);
 
     await expect(
-      hWallet.meltTokens(fbtUid, 100n, { meltAuthorityAddress: externalAddress })
+      hWallet.meltTokens(fbtUid, 100n, { meltAuthorityAddress: externalAddress }),
     ).rejects.toThrow('must belong to your wallet');
 
     // Melt tokens with external address but allowing it
@@ -1639,7 +1640,7 @@ describe('meltTokens', () => {
 
     // Validating a new melt authority was created by default
     const authorityOutputs3 = meltResponse3.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs3).toHaveLength(1);
     const authorityOutput3 = authorityOutputs3[0];
@@ -1801,14 +1802,14 @@ describe('delegateAuthority', () => {
 
     // Should handle trying to delegate without the authority
     await expect(
-      hWallet1.delegateAuthority(fakeTokenUid, 'mint', await hWallet2.getAddressAtIndex(0))
+      hWallet1.delegateAuthority(fakeTokenUid, 'mint', await hWallet2.getAddressAtIndex(0)),
     ).rejects.toThrow();
 
     // Delegating mint authority to wallet 2
     const { hash: delegateMintTxId } = await hWallet1.delegateAuthority(
       tokenUid,
       'mint',
-      await hWallet2.getAddressAtIndex(0)
+      await hWallet2.getAddressAtIndex(0),
     );
     await waitForTxReceived(hWallet1, delegateMintTxId);
     await waitForTxReceived(hWallet2, delegateMintTxId);
@@ -1833,7 +1834,7 @@ describe('delegateAuthority', () => {
     const { hash: delegateMeltTxId } = await hWallet1.delegateAuthority(
       tokenUid,
       'melt',
-      await hWallet2.getAddressAtIndex(0)
+      await hWallet2.getAddressAtIndex(0),
     );
     await waitForTxReceived(hWallet1, delegateMeltTxId);
     await waitForTxReceived(hWallet2, delegateMeltTxId);
@@ -1864,7 +1865,7 @@ describe('delegateAuthority', () => {
       tokenUid,
       'mint',
       await hWallet2.getAddressAtIndex(0),
-      { createAnother: false }
+      { createAnother: false },
     );
     await waitForTxReceived(hWallet1, giveAwayMintTx);
     await waitForTxReceived(hWallet2, giveAwayMintTx);
@@ -1885,7 +1886,7 @@ describe('delegateAuthority', () => {
       tokenUid,
       'melt',
       await hWallet2.getAddressAtIndex(0),
-      { createAnother: false }
+      { createAnother: false },
     );
     await waitForTxReceived(hWallet1, giveAwayMeltTx);
     await waitForTxReceived(hWallet2, giveAwayMeltTx);
@@ -1908,7 +1909,7 @@ describe('delegateAuthority', () => {
       tokenUid,
       'mint',
       await hWallet1.getAddressAtIndex(1),
-      { createAnother: true }
+      { createAnother: true },
     );
     await waitForTxReceived(hWallet1, duplicateMintAuth);
 
@@ -1934,7 +1935,7 @@ describe('delegateAuthority', () => {
       tokenUid,
       'mint',
       await hWallet2.getAddressAtIndex(1),
-      { createAnother: false }
+      { createAnother: false },
     );
     await waitForTxReceived(hWallet1, delegateMintAuth);
     await waitForTxReceived(hWallet2, delegateMintAuth);
@@ -1972,7 +1973,7 @@ describe('delegateAuthority', () => {
       tokenUid,
       'melt',
       await hWallet1.getAddressAtIndex(1),
-      { createAnother: true }
+      { createAnother: true },
     );
     await waitForTxReceived(hWallet1, duplicateMeltAuth);
 
@@ -1998,7 +1999,7 @@ describe('delegateAuthority', () => {
       tokenUid,
       'melt',
       await hWallet2.getAddressAtIndex(1),
-      { createAnother: false }
+      { createAnother: false },
     );
     await waitForTxReceived(hWallet1, delegateMintAuth);
     await waitForTxReceived(hWallet2, delegateMintAuth);
@@ -2040,14 +2041,14 @@ describe('destroyAuthority', () => {
       hWallet,
       'Token for MintDestroy',
       'DMINT',
-      100n
+      100n,
     );
 
     // Adding another mint authority
     const { hash: newMintTx } = await hWallet.delegateAuthority(
       tokenUid,
       'mint',
-      await hWallet.getAddressAtIndex(0)
+      await hWallet.getAddressAtIndex(0),
     );
     await waitForTxReceived(hWallet, newMintTx);
 
@@ -2084,14 +2085,14 @@ describe('destroyAuthority', () => {
       hWallet,
       'Token for MeltDestroy',
       'DMELT',
-      100n
+      100n,
     );
 
     // Adding another melt authority
     const { hash: newMeltTx } = await hWallet.delegateAuthority(
       tokenUid,
       'melt',
-      await hWallet.getAddressAtIndex(0)
+      await hWallet.getAddressAtIndex(0),
     );
     await waitForTxReceived(hWallet, newMeltTx);
 
@@ -2262,7 +2263,7 @@ describe('createNFT', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(o => o.value === TOKEN_MINT_MASK);
@@ -2295,14 +2296,14 @@ describe('createNFT', () => {
       hWallet.createNFT('New Token', 'NTKN', 100n, sampleNftData, {
         createMint: true,
         mintAuthorityAddress: addr2_0,
-      })
+      }),
     ).rejects.toThrow('must belong to your wallet');
 
     await expect(
       hWallet.createNFT('New Token', 'NTKN', 100n, sampleNftData, {
         createMelt: true,
         meltAuthorityAddress: addr2_1,
-      })
+      }),
     ).rejects.toThrow('must belong to your wallet');
 
     // Creating the new token allowing external address
@@ -2322,7 +2323,7 @@ describe('createNFT', () => {
 
     // Validating a new mint authority was created by default
     const authorityOutputs = newTokenResponse.outputs.filter(o =>
-      transaction.isAuthorityOutput({ token_data: o.tokenData })
+      transaction.isAuthorityOutput({ token_data: o.tokenData }),
     );
     expect(authorityOutputs).toHaveLength(2);
     const mintOutput = authorityOutputs.filter(o => o.value === TOKEN_MINT_MASK);
@@ -2485,7 +2486,7 @@ describe('getTxHistory', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
     txHistory = await hWallet.getTxHistory();
     expect(txHistory).toStrictEqual([
@@ -2544,7 +2545,7 @@ describe('getTxHistory', () => {
     const { hash: tx1Hash } = await hWallet.sendTransaction(
       await hWallet.getAddressAtIndex(0),
       10n,
-      { token: tokenUid }
+      { token: tokenUid },
     );
     await waitForTxReceived(hWallet, tx1Hash);
     txHistory = await hWallet.getTxHistory({ token_id: tokenUid });
@@ -2555,7 +2556,7 @@ describe('getTxHistory', () => {
     const { hash: tx2Hash } = await hWallet.sendTransaction(
       await gWallet.getAddressAtIndex(0),
       10n,
-      { token: tokenUid }
+      { token: tokenUid },
     );
     await waitForTxReceived(hWallet, tx2Hash);
     await waitForTxReceived(gWallet, tx2Hash);

--- a/__tests__/integration/hathorwallet_others.test.ts
+++ b/__tests__/integration/hathorwallet_others.test.ts
@@ -1,6 +1,15 @@
 import { cloneDeep, reverse } from 'lodash';
+
+import { NATIVE_TOKEN_UID, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
+import { AddressError } from '../../src/errors';
+import HathorWallet from '../../src/new/wallet';
+import { MemoryStore } from '../../src/storage';
+import { IHistoryTx } from '../../src/types';
+import dateFormatter from '../../src/utils/date';
+
+import { WALLET_CONSTANTS } from './configuration/test-constants';
 import { GenesisWalletHelper } from './helpers/genesis-wallet.helper';
-import { delay } from './utils/core.util';
+import { precalculationHelpers } from './helpers/wallet-precalculation.helper';
 import {
   createTokenHelper,
   generateWalletHelper,
@@ -8,14 +17,7 @@ import {
   waitForTxReceived,
   waitUntilNextTimestamp,
 } from './helpers/wallet.helper';
-import { NATIVE_TOKEN_UID, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
-import { WALLET_CONSTANTS } from './configuration/test-constants';
-import dateFormatter from '../../src/utils/date';
-import { AddressError } from '../../src/errors';
-import { precalculationHelpers } from './helpers/wallet-precalculation.helper';
-import HathorWallet from '../../src/new/wallet';
-import { MemoryStore } from '../../src/storage';
-import { IHistoryTx } from '../../src/types';
+import { delay } from './utils/core.util';
 
 describe('processing transaction metadata changes', () => {
   let hWallet: HathorWallet;
@@ -30,7 +32,7 @@ describe('processing transaction metadata changes', () => {
 
   function findLastCallFor(
     txId: string,
-    wsSpy: jest.SpiedFunction<typeof HathorWallet.prototype.onNewTx>
+    wsSpy: jest.SpiedFunction<typeof HathorWallet.prototype.onNewTx>,
   ): { history: IHistoryTx } | undefined {
     for (const call of reverse(cloneDeep(wsSpy.mock.calls))) {
       if (call[0].history.tx_id === txId) {
@@ -47,7 +49,7 @@ describe('processing transaction metadata changes', () => {
     const wsSpy: jest.SpiedFunction<typeof hWallet.onNewTx> = jest.spyOn(hWallet, 'onNewTx');
     const procSpy: jest.SpiedFunction<typeof hWallet.storage.processHistory> = jest.spyOn(
       hWallet.storage,
-      'processHistory'
+      'processHistory',
     );
 
     await expect(hWallet.getBalance(NATIVE_TOKEN_UID)).resolves.toEqual([
@@ -114,7 +116,7 @@ describe('processing transaction metadata changes', () => {
     const wsSpy: jest.SpiedFunction<typeof hWallet.onNewTx> = jest.spyOn(hWallet, 'onNewTx');
     const procSpy: jest.SpiedFunction<typeof hWallet.storage.processHistory> = jest.spyOn(
       hWallet.storage,
-      'processHistory'
+      'processHistory',
     );
 
     await expect(hWallet.getBalance(NATIVE_TOKEN_UID)).resolves.toEqual([
@@ -231,7 +233,7 @@ describe('processing transaction metadata changes', () => {
     const wsSpy: jest.SpiedFunction<typeof hWallet.onNewTx> = jest.spyOn(hWallet, 'onNewTx');
     const procSpy: jest.SpiedFunction<typeof hWallet.storage.processHistory> = jest.spyOn(
       hWallet.storage,
-      'processHistory'
+      'processHistory',
     );
 
     await expect(hWallet.getBalance(NATIVE_TOKEN_UID)).resolves.toEqual([
@@ -341,7 +343,7 @@ describe('processing transaction metadata changes', () => {
     const wsSpy: jest.SpiedFunction<typeof hWallet.onNewTx> = jest.spyOn(hWallet, 'onNewTx');
     const procSpy: jest.SpiedFunction<typeof hWallet.storage.processHistory> = jest.spyOn(
       hWallet.storage,
-      'processHistory'
+      'processHistory',
     );
 
     await expect(hWallet.getBalance(NATIVE_TOKEN_UID)).resolves.toEqual([
@@ -535,7 +537,7 @@ describe('getAddressInfo', () => {
 
   it('should throw for an address outside the wallet', async () => {
     await expect(hWallet.getAddressInfo(WALLET_CONSTANTS.genesis.addresses[0])).rejects.toThrow(
-      AddressError
+      AddressError,
     );
   });
 
@@ -595,7 +597,7 @@ describe('getAddressInfo', () => {
       {
         total_amount_available: 7n,
         total_amount_locked: 3n,
-      }
+      },
     );
   });
 
@@ -612,7 +614,7 @@ describe('getAddressInfo', () => {
       'getAddressInfo Token',
       'GAIT',
       100n,
-      { address: addr0Custom }
+      { address: addr0Custom },
     );
 
     // Validating address information both in HTR and in custom token
@@ -625,7 +627,7 @@ describe('getAddressInfo', () => {
       index: 0,
     });
     await expect(
-      hWalletCustom.getAddressInfo(addr0Custom, { token: tokenUid })
+      hWalletCustom.getAddressInfo(addr0Custom, { token: tokenUid }),
     ).resolves.toMatchObject({
       total_amount_received: 100n,
       total_amount_sent: 0n,
@@ -639,7 +641,7 @@ describe('getAddressInfo', () => {
     const tx = await hWalletCustom.sendTransaction(addr1Custom, 40n, { token: tokenUid });
     await waitForTxReceived(hWalletCustom, tx.hash);
     await expect(
-      hWalletCustom.getAddressInfo(addr0Custom, { token: tokenUid })
+      hWalletCustom.getAddressInfo(addr0Custom, { token: tokenUid }),
     ).resolves.toMatchObject({
       total_amount_received: 100n,
       total_amount_sent: 100n,
@@ -648,7 +650,7 @@ describe('getAddressInfo', () => {
       index: 0,
     });
     await expect(
-      hWalletCustom.getAddressInfo(addr1Custom, { token: tokenUid })
+      hWalletCustom.getAddressInfo(addr1Custom, { token: tokenUid }),
     ).resolves.toMatchObject({
       total_amount_received: 40n,
       total_amount_sent: 0n,
@@ -673,7 +675,7 @@ describe('getTxAddresses', () => {
       ],
       {
         changeAddress: WALLET_CONSTANTS.genesis.addresses[0],
-      }
+      },
     );
     await waitForTxReceived(hWallet, tx.hash);
     await waitForTxReceived(gWallet, tx.hash);
@@ -685,12 +687,12 @@ describe('getTxAddresses', () => {
         await hWallet.getAddressAtIndex(1),
         await hWallet.getAddressAtIndex(3),
         await hWallet.getAddressAtIndex(5),
-      ])
+      ]),
     );
 
     // By convention, only the address 0 of the genesis wallet is used on the integration tests
     await expect(gWallet.getTxAddresses(decodedTx)).resolves.toStrictEqual(
-      new Set([WALLET_CONSTANTS.genesis.addresses[0]])
+      new Set([WALLET_CONSTANTS.genesis.addresses[0]]),
     );
   });
 });
@@ -704,7 +706,7 @@ describe('checkAddressesMine', () => {
     const address3 = await hWallet.getAddressAtIndex(3);
 
     expect(
-      await hWallet.checkAddressesMine([address1, address2, address3, 'invalid-address'])
+      await hWallet.checkAddressesMine([address1, address2, address3, 'invalid-address']),
     ).toStrictEqual({
       [address1]: true,
       [address2]: true,
@@ -735,7 +737,7 @@ describe('getAvailableUtxos', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
 
     // Get correct results for a single transaction
@@ -769,12 +771,12 @@ describe('getAvailableUtxos', () => {
     const tx1 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      10n
+      10n,
     );
     const tx2 = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(1),
-      5n
+      5n,
     );
 
     // Validate that on the address that received tx1, the UTXO is listed
@@ -816,7 +818,7 @@ describe('getAvailableUtxos', () => {
       hWallet,
       'getAvailableUtxos Token',
       'GAUT',
-      100n
+      100n,
     );
 
     /*
@@ -849,7 +851,7 @@ describe('getAvailableUtxos', () => {
           value: 100n,
           authorities: 0n, // The custom token balance itself
         }),
-      ])
+      ]),
     );
 
     // List all authorities
@@ -873,7 +875,7 @@ describe('getAvailableUtxos', () => {
           value: TOKEN_MELT_MASK,
           authorities: TOKEN_MELT_MASK,
         }),
-      ])
+      ]),
     );
   });
 });
@@ -945,7 +947,7 @@ describe('getUtxosForAmount', () => {
       utxos: [expect.anything()],
     });
     await expect(hWallet.getUtxosForAmount(10n, { filter_address: addr1 })).rejects.toThrow(
-      'utxos to fill total amount'
+      'utxos to fill total amount',
     );
 
     // Should throw for an amount higher than available funds
@@ -1028,7 +1030,7 @@ describe('getUtxosForAmount', () => {
       'getUtxosForAmount Test Token',
       'GUFAT',
       200n,
-      { address: addr2 }
+      { address: addr2 },
     );
 
     // Should work only with the token filter
@@ -1047,7 +1049,7 @@ describe('getUtxosForAmount', () => {
       {
         changeAmount: expect.any(BigInt),
         utxos: [expect.objectContaining({ tokenId: NATIVE_TOKEN_UID })],
-      }
+      },
     );
     // Implicitly filtering for HTR
     await expect(hWallet.getUtxosForAmount(6n)).resolves.toStrictEqual({
@@ -1057,7 +1059,7 @@ describe('getUtxosForAmount', () => {
 
     // The token filter should work combined with the address filter
     await expect(
-      hWallet.getUtxosForAmount(6n, { token: tokenUid, filter_address: addr2 })
+      hWallet.getUtxosForAmount(6n, { token: tokenUid, filter_address: addr2 }),
     ).resolves.toStrictEqual({
       changeAmount: 194n,
       utxos: [
@@ -1068,7 +1070,7 @@ describe('getUtxosForAmount', () => {
       ],
     });
     await expect(
-      hWallet.getUtxosForAmount(6n, { token: tokenUid, filter_address: addr3 })
+      hWallet.getUtxosForAmount(6n, { token: tokenUid, filter_address: addr3 }),
     ).rejects.toThrow('utxos to fill');
   });
 
@@ -1083,7 +1085,7 @@ describe('getUtxosForAmount', () => {
 
     // Validate that it will not be retrieved on getUtxosForAmount
     await expect(hWallet.getUtxosForAmount(50n, { filter_address: addr })).rejects.toThrow(
-      'utxos to fill'
+      'utxos to fill',
     );
   });
 });
@@ -1112,7 +1114,7 @@ describe('consolidateUtxos', () => {
       1000n,
       {
         address: await hWallet2.getAddressAtIndex(0),
-      }
+      },
     );
     tokenHash = tokenUid;
   });
@@ -1137,7 +1139,7 @@ describe('consolidateUtxos', () => {
     const cleanTx = await hWallet1.sendTransaction(
       await hWallet2.getAddressAtIndex(0),
       tokenBalance,
-      { token }
+      { token },
     );
     await waitForTxReceived(hWallet1, cleanTx.hash);
     await waitForTxReceived(hWallet2, cleanTx.hash);
@@ -1146,7 +1148,7 @@ describe('consolidateUtxos', () => {
 
   it('should throw when consolidating on an empty wallet', async () => {
     await expect(hWallet1.consolidateUtxos(await hWallet1.getAddressAtIndex(0))).rejects.toThrow(
-      'available utxo'
+      'available utxo',
     );
   });
 
@@ -1159,7 +1161,7 @@ describe('consolidateUtxos', () => {
     await waitForTxReceived(hWallet2, fundTx.hash);
 
     await expect(hWallet1.consolidateUtxos(hWallet2.getAddressAtIndex(0))).rejects.toThrow(
-      'not owned by this wallet'
+      'not owned by this wallet',
     );
 
     await waitUntilNextTimestamp(hWallet1, fundTx.hash);
@@ -1459,7 +1461,7 @@ describe('consolidateUtxos', () => {
     // We should now have 4 utxos on wallet1 for this custom token
     expect(await hWallet1.getUtxos({ token: tokenHash })).toHaveProperty(
       'total_utxos_available',
-      4n
+      4n,
     );
 
     // Reducing the amount of maximum inputs allowed for the lib (not the fullnode)
@@ -1482,7 +1484,7 @@ describe('consolidateUtxos', () => {
     // Ensure the maximum possible amount of utxos was consolidated ( 1 consolidated + 2 remaining )
     expect(await hWallet1.getUtxos({ token: tokenHash })).toHaveProperty(
       'total_utxos_available',
-      3n
+      3n,
     );
   });
 });

--- a/__tests__/integration/hathorwallet_prepare_without_sign.test.ts
+++ b/__tests__/integration/hathorwallet_prepare_without_sign.test.ts
@@ -1,4 +1,11 @@
 import { isEmpty } from 'lodash';
+
+import { SendTransaction } from '../../src';
+import ncApi from '../../src/api/nano';
+import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../src/constants';
+import HathorWallet from '../../src/new/wallet';
+import { TokenVersion } from '../../src/types';
+
 import { GenesisWalletHelper } from './helpers/genesis-wallet.helper';
 import {
   DEFAULT_PIN_CODE,
@@ -7,12 +14,6 @@ import {
   waitForTxReceived,
   waitTxConfirmed,
 } from './helpers/wallet.helper';
-
-import ncApi from '../../src/api/nano';
-import HathorWallet from '../../src/new/wallet';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../src/constants';
-import { TokenVersion } from '../../src/types';
-import { SendTransaction } from '../../src';
 
 describe('HathorWallet prepare transaction without signing', () => {
   let hWallet: HathorWallet;
@@ -39,7 +40,7 @@ describe('HathorWallet prepare transaction without signing', () => {
             changeAddress: address,
           },
         ],
-      }
+      },
     );
     await checkTxValid(hWallet, initTx);
     contractId = initTx.hash!;
@@ -59,7 +60,7 @@ describe('HathorWallet prepare transaction without signing', () => {
             changeAddress: address,
           },
         ],
-      }
+      },
     );
     await checkTxValid(hWallet, createFbtTx);
 
@@ -67,7 +68,7 @@ describe('HathorWallet prepare transaction without signing', () => {
       contractId,
       ['fbt_uid'],
       [NATIVE_TOKEN_UID],
-      []
+      [],
     );
     fbtUid = ncState.fields.fbt_uid.value;
   });
@@ -126,7 +127,7 @@ describe('HathorWallet prepare transaction without signing', () => {
           },
         ],
       },
-      { signTx: false }
+      { signTx: false },
     );
 
     const txBeforeChangeCaller = sendTransaction.transaction;
@@ -153,7 +154,7 @@ describe('HathorWallet prepare transaction without signing', () => {
         expect.objectContaining({
           tokenData: 0,
         }),
-      ])
+      ]),
     );
 
     // 3. Edit caller: change address AND seqnum for the new caller
@@ -205,7 +206,7 @@ describe('HathorWallet prepare transaction without signing', () => {
         mintAddress: address0,
         tokenVersion: TokenVersion.FEE,
       },
-      { signTx: false }
+      { signTx: false },
     );
     const txBeforeChangeCaller = sendTransaction.transaction;
 
@@ -228,7 +229,7 @@ describe('HathorWallet prepare transaction without signing', () => {
         expect.objectContaining({
           tokenData: 0, // HTR change
         }),
-      ])
+      ]),
     );
 
     // 3. Edit caller: change address AND seqnum for the new caller

--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -5,16 +5,17 @@
  * LICENSE file in the root directory of this source tree.
  */
 /* eslint max-classes-per-file: ["error", 2] */
-import { FULLNODE_URL, WALLET_CONSTANTS } from '../configuration/test-constants';
+import { HathorWalletServiceWallet } from '../../../src';
+import Transaction from '../../../src/models/transaction';
 import Connection from '../../../src/new/connection';
 import HathorWallet from '../../../src/new/wallet';
-import { waitForTxReceived, waitForWalletReady, waitUntilNextTimestamp } from './wallet.helper';
-import { loggers } from '../utils/logger.util';
-import { delay, getGapLimitConfig } from '../utils/core.util';
 import { OutputValueType } from '../../../src/types';
-import Transaction from '../../../src/models/transaction';
-import { HathorWalletServiceWallet } from '../../../src';
+import { FULLNODE_URL, WALLET_CONSTANTS } from '../configuration/test-constants';
+import { delay, getGapLimitConfig } from '../utils/core.util';
+import { loggers } from '../utils/logger.util';
+
 import { buildWalletInstance, pollForTx } from './service-facade.helper';
+import { waitForTxReceived, waitForWalletReady, waitUntilNextTimestamp } from './wallet.helper';
 
 interface InjectFundsOptions {
   waitTimeout?: number;
@@ -80,7 +81,7 @@ export class GenesisWalletHelper {
     destinationWallet: HathorWallet,
     address: string,
     value: OutputValueType,
-    options: InjectFundsOptions = {}
+    options: InjectFundsOptions = {},
   ): Promise<Transaction> {
     try {
       const result = (await this.hWallet.sendTransaction(address, value, {
@@ -135,7 +136,7 @@ export class GenesisWalletHelper {
     destinationWallet: HathorWallet,
     address: string,
     value: OutputValueType,
-    options: InjectFundsOptions = {}
+    options: InjectFundsOptions = {},
   ) {
     const instance = await GenesisWalletHelper.getSingleton();
     return instance._injectFunds(destinationWallet, address, value, options);
@@ -216,7 +217,7 @@ export class GenesisWalletServiceHelper {
   static async injectFunds(
     address: string,
     amount: bigint,
-    destinationWallet?: HathorWalletServiceWallet
+    destinationWallet?: HathorWalletServiceWallet,
   ): Promise<Transaction> {
     const gWallet = GenesisWalletServiceHelper.getSingleton();
     const fundTx = await gWallet.sendTransaction(address, amount, {

--- a/__tests__/integration/helpers/service-facade.helper.ts
+++ b/__tests__/integration/helpers/service-facade.helper.ts
@@ -1,13 +1,15 @@
 import { isEmpty } from 'lodash';
-import { loggers } from '../utils/logger.util';
-import { delay } from '../utils/core.util';
+
 import { HathorWalletServiceWallet, MemoryStore, Storage, walletUtils } from '../../../src';
+import ncApi from '../../../src/api/nano';
+import config from '../../../src/config';
+import { TxNotFoundError } from '../../../src/errors';
 import Network from '../../../src/models/network';
 import { FULLNODE_URL, NETWORK_NAME } from '../configuration/test-constants';
-import { TxNotFoundError } from '../../../src/errors';
+import { delay } from '../utils/core.util';
+import { loggers } from '../utils/logger.util';
+
 import { precalculationHelpers } from './wallet-precalculation.helper';
-import config from '../../../src/config';
-import ncApi from '../../../src/api/nano';
 
 /** Default pin to simplify the tests */
 const pinCode = '123456';
@@ -105,7 +107,7 @@ export async function pollUntilCondition<T>(
   predicate: () => Promise<T>,
   label: string,
   maxAttempts = 10,
-  delayMs = 500
+  delayMs = 500,
 ): Promise<T> {
   let attempts = 0;
 
@@ -186,7 +188,7 @@ export async function pollForNcState(
   fields: string[],
   requiredField?: string,
   maxAttempts = 10,
-  delayMs = 1000
+  delayMs = 1000,
 ): Promise<unknown> {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
@@ -220,7 +222,7 @@ export async function pollForTokenDetails(
   wallet: HathorWalletServiceWallet,
   tokenId: string,
   maxAttempts = 20,
-  delayMs = 2000
+  delayMs = 2000,
 ): Promise<void> {
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     try {
@@ -239,7 +241,7 @@ export async function pollForTokenDetails(
  */
 export async function checkTxNotVoided(
   wallet: HathorWalletServiceWallet,
-  txId: string
+  txId: string,
 ): Promise<void> {
   const txData = await wallet.getFullTxById(txId);
   expect(txData.success).toBe(true);

--- a/__tests__/integration/helpers/wallet-precalculation.helper.ts
+++ b/__tests__/integration/helpers/wallet-precalculation.helper.ts
@@ -6,10 +6,12 @@
  */
 
 import { promises as fs } from 'fs';
+
 import { Address, Script } from 'bitcore-lib';
+
+import { deriveAddressFromXPubP2PKH } from '../../../src/utils/address';
 import walletUtils from '../../../src/utils/wallet';
 import { NETWORK_NAME } from '../configuration/test-constants';
-import { deriveAddressFromXPubP2PKH } from '../../../src/utils/address';
 import { loggers } from '../utils/logger.util';
 
 /**
@@ -91,7 +93,7 @@ export class WalletPrecalculationHelper {
       addressIntervalStart?: number;
       addressIntervalEnd?: number;
       multisig?: { minSignatures: number; wordsArray: string[] };
-    } = {}
+    } = {},
   ): PrecalculatedWalletData {
     const timeStart = Date.now().valueOf();
     let wordsInput = params.words;
@@ -108,7 +110,7 @@ export class WalletPrecalculationHelper {
         const redeemScript = walletUtils.createP2SHRedeemScript(
           pubkeys,
           params.multisig.minSignatures,
-          i
+          i,
         );
         const address = Address.payingTo(Script.fromBuffer(redeemScript), NETWORK_NAME);
         addressesArray.push(address.toString());
@@ -205,7 +207,7 @@ export class WalletPrecalculationHelper {
     params: {
       commonWallets?: number;
       verbose?: boolean;
-    } = {}
+    } = {},
   ): PrecalculatedWalletData[] {
     const amountOfCommonWallets = params.commonWallets || 100;
 
@@ -229,7 +231,7 @@ export class WalletPrecalculationHelper {
     params: {
       wordsArray: string[];
       minSignatures: number;
-    } = { wordsArray: [], minSignatures: 0 }
+    } = { wordsArray: [], minSignatures: 0 },
   ): PrecalculatedWalletData[] {
     const resultingWallets: PrecalculatedWalletData[] = [];
     for (const walletWords of params.wordsArray) {

--- a/__tests__/integration/helpers/wallet.helper.ts
+++ b/__tests__/integration/helpers/wallet.helper.ts
@@ -6,7 +6,12 @@
  */
 
 import { get, includes } from 'lodash';
+
 import Connection from '../../../src/new/connection';
+import HathorWallet from '../../../src/new/wallet';
+import { MemoryStore, Storage } from '../../../src/storage';
+import { TxHistoryProcessingStatus, IHistoryTx } from '../../../src/types';
+import walletUtils from '../../../src/utils/wallet';
 import {
   DEBUG_LOGGING,
   FULLNODE_URL,
@@ -14,13 +19,10 @@ import {
   TX_TIMEOUT_DEFAULT,
   WALLET_CONSTANTS,
 } from '../configuration/test-constants';
-import HathorWallet from '../../../src/new/wallet';
-import walletUtils from '../../../src/utils/wallet';
-import { multisigWalletsData, precalculationHelpers } from './wallet-precalculation.helper';
 import { delay, getGapLimitConfig } from '../utils/core.util';
 import { loggers } from '../utils/logger.util';
-import { MemoryStore, Storage } from '../../../src/storage';
-import { TxHistoryProcessingStatus, IHistoryTx } from '../../../src/types';
+
+import { multisigWalletsData, precalculationHelpers } from './wallet-precalculation.helper';
 
 /**
  * @typedef SendTxResponse
@@ -281,7 +283,7 @@ export function waitForWalletReady(hWallet) {
 export async function waitForTxReceived(
   hWallet: HathorWallet,
   txId: string,
-  timeout: number = 0
+  timeout: number = 0,
 ): Promise<IHistoryTx> {
   const startTime = Date.now().valueOf();
   let timeoutReached = false;
@@ -455,7 +457,7 @@ export async function waitNextBlock(storage) {
 export async function waitTxConfirmed(
   hWallet: HathorWallet,
   txId: string,
-  timeout?: number
+  timeout?: number,
 ): Promise<void> {
   let timeoutHandler: ReturnType<typeof setTimeout> | undefined;
   let timeoutErrorFlag = false;

--- a/__tests__/integration/nanocontracts/authority.test.ts
+++ b/__tests__/integration/nanocontracts/authority.test.ts
@@ -1,16 +1,17 @@
 import { isEmpty } from 'lodash';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
+
+import ncApi from '../../../src/api/nano';
 import {
   CREATE_TOKEN_TX_VERSION,
   NATIVE_TOKEN_UID,
   NANO_CONTRACTS_INITIALIZE_METHOD,
 } from '../../../src/constants';
-import ncApi from '../../../src/api/nano';
+import { NanoContractTransactionError } from '../../../src/errors';
+import { isNanoContractCreateTx } from '../../../src/nano_contracts/utils';
 import { bufferToHex } from '../../../src/utils/buffer';
 import helpersUtils from '../../../src/utils/helpers';
-import { isNanoContractCreateTx } from '../../../src/nano_contracts/utils';
-import { NanoContractTransactionError } from '../../../src/errors';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
 
 describe('Authority actions blueprint test', () => {
   /** @type HathorWallet */
@@ -75,7 +76,7 @@ describe('Authority actions blueprint test', () => {
     const txInitialize = await wallet.createAndSendNanoContractTransaction(
       NANO_CONTRACTS_INITIALIZE_METHOD,
       address0,
-      initializeData
+      initializeData,
     );
     await checkTxValid(wallet, txInitialize);
     const txInitializeData = await wallet.getFullTxById(txInitialize.hash);
@@ -116,8 +117,8 @@ describe('Authority actions blueprint test', () => {
         createTokenMethod,
         'abc',
         createTokenData,
-        createTokenOptions
-      )
+        createTokenOptions,
+      ),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Error with invalid mint authority address
@@ -129,8 +130,8 @@ describe('Authority actions blueprint test', () => {
         {
           ...createTokenOptions,
           mintAuthorityAddress: 'abc',
-        }
-      )
+        },
+      ),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Error with invalid melt authority address
@@ -142,8 +143,8 @@ describe('Authority actions blueprint test', () => {
         {
           ...createTokenOptions,
           meltAuthorityAddress: 'abc',
-        }
-      )
+        },
+      ),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Create token and execute nano method with withdrawal action
@@ -152,7 +153,7 @@ describe('Authority actions blueprint test', () => {
       createTokenMethod,
       address0,
       createTokenData,
-      createTokenOptions
+      createTokenOptions,
     );
     await checkTxValid(wallet, txCreateToken);
     const txCreateTokenData = await wallet.getFullTxById(txCreateToken.hash);
@@ -183,7 +184,7 @@ describe('Authority actions blueprint test', () => {
     const ncState = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     // Deposit 100 - Withdrawal 30 of HTR
@@ -216,7 +217,7 @@ describe('Authority actions blueprint test', () => {
     const txGrant1 = await wallet.createAndSendNanoContractTransaction(
       'grant_authority',
       address0,
-      grantData1
+      grantData1,
     );
     await checkTxValid(wallet, txGrant1);
     const txGrant1Data = await wallet.getFullTxById(txGrant1.hash);
@@ -232,7 +233,7 @@ describe('Authority actions blueprint test', () => {
     const ncStateGrant1 = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     expect(BigInt(ncStateGrant1.balances[txCreateToken.hash].value)).toBe(0n);
@@ -255,7 +256,7 @@ describe('Authority actions blueprint test', () => {
     const txGrant2 = await wallet.createAndSendNanoContractTransaction(
       'grant_authority',
       address0,
-      grantData2
+      grantData2,
     );
     await checkTxValid(wallet, txGrant2);
     const txGrant2Data = await wallet.getFullTxById(txGrant2.hash);
@@ -275,7 +276,7 @@ describe('Authority actions blueprint test', () => {
     const ncStateGrant2 = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     expect(BigInt(ncStateGrant2.balances[txCreateToken.hash].value)).toBe(0n);
@@ -303,7 +304,7 @@ describe('Authority actions blueprint test', () => {
     const ncStateMint = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     expect(BigInt(ncStateMint.balances[NATIVE_TOKEN_UID].value)).toBe(50n);
@@ -326,7 +327,7 @@ describe('Authority actions blueprint test', () => {
     const ncStateMelt = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     expect(BigInt(ncStateMelt.balances[NATIVE_TOKEN_UID].value)).toBe(60n);
@@ -356,7 +357,7 @@ describe('Authority actions blueprint test', () => {
     const txAcquire = await wallet.createAndSendNanoContractTransaction(
       'acquire_authority',
       address0,
-      acquireData
+      acquireData,
     );
     await checkTxValid(wallet, txAcquire);
     const txAcquireData = await wallet.getFullTxById(txAcquire.hash);
@@ -373,7 +374,7 @@ describe('Authority actions blueprint test', () => {
     const ncStateAcquire = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     expect(BigInt(ncStateAcquire.balances[NATIVE_TOKEN_UID].value)).toBe(60n);
@@ -403,7 +404,7 @@ describe('Authority actions blueprint test', () => {
     const ncStateRevoke = await ncApi.getNanoContractState(
       txInitialize.hash,
       [],
-      [txCreateToken.hash, NATIVE_TOKEN_UID]
+      [txCreateToken.hash, NATIVE_TOKEN_UID],
     );
 
     expect(BigInt(ncStateRevoke.balances[NATIVE_TOKEN_UID].value)).toBe(60n);
@@ -456,7 +457,7 @@ describe('Authority actions blueprint test', () => {
       NANO_CONTRACTS_INITIALIZE_METHOD,
       address2,
       newInitializeData,
-      singleUtxoCreateTokenOptions
+      singleUtxoCreateTokenOptions,
     );
     await checkTxValid(wallet, initializeTokenCreate);
     const initializeTokenCreateData = await wallet.getFullTxById(initializeTokenCreate.hash);
@@ -525,18 +526,18 @@ describe('Authority actions blueprint test', () => {
         NANO_CONTRACTS_INITIALIZE_METHOD,
         newAddress0,
         twoUtxosInitializeData,
-        twoUtxosCreateTokenOptions
+        twoUtxosCreateTokenOptions,
       );
     await checkTxValid(newWallet, twoUtxosInitializeTokenCreate);
     const twoUtxosInitializeTokenCreateData = await newWallet.getFullTxById(
-      twoUtxosInitializeTokenCreate.hash
+      twoUtxosInitializeTokenCreate.hash,
     );
 
     expect(twoUtxosInitializeTokenCreateData.tx.nc_method).toBe(NANO_CONTRACTS_INITIALIZE_METHOD);
     expect(twoUtxosInitializeTokenCreateData.tx.version).toBe(CREATE_TOKEN_TX_VERSION);
     expect(twoUtxosInitializeTokenCreateData.tx.token_name).toBe(twoUtxosCreateTokenOptions.name);
     expect(twoUtxosInitializeTokenCreateData.tx.token_symbol).toBe(
-      twoUtxosCreateTokenOptions.symbol
+      twoUtxosCreateTokenOptions.symbol,
     );
     // Two utxos were used
     expect(twoUtxosInitializeTokenCreateData.tx.inputs.length).toBe(2);
@@ -574,7 +575,7 @@ describe('Authority actions blueprint test', () => {
       'create_token_no_deposit',
       address0,
       newCreateTokenData,
-      newCreateTokenOptions
+      newCreateTokenOptions,
     );
     await checkTxValid(wallet, newTxCreateToken);
     const newTxCreateTokenData = await wallet.getFullTxById(newTxCreateToken.hash);
@@ -620,7 +621,7 @@ describe('Authority actions blueprint test', () => {
     const txDepositAndGrant = await wallet.createAndSendNanoContractTransaction(
       'deposit_and_grant',
       address0,
-      depositAndGrantData
+      depositAndGrantData,
     );
     await checkTxValid(wallet, txDepositAndGrant);
     const txDepositAndGrantData = await wallet.getFullTxById(txDepositAndGrant.hash);

--- a/__tests__/integration/nanocontracts/bet.test.ts
+++ b/__tests__/integration/nanocontracts/bet.test.ts
@@ -1,7 +1,34 @@
 import fs from 'fs';
+
 import { isEmpty } from 'lodash';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+
+import ncApi from '../../../src/api/nano';
+import {
+  CREATE_TOKEN_TX_VERSION,
+  NATIVE_TOKEN_UID,
+  NANO_CONTRACTS_INITIALIZE_METHOD,
+} from '../../../src/constants';
+import {
+  NanoContractTransactionError,
+  NanoRequest404Error,
+  NanoRequestError,
+  PinRequiredError,
+} from '../../../src/errors';
+import Address from '../../../src/models/address';
+import P2PKH from '../../../src/models/p2pkh';
+import P2SH from '../../../src/models/p2sh';
+import NanoContractTransactionParser from '../../../src/nano_contracts/parser';
+import {
+  getOracleSignedDataFromUser,
+  getOracleBuffer,
+  isNanoContractCreateTx,
+} from '../../../src/nano_contracts/utils';
+import { bufferToHex } from '../../../src/utils/buffer';
+import dateFormatter from '../../../src/utils/date';
+import helpersUtils from '../../../src/utils/helpers';
+import { OutputType } from '../../../src/wallet/types';
 import { WALLET_CONSTANTS } from '../configuration/test-constants';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import {
   generateMultisigWalletHelper,
   generateWalletHelper,
@@ -9,31 +36,6 @@ import {
   waitTxConfirmed,
   waitNextBlock,
 } from '../helpers/wallet.helper';
-import {
-  CREATE_TOKEN_TX_VERSION,
-  NATIVE_TOKEN_UID,
-  NANO_CONTRACTS_INITIALIZE_METHOD,
-} from '../../../src/constants';
-import ncApi from '../../../src/api/nano';
-import dateFormatter from '../../../src/utils/date';
-import { bufferToHex } from '../../../src/utils/buffer';
-import helpersUtils from '../../../src/utils/helpers';
-import Address from '../../../src/models/address';
-import P2PKH from '../../../src/models/p2pkh';
-import P2SH from '../../../src/models/p2sh';
-import {
-  getOracleSignedDataFromUser,
-  getOracleBuffer,
-  isNanoContractCreateTx,
-} from '../../../src/nano_contracts/utils';
-import {
-  NanoContractTransactionError,
-  NanoRequest404Error,
-  NanoRequestError,
-  PinRequiredError,
-} from '../../../src/errors';
-import { OutputType } from '../../../src/wallet/types';
-import NanoContractTransactionParser from '../../../src/nano_contracts/parser';
 
 let fundsTx;
 
@@ -47,7 +49,7 @@ describe('full cycle of bet nano contract', () => {
     fundsTx = await GenesisWalletHelper.injectFunds(
       hWallet,
       await hWallet.getAddressAtIndex(0),
-      1000n
+      1000n,
     );
 
     mhWallet = await generateMultisigWalletHelper({ walletIndex: 3 });
@@ -104,7 +106,7 @@ describe('full cycle of bet nano contract', () => {
       {
         blueprintId,
         args: [bufferToHex(oracleData), NATIVE_TOKEN_UID, dateLastBet],
-      }
+      },
     );
     await checkTxValid(wallet, tx1);
     const tx1Data = await wallet.getFullTxById(tx1.hash);
@@ -119,7 +121,7 @@ describe('full cycle of bet nano contract', () => {
       NANO_CONTRACTS_INITIALIZE_METHOD,
       tx1Data.tx.nc_address,
       network,
-      tx1Data.tx.nc_args
+      tx1Data.tx.nc_args,
     );
     await tx1Parser.parseArguments();
     expect(tx1Parser.address?.base58).toBe(address0);
@@ -162,7 +164,7 @@ describe('full cycle of bet nano contract', () => {
             changeAddress: address0,
           },
         ],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Invalid address
@@ -178,7 +180,7 @@ describe('full cycle of bet nano contract', () => {
             changeAddress: address0,
           },
         ],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Not enough funds for the deposit
@@ -194,7 +196,7 @@ describe('full cycle of bet nano contract', () => {
             changeAddress: address0,
           },
         ],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Bet 100 to address 2
@@ -227,7 +229,7 @@ describe('full cycle of bet nano contract', () => {
       'bet',
       txBetData.tx.nc_address,
       network,
-      txBetData.tx.nc_args
+      txBetData.tx.nc_args,
     );
     await txBetParser.parseArguments();
     expect(txBetParser.address?.base58).toBe(address2);
@@ -281,7 +283,7 @@ describe('full cycle of bet nano contract', () => {
       'bet',
       txBet2Data.tx.nc_address,
       network,
-      txBet2Data.tx.nc_args
+      txBet2Data.tx.nc_args,
     );
     await txBet2Parser.parseArguments();
     expect(txBet2Parser.address?.base58).toBe(address3);
@@ -351,7 +353,7 @@ describe('full cycle of bet nano contract', () => {
       tx1.hash,
       'SignedData[str]',
       result,
-      wallet
+      wallet,
     );
 
     const txSetResult = await wallet.createAndSendNanoContractTransaction('set_result', address1, {
@@ -372,7 +374,7 @@ describe('full cycle of bet nano contract', () => {
       'set_result',
       txSetResultData.tx.nc_address,
       network,
-      txSetResultData.tx.nc_args
+      txSetResultData.tx.nc_args,
     );
     await txSetResultParser.parseArguments();
     expect(txSetResultParser.address?.base58).toBe(address1);
@@ -424,8 +426,8 @@ describe('full cycle of bet nano contract', () => {
         'withdraw',
         'abc',
         withdrawalData,
-        withdrawalCreateTokenOptions
-      )
+        withdrawalCreateTokenOptions,
+      ),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Error with invalid mint authority address
@@ -433,7 +435,7 @@ describe('full cycle of bet nano contract', () => {
       wallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, withdrawalData, {
         ...withdrawalCreateTokenOptions,
         mintAuthorityAddress: 'abc',
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Error with invalid melt authority address
@@ -441,7 +443,7 @@ describe('full cycle of bet nano contract', () => {
       wallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, withdrawalData, {
         ...withdrawalCreateTokenOptions,
         meltAuthorityAddress: 'abc',
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Try to withdraw to address 2, success
@@ -449,7 +451,7 @@ describe('full cycle of bet nano contract', () => {
       'withdraw',
       address2,
       withdrawalData,
-      withdrawalCreateTokenOptions
+      withdrawalCreateTokenOptions,
     );
     await checkTxValid(wallet, txWithdrawal);
     txIds.push(txWithdrawal.hash);
@@ -480,7 +482,7 @@ describe('full cycle of bet nano contract', () => {
       'withdraw',
       txWithdrawalData.tx.nc_address,
       network,
-      txWithdrawalData.tx.nc_args
+      txWithdrawalData.tx.nc_args,
     );
     await txWithdrawalParser.parseArguments();
     expect(txWithdrawalParser.address?.base58).toBe(address2);
@@ -553,7 +555,7 @@ describe('full cycle of bet nano contract', () => {
       ],
       [],
       [],
-      firstBlock
+      firstBlock,
     );
 
     expect(ncStateFirstBlock.fields.token_uid.value).toBe(NATIVE_TOKEN_UID);
@@ -593,13 +595,13 @@ describe('full cycle of bet nano contract', () => {
       [],
       [],
       null,
-      firstBlockHeight
+      firstBlockHeight,
     );
 
     expect(ncStateFirstBlockHeight.fields.token_uid.value).toBe(NATIVE_TOKEN_UID);
     expect(ncStateFirstBlockHeight.fields.date_last_bet.value).toBe(dateLastBet);
     expect(ncStateFirstBlockHeight.fields.oracle_script.value).toBe(
-      bufferToHex(outputScriptBuffer1)
+      bufferToHex(outputScriptBuffer1),
     );
     expect(ncStateFirstBlockHeight.fields.final_result.value).toBeNull();
     expect(ncStateFirstBlockHeight.fields.total.value).toBe(300);
@@ -684,7 +686,7 @@ describe('full cycle of bet nano contract', () => {
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         blueprintId,
         args: [bufferToHex(oracleData), NATIVE_TOKEN_UID],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Args as null
@@ -692,7 +694,7 @@ describe('full cycle of bet nano contract', () => {
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         blueprintId,
         args: null,
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Address selected to sign does not belong to the wallet
@@ -705,8 +707,8 @@ describe('full cycle of bet nano contract', () => {
         {
           blueprintId,
           args: [bufferToHex(oracleData), NATIVE_TOKEN_UID, dateLastBet],
-        }
-      )
+        },
+      ),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Oracle data is expected to be a hexa
@@ -714,7 +716,7 @@ describe('full cycle of bet nano contract', () => {
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         blueprintId,
         args: ['error', NATIVE_TOKEN_UID, dateLastBet],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Date last bet is expected to be an integer
@@ -722,7 +724,7 @@ describe('full cycle of bet nano contract', () => {
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         blueprintId,
         args: ['123', NATIVE_TOKEN_UID, 'error'],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
   };
 
@@ -750,7 +752,7 @@ describe('full cycle of bet nano contract', () => {
     await expect(
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         args: [bufferToHex(oracleData), NATIVE_TOKEN_UID, dateLastBet],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Invalid blueprint id
@@ -758,7 +760,7 @@ describe('full cycle of bet nano contract', () => {
       hWallet.createAndSendNanoContractTransaction(NANO_CONTRACTS_INITIALIZE_METHOD, address0, {
         blueprintId: '1234',
         args: [bufferToHex(oracleData), NATIVE_TOKEN_UID, dateLastBet],
-      })
+      }),
     ).rejects.toThrow(NanoRequest404Error);
 
     // Missing ncId for bet
@@ -773,7 +775,7 @@ describe('full cycle of bet nano contract', () => {
             amount: 100n,
           },
         ],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Invalid ncId for bet
@@ -788,7 +790,7 @@ describe('full cycle of bet nano contract', () => {
             amount: 100n,
           },
         ],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // Invalid ncId for bet again
@@ -803,18 +805,18 @@ describe('full cycle of bet nano contract', () => {
             amount: 100n,
           },
         ],
-      })
+      }),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // If we remove the pin from the wallet object, it should throw error
     const oldPin = hWallet.pinCode;
     hWallet.pinCode = '';
     await expect(
-      hWallet.createAndSendNanoContractTransaction('withdraw', address2, {})
+      hWallet.createAndSendNanoContractTransaction('withdraw', address2, {}),
     ).rejects.toThrow(PinRequiredError);
 
     await expect(
-      hWallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, {}, {})
+      hWallet.createAndSendNanoContractCreateTokenTransaction('withdraw', address2, {}, {}),
     ).rejects.toThrow(PinRequiredError);
     // Add the pin back for the other tests
     hWallet.pinCode = oldPin;
@@ -826,14 +828,14 @@ describe('full cycle of bet nano contract', () => {
     const code = fs.readFileSync('./__tests__/integration/configuration/blueprints/bet.py', 'utf8');
     // Use an address that is not from the ocbWallet
     await expect(
-      ocbWallet.createAndSendOnChainBlueprintTransaction(code, address0)
+      ocbWallet.createAndSendOnChainBlueprintTransaction(code, address0),
     ).rejects.toThrow(NanoContractTransactionError);
 
     // If we remove the pin from the wallet object, it should throw error
     const oldOcbPin = ocbWallet.pinCode;
     ocbWallet.pinCode = '';
     await expect(
-      ocbWallet.createAndSendOnChainBlueprintTransaction(code, address0)
+      ocbWallet.createAndSendOnChainBlueprintTransaction(code, address0),
     ).rejects.toThrow(PinRequiredError);
 
     // Add the pin back in case there are more tests here

--- a/__tests__/integration/nanocontracts/fee.test.ts
+++ b/__tests__/integration/nanocontracts/fee.test.ts
@@ -1,4 +1,11 @@
 import { isEmpty } from 'lodash';
+
+import ncApi from '../../../src/api/nano';
+import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+import CreateTokenTransaction from '../../../src/models/create_token_transaction';
+import { NanoContractHeaderActionType } from '../../../src/nano_contracts/types';
+import HathorWallet from '../../../src/new/wallet';
+import { TokenVersion } from '../../../src/types';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import {
   generateWalletHelper,
@@ -6,13 +13,6 @@ import {
   waitForTxReceived,
   waitTxConfirmed,
 } from '../helpers/wallet.helper';
-
-import ncApi from '../../../src/api/nano';
-import HathorWallet from '../../../src/new/wallet';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
-import { TokenVersion } from '../../../src/types';
-import CreateTokenTransaction from '../../../src/models/create_token_transaction';
-import { NanoContractHeaderActionType } from '../../../src/nano_contracts/types';
 
 describe('FeeBlueprint nano contract operations', () => {
   let hWallet: HathorWallet;
@@ -64,7 +64,7 @@ describe('FeeBlueprint nano contract operations', () => {
             changeAddress: address0,
           },
         ],
-      }
+      },
     );
     await checkTxValid(hWallet, tx);
 
@@ -92,7 +92,7 @@ describe('FeeBlueprint nano contract operations', () => {
             changeAddress: address0,
           },
         ],
-      }
+      },
     );
     await checkTxValid(hWallet, tx);
 
@@ -100,7 +100,7 @@ describe('FeeBlueprint nano contract operations', () => {
       contractId,
       ['dbt_uid'],
       [NATIVE_TOKEN_UID],
-      []
+      [],
     );
     expect(ncState.fields.dbt_uid.value).toBeDefined();
     dbtUid = ncState.fields.dbt_uid.value;
@@ -129,7 +129,7 @@ describe('FeeBlueprint nano contract operations', () => {
       contractId,
       ['fbt_uid'],
       [NATIVE_TOKEN_UID],
-      []
+      [],
     );
     expect(ncState.fields.fbt_uid.value).toBeDefined();
     fbtUid = ncState.fields.fbt_uid.value;
@@ -165,8 +165,8 @@ describe('FeeBlueprint nano contract operations', () => {
           mintAddress: address0,
           tokenVersion: TokenVersion.FEE,
         },
-        { maxFee: 0n }
-      )
+        { maxFee: 0n },
+      ),
     ).rejects.toThrow(/exceeds maximum fee/);
   });
 
@@ -196,7 +196,7 @@ describe('FeeBlueprint nano contract operations', () => {
         amount: 1000n,
         mintAddress: address0,
         tokenVersion: TokenVersion.FEE,
-      }
+      },
     );
     await checkTxValid(hWallet, tx);
 
@@ -264,7 +264,7 @@ describe('FeeBlueprint nano contract operations', () => {
         mintAddress: address0,
         tokenVersion: TokenVersion.FEE,
       },
-      { contractPaysFees: true }
+      { contractPaysFees: true },
     );
     await checkTxValid(hWallet, tx);
 
@@ -331,7 +331,7 @@ describe('FeeBlueprint nano contract operations', () => {
           },
         ],
       },
-      { contractPaysFees: true }
+      { contractPaysFees: true },
     );
     await checkTxValid(hWallet, tx);
 
@@ -383,8 +383,8 @@ describe('FeeBlueprint nano contract operations', () => {
             // No HTR withdrawal - fee cannot be deducted
           ],
         },
-        { contractPaysFees: true }
-      )
+        { contractPaysFees: true },
+      ),
     ).rejects.toThrow('No available HTR output to deduct fee from.');
   });
 
@@ -414,7 +414,7 @@ describe('FeeBlueprint nano contract operations', () => {
         mintAddress: address0,
         tokenVersion: TokenVersion.FEE,
       },
-      { contractPaysFees: true }
+      { contractPaysFees: true },
     );
     await checkTxValid(hWallet, createTx);
     const fbt2Uid = createTx.hash!;
@@ -450,8 +450,8 @@ describe('FeeBlueprint nano contract operations', () => {
             },
           ],
         },
-        { contractPaysFees: true }
-      )
+        { contractPaysFees: true },
+      ),
     ).rejects.toThrow(/HTR withdrawal amount insufficient to cover fee/);
   });
 
@@ -481,8 +481,8 @@ describe('FeeBlueprint nano contract operations', () => {
           mintAddress: address0,
           contractPaysTokenDeposit: true,
           tokenVersion: TokenVersion.DEPOSIT,
-        }
-      )
+        },
+      ),
     ).rejects.toThrow('Withdrawal amount -100 for token 00 is less than 0.');
   });
 
@@ -536,8 +536,8 @@ describe('FeeBlueprint nano contract operations', () => {
             },
           ],
         },
-        { maxFee: 0n } // Calculated fee (1n) exceeds this
-      )
+        { maxFee: 0n }, // Calculated fee (1n) exceeds this
+      ),
     ).rejects.toThrow('Calculated fee (1) exceeds maximum fee (0)');
   });
 
@@ -619,7 +619,7 @@ describe('FeeBlueprint nano contract operations', () => {
             address: address0,
           },
         ],
-      })
+      }),
     ).rejects.toThrow('Not enough HTR utxos to pay the fee.');
   });
 
@@ -711,7 +711,7 @@ describe('FeeBlueprint nano contract operations', () => {
             changeAddress: address0,
           },
         ],
-      }
+      },
     );
     await checkTxValid(hWallet, tx);
 
@@ -800,7 +800,7 @@ describe('FeeBlueprint nano contract operations', () => {
         createMint: true,
         createMelt: true,
         tokenVersion: TokenVersion.FEE,
-      }
+      },
     );
     await checkTxValid(hWallet, createTokenTx);
 
@@ -915,7 +915,7 @@ describe('FeeBlueprint nano contract operations', () => {
         mintAddress: address0,
         tokenVersion: TokenVersion.FEE,
         data: ['data1', 'data2'],
-      }
+      },
     );
     await checkTxValid(hWallet, tx);
 
@@ -974,7 +974,7 @@ describe('FeeBlueprint nano contract operations', () => {
         tokenVersion: TokenVersion.FEE,
         data: ['data1', 'data2'],
       },
-      { contractPaysFees: true }
+      { contractPaysFees: true },
     );
     await checkTxValid(hWallet, tx);
 

--- a/__tests__/integration/nanocontracts/full_blueprint.test.ts
+++ b/__tests__/integration/nanocontracts/full_blueprint.test.ts
@@ -1,12 +1,13 @@
 import { isEmpty } from 'lodash';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
-import { NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+
 import ncApi from '../../../src/api/nano';
+import { NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+import NanoContractTransactionParser from '../../../src/nano_contracts/parser';
+import { isNanoContractCreateTx } from '../../../src/nano_contracts/utils';
 import { bufferToHex } from '../../../src/utils/buffer';
 import helpersUtils from '../../../src/utils/helpers';
-import { isNanoContractCreateTx } from '../../../src/nano_contracts/utils';
-import NanoContractTransactionParser from '../../../src/nano_contracts/parser';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
 
 describe('Full blueprint basic tests', () => {
   /** @type HathorWallet */
@@ -87,7 +88,7 @@ describe('Full blueprint basic tests', () => {
           attrTuple,
           attrList,
         ],
-      }
+      },
     );
     await checkTxValid(wallet, txInitialize);
     const txInitializeData = await wallet.getFullTxById(txInitialize.hash);
@@ -116,7 +117,7 @@ describe('Full blueprint basic tests', () => {
         'attr_list',
       ],
       [],
-      [attrCall]
+      [attrCall],
     );
 
     expect(ncState.fields.vertex.value).toBe(vertexId);
@@ -164,7 +165,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [address],
-      }
+      },
     );
     await checkTxValid(wallet, txCallerIdAddress);
 
@@ -180,7 +181,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [contractId],
-      }
+      },
     );
     await checkTxValid(wallet, txCallerIdContract);
 
@@ -196,7 +197,7 @@ describe('Full blueprint basic tests', () => {
       'set_caller_id',
       txCallerIdContractData.tx.nc_address,
       network,
-      txCallerIdContractData.tx.nc_args
+      txCallerIdContractData.tx.nc_args,
     );
     await txCallerIdParser.parseArguments();
     expect(txCallerIdParser.address?.base58).toBe(address0);
@@ -220,7 +221,7 @@ describe('Full blueprint basic tests', () => {
       txInitialize.hash,
       ['attr_optional'],
       [],
-      [attrCall]
+      [attrCall],
     );
 
     expect(ncStateOptional.fields.attr_optional.value).toBe(attrOptional);
@@ -233,7 +234,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [address, amount],
-      }
+      },
     );
     await checkTxValid(wallet, txDictAddress);
 
@@ -253,7 +254,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [attrBytes, attrInt],
-      }
+      },
     );
     await checkTxValid(wallet, txDictBytes);
 
@@ -273,7 +274,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: ['test1', 'test2', 2],
-      }
+      },
     );
     await checkTxValid(wallet, txDictStrInt);
 
@@ -293,7 +294,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: ['test1', 'cafecafe', 2],
-      }
+      },
     );
     await checkTxValid(wallet, txDictStrBytesInt);
 
@@ -345,7 +346,7 @@ describe('Full blueprint basic tests', () => {
       address0,
       {
         ncId: txInitialize.hash,
-      }
+      },
     );
     await checkTxValid(wallet, txRandom);
 
@@ -361,7 +362,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [['ab', 'cd', 'efg']],
-      }
+      },
     );
     await checkTxValid(wallet, txListAttrs);
 
@@ -387,7 +388,7 @@ describe('Full blueprint basic tests', () => {
       'set_tuple',
       txTupleData.tx.nc_address,
       network,
-      txTupleData.tx.nc_args
+      txTupleData.tx.nc_args,
     );
     await txTupleParser.parseArguments();
     expect(txTupleParser.address?.base58).toBe(address0);
@@ -413,7 +414,7 @@ describe('Full blueprint basic tests', () => {
       'set_list',
       txListData.tx.nc_address,
       network,
-      txListData.tx.nc_args
+      txListData.tx.nc_args,
     );
     await txListParser.parseArguments();
     expect(txListParser.address?.base58).toBe(address0);
@@ -438,7 +439,7 @@ describe('Full blueprint basic tests', () => {
       'set_set',
       txSetData.tx.nc_address,
       network,
-      txSetData.tx.nc_args
+      txSetData.tx.nc_args,
     );
     await txSetParser.parseArguments();
     expect(txSetParser.address?.base58).toBe(address0);
@@ -456,7 +457,7 @@ describe('Full blueprint basic tests', () => {
       txInitialize.hash,
       ['attr_tuple'],
       [],
-      [setCall, listCall]
+      [setCall, listCall],
     );
 
     expect(txContainersState.fields.attr_tuple.value).toStrictEqual(attrTuple);
@@ -482,7 +483,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [argAttrDictListTuple],
-      }
+      },
     );
     await checkTxValid(wallet, txAttrDictListTuple);
     const txAttrDictListTupleData = await wallet.getFullTxById(txAttrDictListTuple.hash);
@@ -492,7 +493,7 @@ describe('Full blueprint basic tests', () => {
       'set_attr_dict_list_tuple',
       txAttrDictListTupleData.tx.nc_address,
       network,
-      txAttrDictListTupleData.tx.nc_args
+      txAttrDictListTupleData.tx.nc_args,
     );
     await txAttrDictListTupleParser.parseArguments();
     expect(txAttrDictListTupleParser.address?.base58).toBe(address0);
@@ -517,7 +518,7 @@ describe('Full blueprint basic tests', () => {
       {
         ncId: txInitialize.hash,
         args: [dictArg],
-      }
+      },
     );
     await checkTxValid(wallet, txAttrDictDictSet);
     const txAttrDictDictSetData = await wallet.getFullTxById(txAttrDictDictSet.hash);
@@ -527,7 +528,7 @@ describe('Full blueprint basic tests', () => {
       'set_attr_dict_dict_set',
       txAttrDictDictSetData.tx.nc_address,
       network,
-      txAttrDictDictSetData.tx.nc_args
+      txAttrDictDictSetData.tx.nc_args,
     );
     await txAttrDictDictSetParser.parseArguments();
     expect(txAttrDictDictSetParser.address?.base58).toBe(address0);
@@ -555,7 +556,7 @@ describe('Full blueprint basic tests', () => {
             },
           ],
         ],
-      }
+      },
     );
     await checkTxValid(wallet, txAttrListDictTuple);
     const txAttrListDictTupleData = await wallet.getFullTxById(txAttrListDictTuple.hash);
@@ -565,7 +566,7 @@ describe('Full blueprint basic tests', () => {
       'set_attr_list_dict_tuple',
       txAttrListDictTupleData.tx.nc_address,
       network,
-      txAttrListDictTupleData.tx.nc_args
+      txAttrListDictTupleData.tx.nc_args,
     );
     await txAttrListDictTupleParser.parseArguments();
     expect(txAttrListDictTupleParser.address?.base58).toBe(address0);
@@ -591,7 +592,7 @@ describe('Full blueprint basic tests', () => {
       txInitialize.hash,
       [],
       [],
-      [dictDictSetCall, tupleDictListCall, dictListDictTupleCall]
+      [dictDictSetCall, tupleDictListCall, dictListDictTupleCall],
     );
 
     expect(callStates.calls[dictDictSetCall].value).toBe(true);

--- a/__tests__/integration/nanocontracts/parent_children.test.ts
+++ b/__tests__/integration/nanocontracts/parent_children.test.ts
@@ -1,11 +1,12 @@
 import { isEmpty } from 'lodash';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+
 import ncApi from '../../../src/api/nano';
+import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+import { isNanoContractCreateTx } from '../../../src/nano_contracts/utils';
 import { bufferToHex } from '../../../src/utils/buffer';
 import helpersUtils from '../../../src/utils/helpers';
-import { isNanoContractCreateTx } from '../../../src/nano_contracts/utils';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
 
 describe('Parent - children tests', () => {
   /** @type HathorWallet */
@@ -51,7 +52,7 @@ describe('Parent - children tests', () => {
       {
         blueprintId: blueprintParentId,
         args: [],
-      }
+      },
     );
     await checkTxValid(wallet, txInitialize);
     const txInitializeData = await wallet.getFullTxById(txInitialize.hash);
@@ -76,7 +77,7 @@ describe('Parent - children tests', () => {
       txInitialize.hash,
       [],
       [NATIVE_TOKEN_UID],
-      []
+      [],
     );
 
     expect(ncStateDeposit.balances[NATIVE_TOKEN_UID].value).toBe('500');
@@ -89,7 +90,7 @@ describe('Parent - children tests', () => {
         ncId: txInitialize.hash,
         args: ['Test token', 'TKN', 200n, true, true],
         actions: [],
-      }
+      },
     );
     await checkTxValid(wallet, txCreateToken);
 
@@ -98,7 +99,7 @@ describe('Parent - children tests', () => {
       txInitialize.hash,
       ['last_created_token'],
       [],
-      []
+      [],
     );
 
     const createTokenUid = ncStateCreateToken.fields.last_created_token.value;
@@ -107,7 +108,7 @@ describe('Parent - children tests', () => {
       txInitialize.hash,
       [],
       [NATIVE_TOKEN_UID, createTokenUid],
-      []
+      [],
     );
 
     expect(ncStateCreateTokenBalance.balances[NATIVE_TOKEN_UID].value).toBe('498');
@@ -121,7 +122,7 @@ describe('Parent - children tests', () => {
         ncId: txInitialize.hash,
         args: [blueprintChildrenId, 'cafecafe', 'Test contract'],
         actions: [],
-      }
+      },
     );
     await checkTxValid(wallet, txCreateContract);
 
@@ -130,7 +131,7 @@ describe('Parent - children tests', () => {
       txInitialize.hash,
       ['last_created_contract'],
       [],
-      []
+      [],
     );
 
     const createContractId = ncStateCreateContract.fields.last_created_contract.value;
@@ -140,7 +141,7 @@ describe('Parent - children tests', () => {
       createContractId,
       ['name', 'attr'],
       [],
-      []
+      [],
     );
 
     expect(ncStateChildInitial.fields.name.value).toBe('Test contract');
@@ -158,7 +159,7 @@ describe('Parent - children tests', () => {
       createContractId,
       ['name', 'attr'],
       [],
-      []
+      [],
     );
 
     expect(ncStateChild.fields.name.value).toBe('Test contract');

--- a/__tests__/integration/service-specific/authority-utxos.test.ts
+++ b/__tests__/integration/service-specific/authority-utxos.test.ts
@@ -15,10 +15,10 @@
  */
 
 import type { HathorWalletServiceWallet } from '../../../src';
-import { buildWalletInstance, pollForTx } from '../helpers/service-facade.helper';
+import { AuthorityType } from '../../../src/types';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
 import { GenesisWalletServiceHelper } from '../helpers/genesis-wallet.helper';
-import { AuthorityType } from '../../../src/types';
+import { buildWalletInstance, pollForTx } from '../helpers/service-facade.helper';
 
 const adapter = new ServiceWalletTestAdapter();
 
@@ -88,7 +88,7 @@ describe('[Service] getAuthorityUtxo', () => {
 
   it('should throw error for invalid authority type', async () => {
     await expect(utxosTestWallet.getAuthorityUtxo(createdTokenUid, 'invalid')).rejects.toThrow(
-      'Invalid authority value.'
+      'Invalid authority value.',
     );
   });
 
@@ -100,7 +100,7 @@ describe('[Service] getAuthorityUtxo', () => {
       AuthorityType.MINT,
       {
         many: true,
-      }
+      },
     );
 
     expect(Array.isArray(multipleAuthorities)).toBe(true);
@@ -115,7 +115,7 @@ describe('[Service] getAuthorityUtxo', () => {
       AuthorityType.MINT,
       {
         many: false,
-      }
+      },
     );
 
     expect(Array.isArray(singleAuthority)).toBe(true);
@@ -130,7 +130,7 @@ describe('[Service] getAuthorityUtxo', () => {
       AuthorityType.MINT,
       {
         only_available_utxos: true,
-      }
+      },
     );
 
     expect(Array.isArray(availableAuthorities)).toBe(true);
@@ -141,7 +141,7 @@ describe('[Service] getAuthorityUtxo', () => {
           index: expect.any(Number),
           address: expect.any(String),
           authorities: expect.any(BigInt),
-        })
+        }),
       );
     });
   });

--- a/__tests__/integration/service-specific/get-balance.test.ts
+++ b/__tests__/integration/service-specific/get-balance.test.ts
@@ -16,8 +16,8 @@
 
 import type { HathorWalletServiceWallet } from '../../../src';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
-import { buildWalletInstance, emptyWallet } from '../helpers/service-facade.helper';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import { buildWalletInstance, emptyWallet } from '../helpers/service-facade.helper';
 
 const adapter = new ServiceWalletTestAdapter();
 

--- a/__tests__/integration/service-specific/start.test.ts
+++ b/__tests__/integration/service-specific/start.test.ts
@@ -16,15 +16,16 @@
  */
 
 import Mnemonic from 'bitcore-mnemonic';
+
 import { HathorWalletServiceWallet, Storage } from '../../../src';
 import { WALLET_SERVICE_AUTH_DERIVATION_PATH } from '../../../src/constants';
 import { WalletFromXPubGuard } from '../../../src/errors';
+import Network from '../../../src/models/network';
 import { decryptData } from '../../../src/utils/crypto';
 import walletUtils from '../../../src/utils/wallet';
-import Network from '../../../src/models/network';
+import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
 import { NETWORK_NAME } from '../configuration/test-constants';
 import { buildWalletInstance, emptyWallet } from '../helpers/service-facade.helper';
-import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
 import { deriveXpubFromSeed } from '../utils/core.util';
 import { loggers } from '../utils/logger.util';
 

--- a/__tests__/integration/shared/authority-utxos.test.ts
+++ b/__tests__/integration/shared/authority-utxos.test.ts
@@ -17,11 +17,11 @@
  * - `service-specific/authority-utxos.test.ts`
  */
 
-import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 import { TOKEN_MINT_MASK, TOKEN_MELT_MASK } from '../../../src/constants';
 import { AuthorityType } from '../../../src/types';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 
 const adapters: IWalletTestAdapter[] = [
   new FullnodeWalletTestAdapter(),
@@ -60,7 +60,7 @@ describe.each(adapters)('[Shared] authority UTXOs — $name', adapter => {
           index: expect.any(Number),
           address: expect.any(String),
           authorities: expect.any(BigInt),
-        })
+        }),
       );
       expect(authUtxo.authorities & TOKEN_MINT_MASK).toBe(TOKEN_MINT_MASK);
     });
@@ -79,7 +79,7 @@ describe.each(adapters)('[Shared] authority UTXOs — $name', adapter => {
           index: expect.any(Number),
           address: expect.any(String),
           authorities: expect.any(BigInt),
-        })
+        }),
       );
       expect(authUtxo.authorities & TOKEN_MELT_MASK).toBe(TOKEN_MELT_MASK);
     });
@@ -90,7 +90,7 @@ describe.each(adapters)('[Shared] authority UTXOs — $name', adapter => {
     const authorities = await adapter.getAuthorityUtxos(
       wallet,
       nonExistentTokenUid,
-      AuthorityType.MINT
+      AuthorityType.MINT,
     );
 
     expect(Array.isArray(authorities)).toBe(true);
@@ -106,12 +106,12 @@ describe.each(adapters)('[Shared] authority UTXOs — $name', adapter => {
     const mintAuthorities = await adapter.getAuthorityUtxos(
       wallet,
       noAuthToken.hash,
-      AuthorityType.MINT
+      AuthorityType.MINT,
     );
     const meltAuthorities = await adapter.getAuthorityUtxos(
       wallet,
       noAuthToken.hash,
-      AuthorityType.MELT
+      AuthorityType.MELT,
     );
 
     expect(mintAuthorities).toHaveLength(0);
@@ -200,7 +200,7 @@ describe.each(adapters)('[Shared] authority UTXOs — $name', adapter => {
       AuthorityType.MINT,
       {
         filter_address: addr4,
-      }
+      },
     );
     expect(mintAtAddr4).toHaveLength(1);
     expect(mintAtAddr4[0].address).toBe(addr4);
@@ -212,7 +212,7 @@ describe.each(adapters)('[Shared] authority UTXOs — $name', adapter => {
       AuthorityType.MINT,
       {
         filter_address: addr5,
-      }
+      },
     );
     expect(mintAtAddr5).toHaveLength(0);
   });

--- a/__tests__/integration/shared/get-balance.test.ts
+++ b/__tests__/integration/shared/get-balance.test.ts
@@ -17,11 +17,11 @@
  * - `service-specific/get-balance.test.ts`
  */
 
-import type { IWalletTestAdapter } from '../adapters/types';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
-import { getRandomInt } from '../utils/core.util';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import type { IWalletTestAdapter } from '../adapters/types';
+import { getRandomInt } from '../utils/core.util';
 
 const adapters: IWalletTestAdapter[] = [
   new FullnodeWalletTestAdapter(),

--- a/__tests__/integration/shared/internal.test.ts
+++ b/__tests__/integration/shared/internal.test.ts
@@ -6,11 +6,12 @@
  */
 
 import axios from 'axios';
-import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
+
+import Network from '../../../src/models/network';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 import { FULLNODE_NETWORK_NAME, FULLNODE_URL, NETWORK_NAME } from '../configuration/test-constants';
-import Network from '../../../src/models/network';
 import { loggers } from '../utils/logger.util';
 
 // XXX: onConnectionChangedState has different behavior between facades

--- a/__tests__/integration/shared/send-many-outputs.test.ts
+++ b/__tests__/integration/shared/send-many-outputs.test.ts
@@ -13,11 +13,11 @@
  * facades.
  */
 
-import type { IWalletTestAdapter } from '../adapters/types';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
+import dateFormatter from '../../../src/utils/date';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
-import dateFormatter from '../../../src/utils/date';
+import type { IWalletTestAdapter } from '../adapters/types';
 import { delay } from '../utils/core.util';
 import { loggers } from '../utils/logger.util';
 
@@ -92,7 +92,7 @@ describe.each(adapters)('[Shared] sendManyOutputsTransaction — $name', adapter
             index: largerOutputIndex,
           },
         ],
-      }
+      },
     );
     const decoded3 = await adapter.getTx(wallet, tx3.hash);
     expect(decoded3.inputs).toHaveLength(1);
@@ -110,7 +110,7 @@ describe.each(adapters)('[Shared] sendManyOutputsTransaction — $name', adapter
       wallet,
       'Multiple Tokens Tk',
       'MTTK',
-      200n
+      200n,
     );
 
     const { transaction: tx } = await adapter.sendManyOutputsTransaction(wallet, [
@@ -132,19 +132,19 @@ describe.each(adapters)('[Shared] sendManyOutputsTransaction — $name', adapter
 
     // Validate output values
     expect(sendTx.outputs).toContainEqual(
-      expect.objectContaining({ value: 3n, token: NATIVE_TOKEN_UID })
+      expect.objectContaining({ value: 3n, token: NATIVE_TOKEN_UID }),
     );
     expect(sendTx.outputs).toContainEqual(
-      expect.objectContaining({ value: 5n, token: NATIVE_TOKEN_UID })
+      expect.objectContaining({ value: 5n, token: NATIVE_TOKEN_UID }),
     );
     expect(sendTx.outputs).toContainEqual(expect.objectContaining({ value: 90n, token: tokenUid }));
     expect(sendTx.outputs).toContainEqual(
-      expect.objectContaining({ value: 110n, token: tokenUid })
+      expect.objectContaining({ value: 110n, token: tokenUid }),
     );
 
     // Validate input values
     expect(sendTx.inputs).toContainEqual(
-      expect.objectContaining({ value: 8n, token: NATIVE_TOKEN_UID })
+      expect.objectContaining({ value: 8n, token: NATIVE_TOKEN_UID }),
     );
     expect(sendTx.inputs).toContainEqual(expect.objectContaining({ value: 200n, token: tokenUid }));
   });
@@ -198,7 +198,7 @@ describe.each(adapters)('[Shared] sendManyOutputsTransaction — $name', adapter
     // Confirm that locked balance is unavailable
     // Fullnode: "Insufficient funds" | Wallet Service: "No UTXOs available"
     await expect(
-      adapter.sendTransaction(wallet, (await wallet.getAddressAtIndex(3))!, 8n)
+      adapter.sendTransaction(wallet, (await wallet.getAddressAtIndex(3))!, 8n),
     ).rejects.toThrow();
 
     // Wait for second timelock to expire
@@ -216,7 +216,7 @@ describe.each(adapters)('[Shared] sendManyOutputsTransaction — $name', adapter
     const { hash } = await adapter.sendTransaction(
       wallet,
       (await wallet.getAddressAtIndex(4))!,
-      8n
+      8n,
     );
     expect(hash).toBeDefined();
   });

--- a/__tests__/integration/shared/send-transaction-tokens.test.ts
+++ b/__tests__/integration/shared/send-transaction-tokens.test.ts
@@ -13,14 +13,14 @@
  * ({@link HathorWalletServiceWallet}) facades.
  */
 
-import type { IWalletTestAdapter } from '../adapters/types';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
+import Header from '../../../src/headers/base';
+import FeeHeader from '../../../src/headers/fee';
 import { TokenVersion } from '../../../src/types';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import type { IWalletTestAdapter } from '../adapters/types';
 import { TOKEN_DATA } from '../configuration/test-constants';
-import FeeHeader from '../../../src/headers/fee';
-import Header from '../../../src/headers/base';
 
 const adapters: IWalletTestAdapter[] = [
   new FullnodeWalletTestAdapter(),
@@ -102,7 +102,7 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
       wallet,
       (await wallet.getAddressAtIndex(5))!,
       8000n,
-      { token: tokenUid, changeAddress: (await wallet.getAddressAtIndex(6))! }
+      { token: tokenUid, changeAddress: (await wallet.getAddressAtIndex(6))! },
     );
     validateFeeAmount(tx1.headers, 2n);
 
@@ -115,7 +115,7 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
       wallet,
       (await externalWallet.getAddressAtIndex(0))!,
       82n,
-      { token: tokenUid }
+      { token: tokenUid },
     );
     validateFeeAmount(tx2.headers, 2n);
 
@@ -141,14 +141,14 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
       wallet,
       (await wallet.getAddressAtIndex(5))!,
       200n,
-      { token: tokenUid }
+      { token: tokenUid },
     );
     validateFeeAmount(tx.headers, 1n);
 
     const fullTx = await adapter.getFullTxById(wallet, tx.hash!);
     // Exactly one token output (destination, no change)
     const tokenOutputs = fullTx.tx.outputs.filter(
-      (o: { token_data: number }) => o.token_data !== 0
+      (o: { token_data: number }) => o.token_data !== 0,
     );
     expect(tokenOutputs).toHaveLength(1);
     expect(tokenOutputs[0].value).toBe(200n);
@@ -172,7 +172,7 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
         address: (await wallet.getAddressAtIndex(i))!,
         value: 100n,
         token: tokenUid,
-      }))
+      })),
     );
 
     // 5 token outputs × 1n HTR each = 5n HTR fee, 4n HTR remaining
@@ -181,7 +181,7 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
 
     const fullTx = await adapter.getFullTxById(wallet, tx.hash!);
     const tokenOutputs = fullTx.tx.outputs.filter(
-      (o: { token_data: number }) => o.token_data !== 0
+      (o: { token_data: number }) => o.token_data !== 0,
     );
     expect(tokenOutputs).toHaveLength(5);
     tokenOutputs.forEach((o: { value: bigint }) => expect(o.value).toBe(100n));
@@ -202,7 +202,7 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
       100n,
       {
         tokenVersion: TokenVersion.FEE,
-      }
+      },
     );
 
     const { utxos: utxosHtr } = await adapter.getUtxos(wallet, { token: NATIVE_TOKEN_UID });
@@ -220,14 +220,14 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
           { txId: htrUtxo.tx_id, token: NATIVE_TOKEN_UID, index: htrUtxo.index },
           { txId: tokenUtxo.tx_id, token: tokenUid, index: tokenUtxo.index },
         ],
-      }
+      },
     );
     validateFeeAmount(tx.headers, 2n);
 
     const fullTx = await adapter.getFullTxById(wallet, tx.hash!);
     expect(fullTx.tx.inputs).toHaveLength(2);
     expect(fullTx.tx.outputs).toContainEqual(
-      expect.objectContaining({ value: 50n, token_data: 1 })
+      expect.objectContaining({ value: 50n, token_data: 1 }),
     );
   });
 
@@ -244,7 +244,7 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
       100n,
       {
         tokenVersion: TokenVersion.FEE,
-      }
+      },
     );
 
     const { utxos: utxosHtr } = await adapter.getUtxos(wallet, { token: NATIVE_TOKEN_UID });
@@ -262,14 +262,14 @@ describe.each(adapters)('[Shared] sendTransaction — custom tokens — $name', 
           { txId: tokenUtxo.tx_id, token: tokenUid, index: tokenUtxo.index },
           { txId: htrUtxo.tx_id, token: NATIVE_TOKEN_UID, index: htrUtxo.index },
         ],
-      }
+      },
     );
     validateFeeAmount(tx.headers, 2n);
 
     const fullTx = await adapter.getFullTxById(wallet, tx.hash!);
     expect(fullTx.tx.inputs).toHaveLength(2);
     expect(fullTx.tx.outputs).toContainEqual(
-      expect.objectContaining({ value: 50n, token_data: TOKEN_DATA.TOKEN })
+      expect.objectContaining({ value: 50n, token_data: TOKEN_DATA.TOKEN }),
     );
   });
 });

--- a/__tests__/integration/shared/send-transaction.test.ts
+++ b/__tests__/integration/shared/send-transaction.test.ts
@@ -17,10 +17,10 @@
  * live in `fullnode-specific/send-transaction.test.ts`.
  */
 
-import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 import { WALLET_CONSTANTS } from '../configuration/test-constants';
 
 const adapters: IWalletTestAdapter[] = [
@@ -90,7 +90,7 @@ describe.each(adapters)('[Shared] sendTransaction — $name', adapter => {
         parents: expect.arrayContaining([expect.any(String)]),
         tokens: expect.any(Array),
         signalBits: expect.any(Number),
-      })
+      }),
     );
 
     expect(tx.hash).toHaveLength(64);
@@ -114,7 +114,7 @@ describe.each(adapters)('[Shared] sendTransaction — $name', adapter => {
         hash: expect.any(String),
         inputs: expect.any(Array),
         outputs: expect.any(Array),
-      })
+      }),
     );
 
     const fullTx = await adapter.getFullTxById(wallet, hash);
@@ -137,7 +137,7 @@ describe.each(adapters)('[Shared] sendTransaction — $name', adapter => {
       freshWallet,
       recipientAddr,
       2n,
-      { changeAddress: changeAddr }
+      { changeAddress: changeAddr },
     );
 
     expect(tx.outputs.length).toBe(2);
@@ -146,7 +146,7 @@ describe.each(adapters)('[Shared] sendTransaction — $name', adapter => {
     expect(fullTx.success).toBe(true);
 
     const recipientOutput = fullTx.tx.outputs.find(
-      output => output.decoded?.address === recipientAddr
+      output => output.decoded?.address === recipientAddr,
     );
     expect(recipientOutput).toBeDefined();
     expect(recipientOutput!.value).toBe(2n);

--- a/__tests__/integration/shared/server_changes.test.ts
+++ b/__tests__/integration/shared/server_changes.test.ts
@@ -20,11 +20,11 @@
  * - `testnetServerUrl`: a real testnet endpoint for validation
  */
 
-import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
-import { delay } from '../utils/core.util';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 import { FULLNODE_NETWORK_NAME } from '../configuration/test-constants';
+import { delay } from '../utils/core.util';
 
 const adapters: IWalletTestAdapter[] = [
   new FullnodeWalletTestAdapter(),

--- a/__tests__/integration/shared/start.test.ts
+++ b/__tests__/integration/shared/start.test.ts
@@ -7,15 +7,16 @@
  */
 
 import type { EventEmitter } from 'events';
-import type { AddressInfoObject } from '../../../src/wallet/types';
-import type { ConcreteWalletType, FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
+
+import { WalletAddressMode } from '../../../src';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
-import { delay, deriveXpubFromSeed, getRandomInt } from '../utils/core.util';
-import { loggers } from '../utils/logger.util';
+import { HasTxOutsideFirstAddressError } from '../../../src/errors';
+import type { AddressInfoObject } from '../../../src/wallet/types';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
-import { WalletAddressMode } from '../../../src';
-import { HasTxOutsideFirstAddressError } from '../../../src/errors';
+import type { ConcreteWalletType, FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
+import { delay, deriveXpubFromSeed, getRandomInt } from '../utils/core.util';
+import { loggers } from '../utils/logger.util';
 
 const adapters: IWalletTestAdapter[] = [
   new FullnodeWalletTestAdapter(),
@@ -57,7 +58,7 @@ describe.each(adapters)('[Shared] start — $name', adapter => {
         adapter.startWallet(wallet, {
           pinCode: undefined,
           password: adapter.defaultPassword,
-        })
+        }),
       ).rejects.toThrow(/pin/i);
     });
 
@@ -70,7 +71,7 @@ describe.each(adapters)('[Shared] start — $name', adapter => {
         adapter.startWallet(wallet, {
           pinCode: adapter.defaultPinCode,
           password: undefined,
-        })
+        }),
       ).rejects.toThrow(/password/i);
     });
   });
@@ -407,7 +408,7 @@ describe.each(adapters)('[Shared] start — $name', adapter => {
 
         await expect(wallet.getAddressMode()).resolves.toEqual(WalletAddressMode.MULTI);
         await expect(wallet.enableSingleAddressMode()).rejects.toThrow(
-          HasTxOutsideFirstAddressError
+          HasTxOutsideFirstAddressError,
         );
         await expect(wallet.getAddressMode()).resolves.toEqual(WalletAddressMode.MULTI);
       } finally {

--- a/__tests__/integration/storage/storage.test.ts
+++ b/__tests__/integration/storage/storage.test.ts
@@ -1,3 +1,10 @@
+import { NATIVE_TOKEN_UID } from '../../../src/constants';
+import { InvalidPasswdError, SendTxError } from '../../../src/errors';
+import SendTransaction from '../../../src/new/sendTransaction';
+import HathorWallet from '../../../src/new/wallet';
+import { MemoryStore, Storage } from '../../../src/storage';
+import transactionUtils from '../../../src/utils/transaction';
+import { IHathorWallet } from '../../../src/wallet/types';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
 import {
@@ -9,15 +16,8 @@ import {
   waitForWalletReady,
   waitForTxReceived,
 } from '../helpers/wallet.helper';
-import { InvalidPasswdError, SendTxError } from '../../../src/errors';
-import HathorWallet from '../../../src/new/wallet';
-import { loggers } from '../utils/logger.util';
-import SendTransaction from '../../../src/new/sendTransaction';
-import { MemoryStore, Storage } from '../../../src/storage';
-import transactionUtils from '../../../src/utils/transaction';
-import { NATIVE_TOKEN_UID } from '../../../src/constants';
-import { IHathorWallet } from '../../../src/wallet/types';
 import { getGapLimitConfig } from '../utils/core.util';
+import { loggers } from '../utils/logger.util';
 
 const startedWallets = [];
 

--- a/__tests__/integration/template/transaction/fee.test.ts
+++ b/__tests__/integration/template/transaction/fee.test.ts
@@ -1,4 +1,10 @@
 import { isEmpty } from 'lodash';
+
+import ncApi from '../../../../src/api/nano';
+import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../../src/constants';
+import { NanoContractHeaderActionType } from '../../../../src/nano_contracts/types';
+import HathorWallet from '../../../../src/new/wallet';
+import { TransactionTemplateBuilder } from '../../../../src/template/transaction/builder';
 import { GenesisWalletHelper } from '../../helpers/genesis-wallet.helper';
 import {
   DEFAULT_PIN_CODE,
@@ -7,12 +13,6 @@ import {
   waitForTxReceived,
   waitTxConfirmed,
 } from '../../helpers/wallet.helper';
-
-import ncApi from '../../../../src/api/nano';
-import HathorWallet from '../../../../src/new/wallet';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../../src/constants';
-import { TransactionTemplateBuilder } from '../../../../src/template/transaction/builder';
-import { NanoContractHeaderActionType } from '../../../../src/nano_contracts/types';
 
 describe('FeeBlueprint Template execution', () => {
   let hWallet: HathorWallet;
@@ -44,7 +44,7 @@ describe('FeeBlueprint Template execution', () => {
             changeAddress: address0,
           },
         ],
-      }
+      },
     );
     await waitForTxReceived(hWallet, initTx.hash);
     await waitTxConfirmed(hWallet, initTx.hash, null);
@@ -69,7 +69,7 @@ describe('FeeBlueprint Template execution', () => {
             changeAddress: address0,
           },
         ],
-      }
+      },
     );
     await waitForTxReceived(hWallet, dbtTx.hash);
     await waitTxConfirmed(hWallet, dbtTx.hash, null);
@@ -148,7 +148,7 @@ describe('FeeBlueprint Template execution', () => {
       contractId,
       [],
       [fbtUid, NATIVE_TOKEN_UID],
-      []
+      [],
     );
     const fbtBalanceBefore = BigInt(ncStateBefore.balances[fbtUid].value);
     const htrBalanceBefore = BigInt(ncStateBefore.balances[NATIVE_TOKEN_UID].value);
@@ -213,13 +213,13 @@ describe('FeeBlueprint Template execution', () => {
       contractId,
       [],
       [fbtUid, NATIVE_TOKEN_UID],
-      []
+      [],
     );
     // FBT balance should increase by deposit amount
     expect(BigInt(ncStateAfter.balances[fbtUid].value)).toBe(fbtBalanceBefore + depositAmount);
     // HTR balance should decrease by fee amount (withdrawn to pay fee)
     expect(BigInt(ncStateAfter.balances[NATIVE_TOKEN_UID].value)).toBe(
-      htrBalanceBefore - feeAmount
+      htrBalanceBefore - feeAmount,
     );
   });
 
@@ -407,7 +407,7 @@ describe('FeeBlueprint Template execution', () => {
     // Verify contract balance decreased by total withdrawal
     const ncStateAfter = await ncApi.getNanoContractState(contractId, [], [fbtUid], []);
     expect(BigInt(ncStateAfter.balances[fbtUid].value)).toBe(
-      fbtBalanceBefore - withdrawal1 - withdrawal2
+      fbtBalanceBefore - withdrawal1 - withdrawal2,
     );
   });
 

--- a/__tests__/integration/template/transaction/nano.test.ts
+++ b/__tests__/integration/template/transaction/nano.test.ts
@@ -1,4 +1,18 @@
 import { isEmpty } from 'lodash';
+
+import ncApi from '../../../../src/api/nano';
+import {
+  CREATE_TOKEN_TX_VERSION,
+  NATIVE_TOKEN_UID,
+  TOKEN_AUTHORITY_MASK,
+  TOKEN_MELT_MASK,
+  TOKEN_MINT_MASK,
+} from '../../../../src/constants';
+import SendTransaction from '../../../../src/new/sendTransaction';
+import HathorWallet from '../../../../src/new/wallet';
+import { TransactionTemplateBuilder } from '../../../../src/template/transaction/builder';
+import { WalletTxTemplateInterpreter } from '../../../../src/template/transaction/interpreter';
+import dateFormatter from '../../../../src/utils/date';
 import { GenesisWalletHelper } from '../../helpers/genesis-wallet.helper';
 import {
   DEFAULT_PIN_CODE,
@@ -7,20 +21,6 @@ import {
   waitForTxReceived,
   waitTxConfirmed,
 } from '../../helpers/wallet.helper';
-
-import ncApi from '../../../../src/api/nano';
-import HathorWallet from '../../../../src/new/wallet';
-import SendTransaction from '../../../../src/new/sendTransaction';
-import { TransactionTemplateBuilder } from '../../../../src/template/transaction/builder';
-import { WalletTxTemplateInterpreter } from '../../../../src/template/transaction/interpreter';
-import {
-  CREATE_TOKEN_TX_VERSION,
-  NATIVE_TOKEN_UID,
-  TOKEN_AUTHORITY_MASK,
-  TOKEN_MELT_MASK,
-  TOKEN_MINT_MASK,
-} from '../../../../src/constants';
-import dateFormatter from '../../../../src/utils/date';
 
 const DEBUG = true;
 
@@ -84,7 +84,7 @@ describe('Template execution', () => {
     const initializeTx = await interpreter.buildAndSign(
       initializeTemplate,
       DEFAULT_PIN_CODE,
-      DEBUG
+      DEBUG,
     );
     const initializeSendTx = new SendTransaction({
       storage: hWallet.storage,
@@ -207,7 +207,7 @@ describe('Template execution', () => {
     const withdrawalTx = await interpreter.buildAndSign(
       withdrawalTemplate,
       DEFAULT_PIN_CODE,
-      DEBUG
+      DEBUG,
     );
     const withdrawalSendTx = new SendTransaction({
       storage: hWallet.storage,
@@ -283,7 +283,7 @@ describe('Template execution', () => {
           value: expect.anything(), // change output
           tokenData: 0,
         }),
-      ])
+      ]),
     );
   });
 
@@ -348,7 +348,7 @@ describe('Template execution', () => {
           value: 4n,
           tokenData: 0,
         }),
-      ])
+      ]),
     );
 
     // Grant authority
@@ -395,7 +395,7 @@ describe('Template execution', () => {
       contractId,
       [],
       [tokenUID, NATIVE_TOKEN_UID],
-      []
+      [],
     );
     expect(BigInt(ncStateMint.balances[NATIVE_TOKEN_UID].value)).toBe(93n);
     expect(BigInt(ncStateMint.balances[tokenUID].value)).toBe(200n);
@@ -423,7 +423,7 @@ describe('Template execution', () => {
           value: TOKEN_MINT_MASK,
           tokenData: TOKEN_AUTHORITY_MASK | 1,
         }),
-      ])
+      ]),
     );
 
     const revokeTemplate = TransactionTemplateBuilder.new()
@@ -447,7 +447,7 @@ describe('Template execution', () => {
       contractId,
       [],
       [tokenUID, NATIVE_TOKEN_UID],
-      []
+      [],
     );
 
     expect(BigInt(ncStateRevoke.balances[NATIVE_TOKEN_UID].value)).toBe(93n);

--- a/__tests__/integration/template/transaction/template.test.ts
+++ b/__tests__/integration/template/transaction/template.test.ts
@@ -1,3 +1,15 @@
+import {
+  NATIVE_TOKEN_UID,
+  TOKEN_AUTHORITY_MASK,
+  TOKEN_MELT_MASK,
+  TOKEN_MINT_MASK,
+} from '../../../../src/constants';
+import SendTransaction from '../../../../src/new/sendTransaction';
+import HathorWallet from '../../../../src/new/wallet';
+import { TransactionTemplateBuilder } from '../../../../src/template/transaction/builder';
+import { WalletTxTemplateInterpreter } from '../../../../src/template/transaction/interpreter';
+import { TokenVersion } from '../../../../src/types';
+import transactionUtils from '../../../../src/utils/transaction';
 import { GenesisWalletHelper } from '../../helpers/genesis-wallet.helper';
 import {
   DEFAULT_PIN_CODE,
@@ -5,19 +17,6 @@ import {
   stopAllWallets,
   waitForTxReceived,
 } from '../../helpers/wallet.helper';
-
-import HathorWallet from '../../../../src/new/wallet';
-import SendTransaction from '../../../../src/new/sendTransaction';
-import transactionUtils from '../../../../src/utils/transaction';
-import { TransactionTemplateBuilder } from '../../../../src/template/transaction/builder';
-import { WalletTxTemplateInterpreter } from '../../../../src/template/transaction/interpreter';
-import {
-  NATIVE_TOKEN_UID,
-  TOKEN_AUTHORITY_MASK,
-  TOKEN_MELT_MASK,
-  TOKEN_MINT_MASK,
-} from '../../../../src/constants';
-import { TokenVersion } from '../../../../src/types';
 
 const DEBUG = true;
 
@@ -329,7 +328,7 @@ describe('Template execution', () => {
           tokenData: TOKEN_AUTHORITY_MASK + 1,
           value: TOKEN_MELT_MASK,
         }),
-      ])
+      ]),
     );
   });
 
@@ -360,7 +359,7 @@ describe('Template execution', () => {
           tokenData: 1,
           value: 100n,
         }),
-      ])
+      ]),
     );
   });
 
@@ -403,7 +402,7 @@ describe('Template execution', () => {
           tokenData: 1,
           value: 500n,
         }),
-      ])
+      ]),
     );
 
     /**
@@ -440,7 +439,7 @@ describe('Template execution', () => {
           tokenData: TOKEN_AUTHORITY_MASK | 1,
           value: TOKEN_MINT_MASK,
         }),
-      ])
+      ]),
     );
   });
 });
@@ -508,7 +507,7 @@ describe('Template execution with fee tokens', () => {
 
     // Expecting the transaction to fail validation with negative HTR balance
     await expect(sendTx.runFromMining()).rejects.toThrow(
-      'full validation failed: Fee amount is different than expected. (amount=0, expected=4)'
+      'full validation failed: Fee amount is different than expected. (amount=0, expected=4)',
     );
 
     // Check the wallet balance to verify nothing was spent from the wallet

--- a/__tests__/integration/utils/core.util.ts
+++ b/__tests__/integration/utils/core.util.ts
@@ -6,6 +6,7 @@
  */
 
 import Mnemonic from 'bitcore-mnemonic/lib/mnemonic';
+
 import { P2PKH_ACCT_PATH } from '../../../src/constants';
 import Network from '../../../src/models/network';
 import { AddressScanPolicyData, SCANNING_POLICY } from '../../../src/types';

--- a/__tests__/integration/utils/logger.util.ts
+++ b/__tests__/integration/utils/logger.util.ts
@@ -6,6 +6,7 @@
  */
 
 import winston from 'winston';
+
 import testConfig from '../configuration/test.config';
 
 export const loggers: {

--- a/__tests__/integration/utils/wallet-tracker.util.ts
+++ b/__tests__/integration/utils/wallet-tracker.util.ts
@@ -6,6 +6,7 @@
  */
 
 import type { WalletStopOptions } from '../../../src/new/types';
+
 import { loggers } from './logger.util';
 
 interface Stoppable {

--- a/__tests__/integration/walletservice_facade.test.ts
+++ b/__tests__/integration/walletservice_facade.test.ts
@@ -1,4 +1,3 @@
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
 import {
   CreateTokenTransaction,
   MemoryStore,
@@ -8,18 +7,20 @@ import {
   Network,
   transactionUtils,
 } from '../../src';
-import { WALLET_CONSTANTS } from './configuration/test-constants';
 import { NATIVE_TOKEN_UID, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../../src/constants';
+import { SendTxError, UtxoError, WalletRequestError } from '../../src/errors';
+import { TokenVersion, WalletAddressMode } from '../../src/types';
+import { GetAddressesObject } from '../../src/wallet/types';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
+
+import { WALLET_CONSTANTS } from './configuration/test-constants';
+import { GenesisWalletServiceHelper } from './helpers/genesis-wallet.helper';
 import {
   buildWalletInstance,
   emptyWallet,
   initializeServiceGlobalConfigs,
   pollForTx,
 } from './helpers/service-facade.helper';
-import { SendTxError, UtxoError, WalletRequestError } from '../../src/errors';
-import { GetAddressesObject } from '../../src/wallet/types';
-import { TokenVersion, WalletAddressMode } from '../../src/types';
-import { GenesisWalletServiceHelper } from './helpers/genesis-wallet.helper';
 
 // Set base URL for the wallet service API inside the privatenet test container
 initializeServiceGlobalConfigs();
@@ -280,7 +281,7 @@ describe('empty wallet address methods', () => {
 
   it('getPrivateKeyFromAddress throws for unknown address', async () => {
     await expect(wallet.getPrivateKeyFromAddress(unknownAddress, { pinCode })).rejects.toThrow(
-      /does not belong to this wallet/
+      /does not belong to this wallet/,
     );
   });
 });
@@ -305,7 +306,7 @@ describe('basic transaction methods', () => {
       await wallet.start({ pinCode, password });
 
       await expect(
-        wallet.createNewToken(tokenName, tokenSymbol, tokenAmount, { pinCode })
+        wallet.createNewToken(tokenName, tokenSymbol, tokenAmount, { pinCode }),
       ).rejects.toThrow(UtxoError);
     });
 
@@ -349,7 +350,7 @@ describe('basic transaction methods', () => {
 
           // Headers
           headers: expect.any(Array), // May be empty
-        })
+        }),
       );
 
       // Deep validate the Outputs array
@@ -360,7 +361,7 @@ describe('basic transaction methods', () => {
             script: expect.any(Buffer),
             tokenData: expect.any(Number),
           }),
-        ])
+        ]),
       );
 
       // Additional validations
@@ -396,7 +397,7 @@ describe('basic transaction methods', () => {
           value: tokenAmount,
           tokenData: 1,
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Validate mint authority output (default behavior creates mint authority)
@@ -406,7 +407,7 @@ describe('basic transaction methods', () => {
           value: 1n, // TOKEN_MINT_MASK
           tokenData: 129, // AUTHORITY_TOKEN_DATA + mint bit
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Validate melt authority output (default behavior creates melt authority)
@@ -416,7 +417,7 @@ describe('basic transaction methods', () => {
           value: 2n, // TOKEN_MELT_MASK
           tokenData: 129, // AUTHORITY_TOKEN_DATA + melt bit
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Verify the transaction can be found after creation
@@ -430,7 +431,7 @@ describe('basic transaction methods', () => {
           id: tokenUid,
           name: tokenName,
           symbol: tokenSymbol,
-        })
+        }),
       );
       expect(tokenDetails.totalSupply).toBe(tokenAmount);
       expect(tokenDetails.totalTransactions).toBe(1);
@@ -470,14 +471,14 @@ describe('basic transaction methods', () => {
           address: recipientAddress,
           value: 10n,
           tokenId: tokenUid,
-        })
+        }),
       );
       const changeUtxo = await wallet.getUtxoFromId(sendTransaction.hash!, changeIndex);
       expect(changeUtxo).toStrictEqual(
         expect.objectContaining({
           value: 90n,
           tokenId: tokenUid,
-        })
+        }),
       );
     });
 
@@ -502,7 +503,7 @@ describe('basic transaction methods', () => {
           // Token creation specific properties
           name: tokenName,
           symbol: tokenSymbol,
-        })
+        }),
       );
 
       // Validate specific output types for token creation with no authorities
@@ -526,7 +527,7 @@ describe('basic transaction methods', () => {
           value: tokenAmount,
           tokenData: 1,
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Validate that no authority outputs were created
@@ -543,7 +544,7 @@ describe('basic transaction methods', () => {
           id: noAuthTokenUid,
           name: tokenName,
           symbol: tokenSymbol,
-        })
+        }),
       );
       expect(tokenDetails.totalSupply).toBe(tokenAmount);
       expect(tokenDetails.totalTransactions).toBe(1);
@@ -579,7 +580,7 @@ describe('basic transaction methods', () => {
           hash: expect.any(String),
           name: tokenName,
           symbol: tokenSymbol,
-        })
+        }),
       );
 
       // Verify the transaction can be found after creation
@@ -617,33 +618,33 @@ describe('basic transaction methods', () => {
           address: destinationAddress,
           value: tokenAmount,
           tokenId: specificAddressTokenUid,
-        })
+        }),
       );
 
       // Verify mint authority output went to mint authority address
       const mintAuthorityUtxo = await wallet.getUtxoFromId(
         specificAddressTokenUid,
-        mintAuthorityOutputIndex
+        mintAuthorityOutputIndex,
       );
       expect(mintAuthorityUtxo).toStrictEqual(
         expect.objectContaining({
           address: mintAuthorityAddress,
           value: 0n,
           tokenId: specificAddressTokenUid,
-        })
+        }),
       );
 
       // Verify melt authority output went to melt authority address
       const meltAuthorityUtxo = await wallet.getUtxoFromId(
         specificAddressTokenUid,
-        meltAuthorityOutputIndex
+        meltAuthorityOutputIndex,
       );
       expect(meltAuthorityUtxo).toStrictEqual(
         expect.objectContaining({
           address: meltAuthorityAddress,
           value: 0n,
           tokenId: specificAddressTokenUid,
-        })
+        }),
       );
 
       // Verify change output went to change address (if exists)
@@ -655,7 +656,7 @@ describe('basic transaction methods', () => {
           expect.objectContaining({
             address: changeAddress,
             tokenId: NATIVE_TOKEN_UID,
-          })
+          }),
         );
       }
 
@@ -666,7 +667,7 @@ describe('basic transaction methods', () => {
           id: specificAddressTokenUid,
           name: tokenName,
           symbol: tokenSymbol,
-        })
+        }),
       );
       expect(tokenDetails.totalSupply).toBe(tokenAmount);
       expect(tokenDetails.totalTransactions).toBe(1);
@@ -699,7 +700,7 @@ describe('basic transaction methods', () => {
           mintAuthorityAddress,
           createMelt: true,
           meltAuthorityAddress,
-        })
+        }),
       ).rejects.toThrow(); // Should throw because external addresses are not allowed without flags
 
       // Second test: Pass the correct flags to allow external addresses - should succeed
@@ -742,7 +743,7 @@ describe('basic transaction methods', () => {
 
           // Headers
           headers: expect.any(Array), // May be empty
-        })
+        }),
       );
 
       // Deep validate the Outputs array
@@ -753,7 +754,7 @@ describe('basic transaction methods', () => {
             script: expect.any(Buffer),
             tokenData: expect.any(Number),
           }),
-        ])
+        ]),
       );
 
       // Additional validations
@@ -791,7 +792,7 @@ describe('basic transaction methods', () => {
           value: tokenAmount,
           tokenData: 1,
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Validate mint authority output
@@ -801,7 +802,7 @@ describe('basic transaction methods', () => {
           value: 1n, // TOKEN_MINT_MASK
           tokenData: 129, // AUTHORITY_TOKEN_DATA + token_data
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Validate melt authority output
@@ -811,7 +812,7 @@ describe('basic transaction methods', () => {
           value: 2n, // TOKEN_MELT_MASK
           tokenData: 129, // AUTHORITY_TOKEN_DATA + token_data
           script: expect.any(Buffer),
-        })
+        }),
       );
 
       // Verify the transaction can be found after creation
@@ -854,7 +855,7 @@ describe('basic transaction methods', () => {
           id: externalWalletTokenUid,
           name: tokenName,
           symbol: tokenSymbol,
-        })
+        }),
       );
       expect(tokenDetails.totalSupply).toBe(tokenAmount);
       expect(tokenDetails.totalTransactions).toBe(1);
@@ -884,7 +885,7 @@ describe('basic transaction methods', () => {
           }),
           transactions: 0,
           lockExpires: null,
-        })
+        }),
       );
 
       const { wallet: destinationWallet } = buildWalletInstance({
@@ -963,7 +964,7 @@ describe('address management methods', () => {
         expect.objectContaining({
           index: expect.any(Number),
           address: expect.any(String),
-        })
+        }),
       );
 
       expect(currentAddress.index).toBeGreaterThanOrEqual(0);
@@ -1023,7 +1024,7 @@ describe('address management methods', () => {
             index: i,
             transactions: 0,
             seqnum: 0,
-          })
+          }),
         );
       }
     });
@@ -1091,7 +1092,7 @@ describe('getUtxos, getUtxosForAmount', () => {
           total_amount_locked: expect.any(BigInt),
           total_utxos_locked: expect.any(BigInt),
           utxos: expect.any(Array),
-        })
+        }),
       );
 
       // Should have at least some UTXOs from our funding transactions
@@ -1108,7 +1109,7 @@ describe('getUtxos, getUtxosForAmount', () => {
             tx_id: expect.any(String),
             locked: expect.any(Boolean),
             index: expect.any(Number),
-          })
+          }),
         );
         expect(utxo.amount).toBeGreaterThan(0n);
         expect(utxosWallet.addresses).toContain(utxo.address);
@@ -1277,7 +1278,7 @@ describe('Fee-based tokens', () => {
 
     // Validate no authority outputs
     const authorityOutputs = createTokenTx.outputs.filter(
-      o => o.tokenData === 129 // AUTHORITY_TOKEN_DATA + 1
+      o => o.tokenData === 129, // AUTHORITY_TOKEN_DATA + 1
     );
     expect(authorityOutputs).toHaveLength(0);
 
@@ -1507,7 +1508,7 @@ describe('Fee-based tokens', () => {
       emptyWalletInstance.createNewToken('NoFundsFeeToken', 'NFFT', 1000n, {
         pinCode,
         tokenVersion: TokenVersion.FEE,
-      })
+      }),
     ).rejects.toThrow(UtxoError);
   });
 
@@ -1539,7 +1540,7 @@ describe('Fee-based tokens', () => {
       const drainTx = await feeWallet.sendTransaction(
         WALLET_CONSTANTS.genesis.addresses[0],
         remainingHtr,
-        { pinCode }
+        { pinCode },
       );
       await pollForTx(feeWallet, drainTx.hash!);
     }
@@ -1557,7 +1558,7 @@ describe('Fee-based tokens', () => {
       feeWallet.sendTransaction(feeTokenWallet.addresses[5], 100n, {
         token: tokenUid,
         pinCode,
-      })
+      }),
     ).rejects.toThrow(SendTxError);
   });
 
@@ -1588,7 +1589,7 @@ describe('Fee-based tokens', () => {
       {
         pinCode,
         tokenVersion: TokenVersion.FEE,
-      }
+      },
     )) as CreateTokenTransaction;
     await pollForTx(feeWallet, createTokenTx.hash!);
     const tokenUid = createTokenTx.hash!;
@@ -1835,7 +1836,7 @@ describe('single-address mode', () => {
     await GenesisWalletServiceHelper.injectFunds(singleAddressWallet2.addresses[1], 10n, wallet);
 
     await expect(wallet.enableSingleAddressMode()).rejects.toThrow(
-      'Cannot enable single-address policy'
+      'Cannot enable single-address policy',
     );
   });
 

--- a/__tests__/integration/walletservice_nano_fee.test.ts
+++ b/__tests__/integration/walletservice_nano_fee.test.ts
@@ -1,3 +1,7 @@
+import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../src/constants';
+import { TokenVersion } from '../../src/types';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
+
 import { GenesisWalletServiceHelper } from './helpers/genesis-wallet.helper';
 import {
   buildWalletInstance,
@@ -7,9 +11,6 @@ import {
   pollForTokenDetails,
   pollForTx,
 } from './helpers/service-facade.helper';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
-import { NATIVE_TOKEN_UID, NANO_CONTRACTS_INITIALIZE_METHOD } from '../../src/constants';
-import { TokenVersion } from '../../src/types';
 
 const pinCode = '123456';
 const password = 'testpass';
@@ -54,7 +55,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
           },
         ],
       },
-      { pinCode }
+      { pinCode },
     );
     await pollForTx(wsWallet, initTx.hash!);
     contractId = initTx.hash!;
@@ -75,7 +76,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
           },
         ],
       },
-      { pinCode }
+      { pinCode },
     );
     await pollForTx(wsWallet, createFbtTx.hash!);
 
@@ -116,7 +117,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
           },
         ],
       },
-      { pinCode }
+      { pinCode },
     );
     await pollForTx(wsWallet, withdrawTx.hash!);
     await checkTxNotVoided(wsWallet, withdrawTx.hash!);
@@ -140,7 +141,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
           },
         ],
       },
-      { signTx: false }
+      { signTx: false },
     );
 
     const txBeforeChangeCaller = sendTransaction.transaction!;
@@ -163,7 +164,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
       expect.arrayContaining([
         expect.objectContaining({ tokenData: 1 }), // FBT
         expect.objectContaining({ tokenData: 0 }), // HTR
-      ])
+      ]),
     );
 
     // 4. Edit caller: change address AND seqnum for the new caller
@@ -218,7 +219,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
         createMelt: true,
         meltAuthorityAddress: address0,
       },
-      { signTx: false }
+      { signTx: false },
     );
 
     const txBeforeChangeCaller = sendTransaction.transaction!;
@@ -243,7 +244,7 @@ describe('WalletService Nano Contract Fee Tests', () => {
         expect.objectContaining({
           tokenData: 0, // HTR change
         }),
-      ])
+      ]),
     );
 
     // 3. Edit caller: change address AND seqnum for the new caller

--- a/__tests__/models/output.test.ts
+++ b/__tests__/models/output.test.ts
@@ -6,12 +6,7 @@
  */
 
 import buffer from 'buffer';
-import Output from '../../src/models/output';
-import Address from '../../src/models/address';
-import P2PKH from '../../src/models/p2pkh';
-import Network from '../../src/models/network';
-import { OutputValueError, ParseScriptError } from '../../src/errors';
-import { parseP2PKH } from '../../src/utils/scripts';
+
 import {
   AUTHORITY_TOKEN_DATA,
   TOKEN_MINT_MASK,
@@ -19,6 +14,12 @@ import {
   MAX_OUTPUT_VALUE,
   MAX_OUTPUT_VALUE_32,
 } from '../../src/constants';
+import { OutputValueError, ParseScriptError } from '../../src/errors';
+import Address from '../../src/models/address';
+import Network from '../../src/models/network';
+import Output from '../../src/models/output';
+import P2PKH from '../../src/models/p2pkh';
+import { parseP2PKH } from '../../src/utils/scripts';
 
 const address = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo');
 const p2pkh = new P2PKH(address);
@@ -48,19 +49,19 @@ test('Validate value', () => {
   // Value greater than 32 bytes max
   const o5 = new Output(MAX_OUTPUT_VALUE_32 + 1n, p2pkhScript);
   expect(o5.valueToBytes()).toStrictEqual(
-    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x80, 0x0, 0x0, 0x0])
+    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x80, 0x0, 0x0, 0x0]),
   );
 
   // Value smaller than max
   const o6 = new Output(MAX_OUTPUT_VALUE - 1n, p2pkhScript);
   expect(o6.valueToBytes()).toStrictEqual(
-    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01])
+    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01]),
   );
 
   // Value equal to max
   const o7 = new Output(MAX_OUTPUT_VALUE, p2pkhScript);
   expect(o7.valueToBytes()).toStrictEqual(
-    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
   );
 
   // Value bigger than the max is invalid

--- a/__tests__/models/p2pkh.test.ts
+++ b/__tests__/models/p2pkh.test.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import P2PKH from '../../src/models/p2pkh';
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
+import P2PKH from '../../src/models/p2pkh';
 
 test('createScript', () => {
   const testnet = new Network('testnet');

--- a/__tests__/models/p2sh.test.ts
+++ b/__tests__/models/p2sh.test.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import P2SH from '../../src/models/p2sh';
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
+import P2SH from '../../src/models/p2sh';
 
 test('createScript', () => {
   const testnet = new Network('testnet');

--- a/__tests__/models/partial_tx.test.ts
+++ b/__tests__/models/partial_tx.test.ts
@@ -5,20 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { PartialTx, ProposalInput, ProposalOutput } from '../../src/models/partial_tx';
-import Network from '../../src/models/network';
-import Address from '../../src/models/address';
-import dateFormatter from '../../src/utils/date';
-
-import { UnsupportedScriptError } from '../../src/errors';
+import txApi from '../../src/api/txApi';
 import {
   NATIVE_TOKEN_UID,
   DEFAULT_TX_VERSION,
   TOKEN_MINT_MASK,
   TOKEN_MELT_MASK,
 } from '../../src/constants';
-import txApi from '../../src/api/txApi';
+import { UnsupportedScriptError } from '../../src/errors';
+import Address from '../../src/models/address';
+import Network from '../../src/models/network';
 import P2PKH from '../../src/models/p2pkh';
+import { PartialTx, ProposalInput, ProposalOutput } from '../../src/models/partial_tx';
+import dateFormatter from '../../src/utils/date';
 import transaction from '../../src/utils/transaction';
 
 describe('PartialTx.getTxData', () => {
@@ -56,7 +55,7 @@ describe('PartialTx.getTxData', () => {
         outputs: [],
         tokens: [],
         version: DEFAULT_TX_VERSION,
-      })
+      }),
     );
   });
 
@@ -80,7 +79,7 @@ describe('PartialTx.getTxData', () => {
       expect.objectContaining({
         inputs: [0, 1, 2, 3, 4],
         outputs: [10, 9, 8],
-      })
+      }),
     );
   });
 });
@@ -204,7 +203,7 @@ describe('PartialTx.addInput', () => {
         authorities: 0n,
         value: 1n,
         address: 'W123',
-      })
+      }),
     );
     partialTx.addInput('hash1', 0, 1n, 'W123', { token: '1', authorities: 0n });
     expect(partialTx.inputs).toEqual(expected);
@@ -218,7 +217,7 @@ describe('PartialTx.addInput', () => {
         authorities: 0n,
         value: 27n,
         address: 'Wabc',
-      })
+      }),
     );
     partialTx.addInput('hash2', 1, 27n, 'Wabc');
     expect(partialTx.inputs).toEqual(expected);
@@ -232,7 +231,7 @@ describe('PartialTx.addInput', () => {
         authorities: TOKEN_MINT_MASK | TOKEN_MELT_MASK,
         value: 1056n,
         address: 'W1b3',
-      })
+      }),
     );
     partialTx.addInput('hash3', 10, 1056n, 'W1b3', {
       token: '1',
@@ -258,7 +257,7 @@ describe('PartialTx.addOutput', () => {
         value: 27n,
         script: expect.toMatchBuffer(Buffer.from([230, 148, 32])),
         authorities: TOKEN_MELT_MASK,
-      })
+      }),
     );
     partialTx.addOutput(27n, Buffer.from([230, 148, 32]), {
       token: '1',
@@ -274,7 +273,7 @@ describe('PartialTx.addOutput', () => {
         value: 72n,
         script: expect.toMatchBuffer(Buffer.from([1, 2, 3])),
         authorities: 0n,
-      })
+      }),
     );
     partialTx.addOutput(72n, Buffer.from([1, 2, 3]), { token: '2' });
     expect(partialTx.outputs).toEqual(expected);

--- a/__tests__/models/partial_tx_inputdata.test.ts
+++ b/__tests__/models/partial_tx_inputdata.test.ts
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { PartialTxInputData } from '../../src/models/partial_tx';
-
 import { IndexOOBError } from '../../src/errors';
+import { PartialTxInputData } from '../../src/models/partial_tx';
 
 describe('PartialTxInputData.addData', () => {
   it('should throw OOB error when index is OOB', () => {

--- a/__tests__/models/script_data.test.ts
+++ b/__tests__/models/script_data.test.ts
@@ -6,10 +6,11 @@
  */
 
 import buffer from 'buffer';
-import ScriptData from '../../src/models/script_data';
+
 import { ParseScriptError } from '../../src/errors';
-import { parseScriptData } from '../../src/utils/scripts';
+import ScriptData from '../../src/models/script_data';
 import { OP_PUSHDATA1 } from '../../src/opcodes';
+import { parseScriptData } from '../../src/utils/scripts';
 
 test('Script data', () => {
   const data = 'test';

--- a/__tests__/models/transaction.test.ts
+++ b/__tests__/models/transaction.test.ts
@@ -6,15 +6,7 @@
  */
 
 import lodash from 'lodash';
-import Transaction from '../../src/models/transaction';
-import CreateTokenTransaction from '../../src/models/create_token_transaction';
-import Output from '../../src/models/output';
-import Input from '../../src/models/input';
-import P2PKH from '../../src/models/p2pkh';
-import Address from '../../src/models/address';
-import Network from '../../src/models/network';
-import { hexToBuffer, bufferToHex } from '../../src/utils/buffer';
-import helpers from '../../src/utils/helpers';
+
 import { DEFAULT_TX_VERSION, MAX_OUTPUTS, DEFAULT_SIGNAL_BITS } from '../../src/constants';
 import {
   CreateTokenTxInvalid,
@@ -22,12 +14,21 @@ import {
   MaximumNumberOutputsError,
   ParseError,
 } from '../../src/errors';
-import { nftCreationTx } from '../__fixtures__/sample_txs';
+import Address from '../../src/models/address';
+import CreateTokenTransaction from '../../src/models/create_token_transaction';
+import Input from '../../src/models/input';
+import Network from '../../src/models/network';
+import Output from '../../src/models/output';
+import P2PKH from '../../src/models/p2pkh';
+import Transaction from '../../src/models/transaction';
 import { TokenVersion } from '../../src/types';
+import { hexToBuffer, bufferToHex } from '../../src/utils/buffer';
+import helpers from '../../src/utils/helpers';
+import { nftCreationTx } from '../__fixtures__/sample_txs';
 
 const compareTxs = (
   tx: Transaction | CreateTokenTransaction,
-  tx2: Transaction | CreateTokenTransaction
+  tx2: Transaction | CreateTokenTransaction,
 ) => {
   expect(tx2.version).toBe(tx.version);
   expect(tx2.tokens.length).toBe(tx.tokens.length);
@@ -50,10 +51,10 @@ const compareTxs = (
     expect(bufferToHex(tx2.outputs[i].script)).toBe(bufferToHex(tx.outputs[i].script));
     if (tx2.outputs[i].decodedScript) {
       expect(tx2.outputs[i].decodedScript.address.base58).toBe(
-        tx.outputs[i].decodedScript.address.base58
+        tx.outputs[i].decodedScript.address.base58,
       );
       expect(tx2.outputs[i].decodedScript.address.network.name).toBe(
-        tx.outputs[i].decodedScript.address.network.name
+        tx.outputs[i].decodedScript.address.network.name,
       );
     }
   }
@@ -357,7 +358,7 @@ test('Known transactions hash', () => {
   expect(tx.inputs.length).toBe(1);
   expect(tx.outputs.length).toBe(2);
   expect(tx.inputs[0].hash).toBe(
-    '0082c7dd1f0ceb8867219dcca68540abe77222d11bb2dc67a7af1f04640ea1f7'
+    '0082c7dd1f0ceb8867219dcca68540abe77222d11bb2dc67a7af1f04640ea1f7',
   );
   expect(tx.inputs[0].index).toBe(1);
   expect(tx.outputs[0].value).toBe(100n);
@@ -390,7 +391,7 @@ test('Known transactions hash', () => {
   expect(tx2.inputs.length).toBe(1);
   expect(tx2.outputs.length).toBe(4);
   expect(tx2.inputs[0].hash).toBe(
-    '0026c04e94574161e0d01e883507fe7615982a70fe07fd484371878738f4fc31'
+    '0026c04e94574161e0d01e883507fe7615982a70fe07fd484371878738f4fc31',
   );
   expect(tx2.inputs[0].index).toBe(1);
   expect(tx2.outputs[0].value).toBe(992n);
@@ -432,15 +433,15 @@ test('Known transactions hash', () => {
   expect(tx3.inputs.length).toBe(3);
   expect(tx3.outputs.length).toBe(4);
   expect(tx3.inputs[0].hash).toBe(
-    '0044185239e750d0d7befd7758b377d8f682194fca1614b4ef6e31acbbca5636'
+    '0044185239e750d0d7befd7758b377d8f682194fca1614b4ef6e31acbbca5636',
   );
   expect(tx3.inputs[0].index).toBe(0);
   expect(tx3.inputs[1].hash).toBe(
-    '0028660612661c0592bb9b6cb8e77124caefbb0d68a119ea558c4947a68f9eef'
+    '0028660612661c0592bb9b6cb8e77124caefbb0d68a119ea558c4947a68f9eef',
   );
   expect(tx3.inputs[1].index).toBe(1);
   expect(tx3.inputs[2].hash).toBe(
-    '00efbc2e64ea93768c29823882185b633bf6380a15f7b621c68dc777558f06ae'
+    '00efbc2e64ea93768c29823882185b633bf6380a15f7b621c68dc777558f06ae',
   );
   expect(tx3.inputs[2].index).toBe(1);
   expect(tx3.outputs[0].value).toBe(77n);
@@ -525,7 +526,7 @@ describe('NFT Validation', () => {
     // Wrong Token Script
     txInstance.outputs[0].tokenData = 0;
     txInstance.outputs[0].script = Buffer.from(historyTx.outputs[0].script, 'base64').toString(
-      'hex'
+      'hex',
     );
     expect(() => txInstance.validateNft(network)).toThrow('not a DataScript');
   });

--- a/__tests__/nano_contracts/fields.test.ts
+++ b/__tests__/nano_contracts/fields.test.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { getFieldParser } from '../../src/nano_contracts/ncTypes/parser';
+import { NATIVE_TOKEN_UID } from '../../src/constants';
 import Network from '../../src/models/network';
 import ncFields from '../../src/nano_contracts/fields';
-import { NATIVE_TOKEN_UID } from '../../src/constants';
+import { getFieldParser } from '../../src/nano_contracts/ncTypes/parser';
 import leb128 from '../../src/utils/leb128';
 import { DWARF5SignedTestCases, DWARF5UnsignedTestCases } from '../__fixtures__/leb128';
 
@@ -43,7 +43,7 @@ describe('str', () => {
       Buffer.concat([
         Buffer.from([0x80, 0x10]), // 2048 in unsigned leb128
         bigUtf8,
-      ])
+      ]),
     );
   });
 });
@@ -338,7 +338,7 @@ describe('SignedData', () => {
     });
     // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
     expect(fieldStr.toBuffer()).toMatchBuffer(
-      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), signature])
+      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), signature]),
     );
 
     const fieldInt = getFieldParser('SignedData[int]', network);
@@ -350,7 +350,7 @@ describe('SignedData', () => {
     });
     // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
     expect(fieldInt.toBuffer()).toMatchBuffer(
-      Buffer.concat([Buffer.from([1 + 0x80, 1]), signature])
+      Buffer.concat([Buffer.from([1 + 0x80, 1]), signature]),
     );
   });
 
@@ -389,7 +389,7 @@ describe('RawSignedData', () => {
     });
     // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
     expect(fieldStr.toBuffer()).toMatchBuffer(
-      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), signature])
+      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), signature]),
     );
 
     const fieldInt = getFieldParser('RawSignedData[int]', network);
@@ -401,7 +401,7 @@ describe('RawSignedData', () => {
     });
     // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
     expect(fieldInt.toBuffer()).toMatchBuffer(
-      Buffer.concat([Buffer.from([1 + 0x80, 1]), signature])
+      Buffer.concat([Buffer.from([1 + 0x80, 1]), signature]),
     );
   });
 
@@ -433,7 +433,7 @@ describe('Tuple', () => {
     field.fromUser(['test', '129']);
     // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
     expect(field.toBuffer()).toMatchBuffer(
-      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), Buffer.from([1 + 0x80, 1])])
+      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), Buffer.from([1 + 0x80, 1])]),
     );
   });
 
@@ -447,7 +447,7 @@ describe('Tuple', () => {
         Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), // test
         Buffer.from([0x00]), // null
         Buffer.from([1 + 0x80, 1]), // 129
-      ])
+      ]),
     );
   });
 
@@ -455,7 +455,7 @@ describe('Tuple', () => {
     const field = getFieldParser('tuple[str, int]', network);
     expect(field).toBeInstanceOf(ncFields.TupleField);
     field.fromBuffer(
-      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), Buffer.from([1 + 0x80, 1])])
+      Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), Buffer.from([1 + 0x80, 1])]),
     );
     expect(field.toUser()).toStrictEqual(['test', '129']);
   });
@@ -468,7 +468,7 @@ describe('Tuple', () => {
         Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), // test
         Buffer.from([0x00]), // null
         Buffer.from([1 + 0x80, 1]), // 129
-      ])
+      ]),
     );
     expect(field.toUser()).toEqual([['test', null], '129']);
   });
@@ -484,7 +484,7 @@ describe('List', () => {
       Buffer.concat([
         leb128.encodeSigned(DWARF5SignedTestCases.length),
         ...DWARF5SignedTestCases.map(el => el[1]),
-      ])
+      ]),
     );
   });
 
@@ -497,9 +497,9 @@ describe('List', () => {
       Buffer.concat([
         leb128.encodeSigned(DWARF5SignedTestCases.length),
         ...DWARF5SignedTestCases.map(el =>
-          Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), el[1]])
+          Buffer.concat([Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), el[1]]),
         ),
-      ])
+      ]),
     );
   });
 
@@ -510,7 +510,7 @@ describe('List', () => {
       Buffer.concat([
         leb128.encodeSigned(DWARF5SignedTestCases.length),
         ...DWARF5SignedTestCases.map(el => el[1]),
-      ])
+      ]),
     );
     expect(field.toUser()).toStrictEqual(DWARF5SignedTestCases.map(el => String(el[0])));
   });
@@ -525,9 +525,9 @@ describe('List', () => {
           Buffer.concat([
             Buffer.from([0x04, 0x74, 0x65, 0x73, 0x74]), // test
             el[1],
-          ])
+          ]),
         ),
-      ])
+      ]),
     );
     expect(field.toUser()).toEqual(DWARF5SignedTestCases.map(el => ['test', String(el[0])]));
   });
@@ -569,7 +569,7 @@ describe('CallerId', () => {
       field.fromUser(testAddress);
       // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
       expect(field.toBuffer()).toMatchBuffer(
-        Buffer.concat([Buffer.from([ADDRESS_TAG]), addressBuf])
+        Buffer.concat([Buffer.from([ADDRESS_TAG]), addressBuf]),
       );
     });
 
@@ -579,7 +579,7 @@ describe('CallerId', () => {
       field.fromUser(testContractId);
       // @ts-expect-error: toMatchBuffer is defined in our setupTests.js so the type check fails.
       expect(field.toBuffer()).toMatchBuffer(
-        Buffer.concat([Buffer.from([CONTRACT_TAG]), contractIdBuf])
+        Buffer.concat([Buffer.from([CONTRACT_TAG]), contractIdBuf]),
       );
     });
   });
@@ -607,7 +607,7 @@ describe('CallerId', () => {
       const field = getFieldParser('CallerId', network);
       expect(field).toBeInstanceOf(ncFields.CallerIdField);
       expect(() => field.fromBuffer(Buffer.alloc(0))).toThrow(
-        'Not enough bytes to read CallerId tag'
+        'Not enough bytes to read CallerId tag',
       );
     });
 
@@ -699,7 +699,7 @@ describe('Dict', () => {
         Buffer.from([0x7e]), // -2
         Buffer.from([0x03, 0x66, 0x6f, 0x6f]), // foo
         Buffer.from([1 + 0x80, 1]), // 129
-      ])
+      ]),
     );
   });
 
@@ -718,7 +718,7 @@ describe('Dict', () => {
         Buffer.from([0x7e, 0x00]), // -2, null
         Buffer.from([0x03, 0x66, 0x6f, 0x6f]), // foo
         Buffer.from([1 + 0x80, 1, 0x00]), // 129, null
-      ])
+      ]),
     );
   });
 
@@ -733,7 +733,7 @@ describe('Dict', () => {
         Buffer.from([0x7e]), // -2
         Buffer.from([0x03, 0x66, 0x6f, 0x6f]), // foo
         Buffer.from([1 + 0x80, 1]), // 129
-      ])
+      ]),
     );
     expect(field.toUser()).toStrictEqual({
       test: '-2',
@@ -751,7 +751,7 @@ describe('Dict', () => {
         Buffer.from([0x7e, 0x00]), // -2, null
         Buffer.from([0x03, 0x66, 0x6f, 0x6f]), // foo
         Buffer.from([1 + 0x80, 1, 0x00]), // 129, null
-      ])
+      ]),
     );
     expect(field.toUser()).toEqual({
       test: ['-2', null],

--- a/__tests__/new/hathorwallet.test.ts
+++ b/__tests__/new/hathorwallet.test.ts
@@ -6,29 +6,30 @@
  */
 
 import { z } from 'zod';
-import Address from '../../src/models/address';
-import HathorWallet from '../../src/new/wallet';
-import { TxNotFoundError, WalletFromXPubGuard } from '../../src/errors';
-import Network from '../../src/models/network';
-import Transaction from '../../src/models/transaction';
-import Input from '../../src/models/input';
+
+import txApi from '../../src/api/txApi';
+import versionApi from '../../src/api/version';
 import {
   DEFAULT_TX_VERSION,
   P2PKH_ACCT_PATH,
   TOKEN_MINT_MASK,
   TOKEN_MELT_MASK,
 } from '../../src/constants';
-import { MemoryStore, Storage } from '../../src/storage';
+import { TxNotFoundError, WalletFromXPubGuard } from '../../src/errors';
+import Address from '../../src/models/address';
+import Input from '../../src/models/input';
+import Network from '../../src/models/network';
 import Queue from '../../src/models/queue';
-import { IHistoryTx, WalletType } from '../../src/types';
+import Transaction from '../../src/models/transaction';
 import { WalletWebSocketData } from '../../src/new/types';
-import txApi from '../../src/api/txApi';
+import HathorWallet from '../../src/new/wallet';
+import { MemoryStore, Storage } from '../../src/storage';
+import { WalletTxTemplateInterpreter, TransactionTemplate } from '../../src/template/transaction';
+import { IHistoryTx, WalletType } from '../../src/types';
 import * as addressUtils from '../../src/utils/address';
+import { decryptData, verifyMessage } from '../../src/utils/crypto';
 import * as storageUtils from '../../src/utils/storage';
 import walletUtils from '../../src/utils/wallet';
-import versionApi from '../../src/api/version';
-import { decryptData, verifyMessage } from '../../src/utils/crypto';
-import { WalletTxTemplateInterpreter, TransactionTemplate } from '../../src/template/transaction';
 import { mockGetToken } from '../__mock_helpers__/get-token.mock';
 
 class FakeHathorWallet {
@@ -70,7 +71,7 @@ test('getFullTxById', async () => {
     resolve({
       success: false,
       message: 'Invalid tx',
-    })
+    }),
   );
 
   await expect(hWallet.getFullTxById('tx1')).rejects.toThrow('Invalid transaction tx1');
@@ -92,7 +93,7 @@ test('getFullTxById', async () => {
     resolve({
       success: false,
       message: 'Transaction not found',
-    })
+    }),
   );
 
   await expect(hWallet.getFullTxById('tx1')).rejects.toThrow(TxNotFoundError);
@@ -123,7 +124,7 @@ test('getTxConfirmationData', async () => {
     resolve({
       success: false,
       message: 'Invalid tx',
-    })
+    }),
   );
 
   await expect(hWallet.getTxConfirmationData('tx1')).rejects.toThrow('Invalid transaction tx1');
@@ -132,7 +133,7 @@ test('getTxConfirmationData', async () => {
     resolve({
       success: false,
       message: 'Transaction not found',
-    })
+    }),
   );
 
   await expect(hWallet.getTxConfirmationData('tx1')).rejects.toThrow(TxNotFoundError);
@@ -145,7 +146,7 @@ test('getTxConfirmationData', async () => {
   // Resolve the promise without calling the resolve param
   getConfirmationDataSpy.mockImplementation(() => Promise.resolve());
   await expect(hWallet.getTxConfirmationData('tx1')).rejects.toThrow(
-    'API client did not use the callback'
+    'API client did not use the callback',
   );
 });
 
@@ -171,18 +172,18 @@ test('graphvizNeighborsQuery', async () => {
     resolve({
       success: false,
       message: 'Invalid tx',
-    })
+    }),
   );
 
   await expect(hWallet.graphvizNeighborsQuery('tx1', 'type', 1)).rejects.toThrow(
-    'Invalid transaction tx1'
+    'Invalid transaction tx1',
   );
 
   getGraphvizNeighborsSpy.mockImplementation((_tx, _graphType, _maxLevel, resolve) =>
     resolve({
       success: false,
       message: 'Transaction not found',
-    })
+    }),
   );
 
   await expect(hWallet.graphvizNeighborsQuery('tx1', 'type', 1)).rejects.toThrow(TxNotFoundError);
@@ -195,7 +196,7 @@ test('graphvizNeighborsQuery', async () => {
   // Resolve the promise without calling the resolve param
   getGraphvizNeighborsSpy.mockImplementation(() => Promise.resolve());
   await expect(hWallet.graphvizNeighborsQuery('tx1', 'type', 1)).rejects.toThrow(
-    'API client did not use the callback'
+    'API client did not use the callback',
   );
 });
 
@@ -212,7 +213,7 @@ test('checkAddressesMine', async () => {
     await hWallet.checkAddressesMine([
       'WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp',
       'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ',
-    ])
+    ]),
   ).toStrictEqual({
     WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp: true,
     WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ: false,
@@ -262,7 +263,7 @@ test('getSignatures', async () => {
           addressIndex: 2,
         },
       ],
-    })
+    }),
   );
 
   const hWallet = new FakeHathorWallet();
@@ -306,7 +307,7 @@ test('signTx', async () => {
           addressIndex: 1,
         },
       ],
-    })
+    }),
   );
 
   const hWallet = new FakeHathorWallet();
@@ -345,10 +346,10 @@ test('signTx throws when pinCode is not provided', async () => {
   // Should throw when no pinCode is provided in options and wallet.pinCode is null
   await expect(hWallet.signTx(tx)).rejects.toThrow('Pin code is required to sign a transaction');
   await expect(hWallet.signTx(tx, {})).rejects.toThrow(
-    'Pin code is required to sign a transaction'
+    'Pin code is required to sign a transaction',
   );
   await expect(hWallet.signTx(tx, { pinCode: null })).rejects.toThrow(
-    'Pin code is required to sign a transaction'
+    'Pin code is required to sign a transaction',
   );
 });
 
@@ -376,7 +377,7 @@ test('getWalletInputInfo', async () => {
   jest.spyOn(storage, 'getAddressInfo').mockReturnValue(
     Promise.resolve({
       bip32AddressIndex: 10,
-    })
+    }),
   );
   jest.spyOn(storage, 'getWalletType').mockReturnValue(Promise.resolve(WalletType.P2PKH));
 
@@ -627,7 +628,7 @@ test('getAddressPrivKey', async () => {
   const address0HDPrivKey = await hWallet.getAddressPrivKey('123', 0);
 
   expect(
-    address0HDPrivKey.privateKey.toAddress(new Network('testnet').getNetwork()).toString()
+    address0HDPrivKey.privateKey.toAddress(new Network('testnet').getNetwork()).toString(),
   ).toStrictEqual(address0);
 });
 
@@ -669,7 +670,7 @@ test('signMessageWithAddress', async () => {
   const signedMessage = await hWallet.signMessageWithAddress(message, addressIndex, '1234');
 
   expect(
-    verifyMessage(message, signedMessage, await hWallet.getAddressAtIndex(addressIndex))
+    verifyMessage(message, signedMessage, await hWallet.getAddressAtIndex(addressIndex)),
   ).toBeTruthy();
 });
 
@@ -713,7 +714,7 @@ test('getWalletType', async () => {
   jest.spyOn(storage, 'getAccessData').mockImplementationOnce(() =>
     Promise.resolve({
       walletType: 'p2pkh',
-    })
+    }),
   );
 
   const hWallet = new FakeHathorWallet();
@@ -729,7 +730,7 @@ test('getMultisigData', async () => {
   const dataSpy = jest.spyOn(storage, 'getAccessData').mockImplementationOnce(() =>
     Promise.resolve({
       walletType: 'p2pkh',
-    })
+    }),
   );
 
   const hWallet = new FakeHathorWallet();
@@ -743,7 +744,7 @@ test('getMultisigData', async () => {
     Promise.resolve({
       walletType: 'multisig',
       multisigData: 'multisig data',
-    })
+    }),
   );
   await expect(hWallet.getMultisigData()).resolves.toEqual('multisig data');
 
@@ -751,7 +752,7 @@ test('getMultisigData', async () => {
   dataSpy.mockImplementationOnce(() =>
     Promise.resolve({
       walletType: 'multisig',
-    })
+    }),
   );
   await expect(hWallet.getMultisigData()).rejects.toThrow('Multisig data not found in storage');
 });
@@ -897,7 +898,7 @@ test('getTxHistory', async () => {
   hWallet.getTxBalance = jest.fn().mockReturnValue(
     Promise.resolve({
       'mock-token-uid': 456,
-    })
+    }),
   );
   jest.spyOn(storage, 'tokenHistory').mockImplementation(historyMock);
 
@@ -1002,7 +1003,7 @@ describe('prepare transactions without signature', () => {
         expect.objectContaining({
           data: null,
         }),
-      ])
+      ]),
     );
   });
 
@@ -1048,7 +1049,7 @@ describe('prepare transactions without signature', () => {
         expect.objectContaining({
           data: null,
         }),
-      ])
+      ]),
     );
   });
 
@@ -1096,7 +1097,7 @@ describe('prepare transactions without signature', () => {
         expect.objectContaining({
           data: null,
         }),
-      ])
+      ]),
     );
     expect(txData.outputs).toHaveLength(3);
     expect(txData.outputs).toEqual(
@@ -1114,7 +1115,7 @@ describe('prepare transactions without signature', () => {
           tokenData: 129,
           value: 1n,
         }),
-      ])
+      ]),
     );
   });
 
@@ -1151,7 +1152,7 @@ describe('prepare transactions without signature', () => {
         address: fakeAddress.base58,
         pinCode: '1234',
         signTx: false, // skip the signature
-      })
+      }),
     ).rejects.toThrow('Not enough HTR tokens for deposit or fee: 10 required, 1 available');
   });
 
@@ -1207,7 +1208,7 @@ describe('prepare transactions without signature', () => {
         expect.objectContaining({
           data: null,
         }),
-      ])
+      ]),
     );
   });
 
@@ -1265,7 +1266,7 @@ describe('prepare transactions without signature', () => {
         expect.objectContaining({
           data: null,
         }),
-      ])
+      ]),
     );
     // outputs: data + authority
     expect(txData.outputs).toHaveLength(2);
@@ -1280,7 +1281,7 @@ describe('prepare transactions without signature', () => {
           tokenData: 129,
           value: 2n,
         }),
-      ])
+      ]),
     );
   });
 
@@ -1344,7 +1345,7 @@ describe('prepare transactions without signature', () => {
         expect.objectContaining({
           data: null,
         }),
-      ])
+      ]),
     );
     // outputs: data x2 + change + authority
     expect(txData.outputs).toHaveLength(4);
@@ -1368,7 +1369,7 @@ describe('prepare transactions without signature', () => {
           tokenData: 129,
           value: 2n,
         }),
-      ])
+      ]),
     );
   });
 
@@ -1418,7 +1419,7 @@ describe('prepare transactions without signature', () => {
         address: fakeAddress.base58,
         pinCode: '1234',
         signTx: false, // skip the signature
-      })
+      }),
     ).rejects.toThrow('Not enough tokens to melt: 100 requested, 10 available');
   });
 });
@@ -1442,7 +1443,7 @@ test('build transaction template', async () => {
     build: jest
       .fn()
       .mockImplementation(
-        async (_instructions: z.infer<typeof TransactionTemplate>, _debug: boolean) => preMadeTx
+        async (_instructions: z.infer<typeof TransactionTemplate>, _debug: boolean) => preMadeTx,
       ),
   } as unknown as WalletTxTemplateInterpreter;
   hwallet.txTemplateInterpreter = interpreter;
@@ -1453,7 +1454,7 @@ test('build transaction template', async () => {
   expect(interpreter.build).toHaveBeenCalledTimes(1);
   expect(interpreter.build).toHaveBeenCalledWith(
     [expect.objectContaining({ type: 'action/complete' })],
-    true
+    true,
   );
   expect(dataSpy).not.toHaveBeenCalled();
 });
@@ -1472,7 +1473,7 @@ test('build transaction template with signature', async () => {
           addressIndex: 1,
         },
       ],
-    })
+    }),
   );
 
   const input = new Input('d00d', 0);
@@ -1485,7 +1486,7 @@ test('build transaction template with signature', async () => {
     build: jest
       .fn()
       .mockImplementation(
-        async (_instructions: z.infer<typeof TransactionTemplate>, _debug: boolean) => preMadeTx
+        async (_instructions: z.infer<typeof TransactionTemplate>, _debug: boolean) => preMadeTx,
       ),
   } as unknown as WalletTxTemplateInterpreter;
   hwallet.txTemplateInterpreter = interpreter;
@@ -1499,7 +1500,7 @@ test('build transaction template with signature', async () => {
   expect(interpreter.build).toHaveBeenCalledTimes(1);
   expect(interpreter.build).toHaveBeenCalledWith(
     [expect.objectContaining({ type: 'action/complete' })],
-    true
+    true,
   );
   expect(dataSpy).toHaveBeenCalledTimes(1);
 });

--- a/__tests__/new/sendTransaction.test.ts
+++ b/__tests__/new/sendTransaction.test.ts
@@ -75,7 +75,7 @@ test('prepareTxData', async () => {
           token_data: 1,
         },
       ],
-    })
+    }),
   );
   jest.spyOn(storage, 'isAddressMine').mockReturnValue(true);
   const spyGetToken = jest.spyOn(storage, 'getToken').mockImplementation(mockGetToken);
@@ -222,7 +222,7 @@ test('checkUnspentInput', async () => {
   });
 
   txSpy.mockReturnValueOnce(
-    Promise.resolve({ is_voided: false, outputs: [{ token_data: TOKEN_AUTHORITY_MASK | 1 }] })
+    Promise.resolve({ is_voided: false, outputs: [{ token_data: TOKEN_AUTHORITY_MASK | 1 }] }),
   );
   await expect(checkUnspentInput(storage, input0, '01')).resolves.toEqual({
     success: false,
@@ -233,7 +233,7 @@ test('checkUnspentInput', async () => {
     Promise.resolve({
       is_voided: false,
       outputs: [{ token_data: 1, decoded: { address: 'different-addr' } }],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '01')).resolves.toEqual({
     success: false,
@@ -246,7 +246,7 @@ test('checkUnspentInput', async () => {
     Promise.resolve({
       is_voided: false,
       outputs: [{ token_data: 1, decoded: { address: 'addr0' } }],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '01')).resolves.toEqual({
     success: false,
@@ -257,7 +257,7 @@ test('checkUnspentInput', async () => {
     Promise.resolve({
       is_voided: false,
       outputs: [{ token_data: 1, decoded: {} }],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '01')).resolves.toEqual({
     success: false,
@@ -269,7 +269,7 @@ test('checkUnspentInput', async () => {
     Promise.resolve({
       is_voided: false,
       outputs: [{ token_data: 1, decoded: { address: 'addr0', token: '02' } }],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '02')).resolves.toEqual({
     success: false,
@@ -280,7 +280,7 @@ test('checkUnspentInput', async () => {
     Promise.resolve({
       is_voided: false,
       outputs: [{ token_data: 1, token: '01', decoded: { address: 'addr0' } }],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '02')).resolves.toEqual({
     success: false,
@@ -293,7 +293,7 @@ test('checkUnspentInput', async () => {
       outputs: [
         { token_data: 1, token: '01', spent_by: 'another-tx', decoded: { address: 'addr0' } },
       ],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '01')).resolves.toEqual({
     success: false,
@@ -304,7 +304,7 @@ test('checkUnspentInput', async () => {
     Promise.resolve({
       is_voided: false,
       outputs: [{ token_data: 1, token: '01', decoded: { address: 'addr0' } }],
-    })
+    }),
   );
   await expect(checkUnspentInput(storage, input0, '01')).resolves.toEqual({
     success: true,
@@ -337,14 +337,14 @@ test('prepareSendTokensData', async () => {
     Promise.resolve({
       utxos: [],
       amount: 0n,
-    })
+    }),
   );
 
   await expect(
     prepareSendTokensData(storage, tx, {
       chooseInputs: true,
       utxoSelectionMethod: utxoSelection,
-    })
+    }),
   ).rejects.toThrow('Insufficient amount of tokens');
 
   utxoSelection.mockReturnValue(
@@ -360,7 +360,7 @@ test('prepareSendTokensData', async () => {
         },
       ],
       amount: 3n,
-    })
+    }),
   );
   await expect(
     prepareSendTokensData(storage, tx, {
@@ -368,7 +368,7 @@ test('prepareSendTokensData', async () => {
       chooseInputs: true,
       utxoSelectionMethod: utxoSelection,
       changeAddress: 'addr-change',
-    })
+    }),
   ).resolves.toMatchObject({
     inputs: [
       { txId: 'tx-id', index: 0, address: 'addr-utxo', token: '01', value: 3n, authorities: 0n },
@@ -397,7 +397,7 @@ test('prepareSendTokensData', async () => {
         // Since the last output is skipped we do not need it on the tx
         // { token_data:0, value: 1, decoded: { address: 'addr2', token: '00' } },
       ],
-    })
+    }),
   );
   const tx1 = {
     inputs: [
@@ -417,7 +417,7 @@ test('prepareSendTokensData', async () => {
       token: '01',
       chooseInputs: false,
       changeAddress: 'addr-change',
-    })
+    }),
   ).resolves.toMatchObject({
     // No new inputs since we do not choose inputs
     inputs: [],

--- a/__tests__/new/wallet-utxo.test.ts
+++ b/__tests__/new/wallet-utxo.test.ts
@@ -1,16 +1,17 @@
 import { HDPrivateKey } from 'bitcore-lib';
-import HathorWallet from '../../src/new/wallet';
-import txHistoryFixture from '../__fixtures__/tx_history';
-import { MemoryStore, Storage } from '../../src/storage';
+
+import walletApi from '../../src/api/wallet';
 import {
   MAX_INPUTS,
   MAX_OUTPUTS,
   TOKEN_DEPOSIT_PERCENTAGE,
   TX_WEIGHT_CONSTANTS,
 } from '../../src/constants';
-import { encryptData } from '../../src/utils/crypto';
+import HathorWallet from '../../src/new/wallet';
+import { MemoryStore, Storage } from '../../src/storage';
 import { WalletType } from '../../src/types';
-import walletApi from '../../src/api/wallet';
+import { encryptData } from '../../src/utils/crypto';
+import txHistoryFixture from '../__fixtures__/tx_history';
 
 class FakeHathorWallet {
   constructor() {
@@ -185,13 +186,13 @@ describe('UTXO Consolidation', () => {
 
   test('throw error when there is no utxo to consolidade', async () => {
     await expect(
-      hathorWallet.consolidateUtxos(destinationAddress, { token: '05' })
+      hathorWallet.consolidateUtxos(destinationAddress, { token: '05' }),
     ).rejects.toEqual(new Error('No available utxo to consolidate.'));
   });
 
   test('throw error for invalid destinationAddress', async () => {
     await expect(hathorWallet.consolidateUtxos(invalidDestinationAddress)).rejects.toEqual(
-      new Error("Utxo consolidation to an address not owned by this wallet isn't allowed.")
+      new Error("Utxo consolidation to an address not owned by this wallet isn't allowed."),
     );
   });
 });

--- a/__tests__/pushNotification.test.ts
+++ b/__tests__/pushNotification.test.ts
@@ -1,7 +1,13 @@
+// Must load before any module that imports walletServiceAxios — the helper
+// registers a module-level jest.mock() and Jest only auto-hoists jest.mock
+// calls in the test file itself, not in transitively-imported helpers.
+// eslint-disable-next-line import/order
 import { mockAxiosAdapter } from './__mock_helpers__/axios-adapter.mock';
-import { buildWalletToAuthenticateApiCall } from './__mock_helpers__/wallet-service.fixtures';
-import { PushNotification, PushNotificationProvider } from '../src/pushNotification';
+
 import config from '../src/config';
+import { PushNotification, PushNotificationProvider } from '../src/pushNotification';
+
+import { buildWalletToAuthenticateApiCall } from './__mock_helpers__/wallet-service.fixtures';
 
 test('registerDevice', async () => {
   const wallet = buildWalletToAuthenticateApiCall();
@@ -80,7 +86,7 @@ test('updateDevice', async () => {
   });
 
   await expect(invalidCall).rejects.toThrow(
-    'Error updating push notification settings for device.'
+    'Error updating push notification settings for device.',
   );
 });
 

--- a/__tests__/storage/common_store.test.ts
+++ b/__tests__/storage/common_store.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { MemoryStore, Storage } from '../../src/storage';
 import { TOKEN_AUTHORITY_MASK, TOKEN_MINT_MASK, GAP_LIMIT } from '../../src/constants';
+import { MemoryStore, Storage } from '../../src/storage';
 import {
   ILockedUtxo,
   IStore,
@@ -60,7 +60,7 @@ describe('locked utxo methods', () => {
     height,
     value: OutputValueType,
     token,
-    token_data
+    token_data,
   ): ILockedUtxo {
     return {
       index: 0,
@@ -121,7 +121,7 @@ describe('locked utxo methods', () => {
         undefined,
         100n, // value
         '00', // token
-        0 // token_data
+        0, // token_data
       ),
       // timelocked
       getLockedUtxo(
@@ -131,7 +131,7 @@ describe('locked utxo methods', () => {
         undefined,
         100n, // value
         '00', // token
-        0 // token_data
+        0, // token_data
       ),
       // utxo to be unlocked by height
       getLockedUtxo(
@@ -141,7 +141,7 @@ describe('locked utxo methods', () => {
         undefined,
         100n, // value
         '01', // token
-        0 // token_data
+        0, // token_data
       ),
       // heightlocked
       getLockedUtxo(
@@ -151,7 +151,7 @@ describe('locked utxo methods', () => {
         undefined,
         TOKEN_MINT_MASK, // value, mint
         '01', // token
-        TOKEN_AUTHORITY_MASK | 1 // token_data
+        TOKEN_AUTHORITY_MASK | 1, // token_data
       ),
     ];
     for (const lutxo of lockedUtxos) {

--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -6,13 +6,14 @@
  */
 
 import { HDPrivateKey } from 'bitcore-lib';
+
+import walletApi from '../../src/api/wallet';
 import { GAP_LIMIT } from '../../src/constants';
 import { MemoryStore, Storage } from '../../src/storage';
-import tx_history from '../__fixtures__/tx_history';
-import walletApi from '../../src/api/wallet';
-import { encryptData } from '../../src/utils/crypto';
 import { TokenVersion, WalletType } from '../../src/types';
+import { encryptData } from '../../src/utils/crypto';
 import { processHistory } from '../../src/utils/storage';
+import tx_history from '../__fixtures__/tx_history';
 
 test('default values', async () => {
   const store = new MemoryStore();
@@ -184,7 +185,7 @@ test('token methods', async () => {
           melt: { locked: 1n, unlocked: 2n },
         },
       },
-    }
+    },
   );
   expect(store.tokens.size).toEqual(2);
   expect(store.tokens.get('02')).toBeDefined();

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -7,11 +7,8 @@
 
 import { HDPrivateKey } from 'bitcore-lib';
 import Mnemonic from 'bitcore-mnemonic';
+
 import walletApi from '../../src/api/wallet';
-import { MemoryStore, Storage } from '../../src/storage';
-import tx_history from '../__fixtures__/tx_history';
-import { processHistory, loadAddresses } from '../../src/utils/storage';
-import walletUtils from '../../src/utils/wallet';
 import {
   P2PKH_ACCT_PATH,
   TOKEN_DEPOSIT_PERCENTAGE,
@@ -22,9 +19,9 @@ import {
   DEFAULT_NATIVE_TOKEN_CONFIG,
   NATIVE_TOKEN_UID,
 } from '../../src/constants';
-import * as cryptoUtils from '../../src/utils/crypto';
 import { InvalidPasswdError } from '../../src/errors';
 import Network from '../../src/models/network';
+import { MemoryStore, Storage } from '../../src/storage';
 import {
   IHistoryTx,
   ILockedUtxo,
@@ -35,6 +32,10 @@ import {
   TokenVersion,
   ApiVersion,
 } from '../../src/types';
+import * as cryptoUtils from '../../src/utils/crypto';
+import { processHistory, loadAddresses } from '../../src/utils/storage';
+import walletUtils from '../../src/utils/wallet';
+import tx_history from '../__fixtures__/tx_history';
 
 describe('handleStop', () => {
   const PIN = '0000';
@@ -337,7 +338,7 @@ test('store fetch methods', async () => {
       bip32AddressIndex: 0,
       numTransactions: 2,
       balance: expect.anything(),
-    }
+    },
   );
   await expect(storage.getAddressAtIndex(1)).resolves.toMatchObject({
     base58: 'WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp',
@@ -355,7 +356,7 @@ test('store fetch methods', async () => {
   expect(historySpy).toHaveBeenCalled();
 
   await expect(
-    storage.getTx('0000000110eb9ec96e255a09d6ae7d856bff53453773bae5500cee2905db670e')
+    storage.getTx('0000000110eb9ec96e255a09d6ae7d856bff53453773bae5500cee2905db670e'),
   ).resolves.toBeDefined();
 
   const tokenSpy = jest.spyOn(store, 'historyIter').mockImplementation(emptyIter);
@@ -478,7 +479,7 @@ describe('process locked utxos', () => {
     height,
     value: OutputValueType,
     token,
-    token_data
+    token_data,
   ): ILockedUtxo {
     return {
       index: 0,
@@ -554,7 +555,7 @@ describe('process locked utxos', () => {
         undefined,
         100n, // value
         '00', // token
-        0 // token_data
+        0, // token_data
       ),
       // timelocked
       getLockedUtxo(
@@ -564,7 +565,7 @@ describe('process locked utxos', () => {
         undefined,
         100n, // value
         '00', // token
-        0 // token_data
+        0, // token_data
       ),
       // utxo to be unlocked by height
       getLockedUtxo(
@@ -574,7 +575,7 @@ describe('process locked utxos', () => {
         5,
         100n, // value
         '01', // token
-        0 // token_data
+        0, // token_data
       ),
       // heightlocked
       getLockedUtxo(
@@ -584,7 +585,7 @@ describe('process locked utxos', () => {
         100,
         TOKEN_MINT_MASK, // value, mint
         '01', // token
-        TOKEN_AUTHORITY_MASK | 1 // token_data
+        TOKEN_AUTHORITY_MASK | 1, // token_data
       ),
     ];
     await store.saveAddress({ base58: 'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ', bip32AddressIndex: 0 });
@@ -726,7 +727,7 @@ describe('getChangeAddress', () => {
     await expect(storage.getChangeAddress({ changeAddress: addr1 })).resolves.toEqual(addr1);
     // Should throw if the provided address is not from the wallet
     await expect(storage.getChangeAddress({ changeAddress: 'invalid' })).rejects.toThrow(
-      'Change address'
+      'Change address',
     );
     // If one is not provided we get the current address
     await expect(storage.getChangeAddress()).resolves.toEqual(addr0);
@@ -833,7 +834,7 @@ test('change pin and password', async () => {
 
   await expect(() => storage.changePin('invalid-pin', '321')).rejects.toThrow(InvalidPasswdError);
   await expect(() => storage.changePassword('invalid-passwd', '456')).rejects.toThrow(
-    InvalidPasswdError
+    InvalidPasswdError,
   );
 
   await storage.changePin('123', '321');
@@ -903,28 +904,28 @@ test('isHardware', async () => {
   accessDataSpy.mockReturnValue(
     Promise.resolve({
       walletFlags: WALLET_FLAGS.HARDWARE,
-    })
+    }),
   );
   await expect(storage.isHardwareWallet()).resolves.toBe(true);
 
   accessDataSpy.mockReturnValue(
     Promise.resolve({
       walletFlags: WALLET_FLAGS.HARDWARE | WALLET_FLAGS.READONLY,
-    })
+    }),
   );
   await expect(storage.isHardwareWallet()).resolves.toBe(true);
 
   accessDataSpy.mockReturnValue(
     Promise.resolve({
       walletFlags: 0,
-    })
+    }),
   );
   await expect(storage.isHardwareWallet()).resolves.toBe(false);
 
   accessDataSpy.mockReturnValue(
     Promise.resolve({
       walletFlags: WALLET_FLAGS.READONLY,
-    })
+    }),
   );
   await expect(storage.isHardwareWallet()).resolves.toBe(false);
 });
@@ -1069,7 +1070,7 @@ describe('utxo selection in all stores', () => {
         index: 2,
         version: 0,
         outputs: [{}, {}, { spent_by: null }],
-      })
+      }),
     );
     await storage.utxoSelectAsInput({ txId: 'tx01', index: 2 }, true);
     buf = [];

--- a/__tests__/stream.test.ts
+++ b/__tests__/stream.test.ts
@@ -1,9 +1,11 @@
 import { Server, WebSocket } from 'mock-socket';
-import HathorWallet from '../src/new/wallet';
+
 import Connection from '../src/new/connection';
+import HathorWallet from '../src/new/wallet';
 import { MemoryStore, Storage } from '../src/storage';
 import { HistorySyncMode, getDefaultLogger } from '../src/types';
 import { JSONBigInt } from '../src/utils/bigint';
+
 import { getGapLimitConfig } from './integration/utils/core.util';
 
 const mock_tx = {
@@ -66,7 +68,7 @@ function makeServerMock(mockServer, mockType, sendCapabilities = true) {
       JSON.stringify({
         id: streamId,
         type: 'stream:history:begin',
-      })
+      }),
     );
     socket.send(
       JSON.stringify({
@@ -74,14 +76,14 @@ function makeServerMock(mockServer, mockType, sendCapabilities = true) {
         type: 'stream:history:address',
         address: 'WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp',
         index: 0,
-      })
+      }),
     );
     socket.send(
       JSONBigInt.stringify({
         id: streamId,
         type: 'stream:history:vertex',
         data: mock_tx,
-      })
+      }),
     );
     if (mockType === SERVER_MOCK_TYPE.simple) {
       socket.send(JSON.stringify({ id: streamId, type: 'stream:history:end' }));
@@ -95,7 +97,7 @@ function makeServerMock(mockServer, mockType, sendCapabilities = true) {
           type: 'stream:history:address',
           address: 'WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp',
           index: 0,
-        })
+        }),
       );
       socket.send(JSON.stringify({ id: streamId, type: 'stream:history:end' }));
     }
@@ -314,7 +316,7 @@ describe('Websocket stream history sync', () => {
     }
 
     await expect(wallet.getAddressAtIndex(0)).resolves.toEqual(
-      'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN'
+      'WewDeXWyvHP7jJTs7tjLoQfoB72LLxJQqN',
     );
   }, 10000);
 });

--- a/__tests__/swapService/swapConnection.test.ts
+++ b/__tests__/swapService/swapConnection.test.ts
@@ -81,13 +81,13 @@ describe('proposal handling', () => {
       JSON.stringify({
         type: 'subscribe_proposal',
         proposalId: 'abc',
-      })
+      }),
     );
     expect(sendMessageSpy).toHaveBeenCalledWith(
       JSON.stringify({
         type: 'subscribe_proposal',
         proposalId: '123',
-      })
+      }),
     );
   });
 
@@ -99,7 +99,7 @@ describe('proposal handling', () => {
       JSON.stringify({
         type: 'unsubscribe_proposal',
         proposalId: '123',
-      })
+      }),
     );
   });
 });

--- a/__tests__/template/transaction/executor.test.ts
+++ b/__tests__/template/transaction/executor.test.ts
@@ -6,6 +6,11 @@
  */
 
 import { cloneDeep } from 'lodash';
+
+import Input from '../../../src/models/input';
+import Network from '../../../src/models/network';
+import Output from '../../../src/models/output';
+import { TxTemplateContext } from '../../../src/template/transaction/context';
 import {
   execAuthorityOutputInstruction,
   execAuthoritySelectInstruction,
@@ -22,8 +27,6 @@ import {
   findInstructionExecution,
   runInstruction,
 } from '../../../src/template/transaction/executor';
-import { TxTemplateContext } from '../../../src/template/transaction/context';
-import { getDefaultLogger } from '../../../src/types';
 import {
   AuthorityOutputInstruction,
   AuthoritySelectInstruction,
@@ -35,9 +38,7 @@ import {
   TokenOutputInstruction,
   UtxoSelectInstruction,
 } from '../../../src/template/transaction/instructions';
-import Network from '../../../src/models/network';
-import Output from '../../../src/models/output';
-import Input from '../../../src/models/input';
+import { getDefaultLogger } from '../../../src/types';
 
 /**
  * This DEBUG constant will enable or disable "build time" debug logs
@@ -84,14 +85,14 @@ describe('findInstructionExecution', () => {
         type: 'input/raw',
         index: 0,
         txId,
-      })
+      }),
     ).toBe(execRawInputInstruction);
 
     expect(
       findInstructionExecution({
         type: 'input/utxo',
         fill: 40,
-      })
+      }),
     ).toBe(execUtxoSelectInstruction);
 
     expect(
@@ -99,7 +100,7 @@ describe('findInstructionExecution', () => {
         type: 'input/authority',
         authority: 'mint',
         token,
-      })
+      }),
     ).toBe(execAuthoritySelectInstruction);
 
     expect(
@@ -107,7 +108,7 @@ describe('findInstructionExecution', () => {
         type: 'output/raw',
         script: 'cafe',
         amount: 10,
-      })
+      }),
     ).toBe(execRawOutputInstruction);
 
     expect(
@@ -115,7 +116,7 @@ describe('findInstructionExecution', () => {
         type: 'output/token',
         amount: 23,
         address,
-      })
+      }),
     ).toBe(execTokenOutputInstruction);
 
     expect(
@@ -124,27 +125,27 @@ describe('findInstructionExecution', () => {
         authority: 'mint',
         token,
         address,
-      })
+      }),
     ).toBe(execAuthorityOutputInstruction);
 
     expect(
       findInstructionExecution({
         type: 'output/data',
         data: 'cafe',
-      })
+      }),
     ).toBe(execDataOutputInstruction);
 
     expect(
       findInstructionExecution({
         type: 'action/shuffle',
         target: 'all',
-      })
+      }),
     ).toBe(execShuffleInstruction);
 
     expect(
       findInstructionExecution({
         type: 'action/complete',
-      })
+      }),
     ).toBe(execCompleteTxInstruction);
 
     expect(
@@ -153,7 +154,7 @@ describe('findInstructionExecution', () => {
         version: 5,
         tokenName: 'foo',
         tokenSymbol: 'bar',
-      })
+      }),
     ).toBe(execConfigInstruction);
 
     expect(
@@ -161,14 +162,14 @@ describe('findInstructionExecution', () => {
         type: 'action/setvar',
         name: 'foo',
         value: 'bar',
-      })
+      }),
     ).toBe(execSetVarInstruction);
 
     expect(
       findInstructionExecution({
         type: 'action/fee',
         amount: 100,
-      })
+      }),
     ).toBe(execFeeInstruction);
   });
 
@@ -178,59 +179,59 @@ describe('findInstructionExecution', () => {
         type: 'input/raw',
         index: 300,
         txId,
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'input/utxo',
         fill: '11g',
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'input/authority',
         authority: 'none',
         token,
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'output/raw',
         script: 'caf',
         amount: 10,
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'output/token',
         amount: '23g',
         address,
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'output/authority',
         authority: 'none',
         token,
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'output/data',
         data: { foo: 'bar' },
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'action/shuffle',
         target: 'none',
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'action/complete',
         token: 123,
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
@@ -239,12 +240,12 @@ describe('findInstructionExecution', () => {
         signalBits: 8001,
         tokenName: '',
         tokenSymbol: 'foobar',
-      })
+      }),
     ).toThrow();
     expect(() =>
       findInstructionExecution({
         type: 'action/setvar',
-      })
+      }),
     ).toThrow();
   });
 });
@@ -261,7 +262,7 @@ const RawInputExecutorTest = async executor => {
             token_data: 1,
           },
         ],
-      })
+      }),
     ),
   };
   const ctx = new TxTemplateContext(getDefaultLogger(), DEBUG);
@@ -617,7 +618,7 @@ const ChargeableInputsTest = async executor => {
             token_data: 1,
           },
         ],
-      })
+      }),
     ),
   };
   const ctx = new TxTemplateContext(getDefaultLogger(), DEBUG);
@@ -780,7 +781,7 @@ describe('tokenVersion validation in output instructions', () => {
     });
 
     await expect(execRawOutputInstruction(interpreter, ctx, ins)).rejects.toThrow(
-      'Current transaction does not have a token version'
+      'Current transaction does not have a token version',
     );
   });
 
@@ -799,7 +800,7 @@ describe('tokenVersion validation in output instructions', () => {
     });
 
     await expect(execDataOutputInstruction(interpreter, ctx, ins)).rejects.toThrow(
-      'Current transaction does not have a token version'
+      'Current transaction does not have a token version',
     );
   });
 
@@ -820,7 +821,7 @@ describe('tokenVersion validation in output instructions', () => {
     });
 
     await expect(execTokenOutputInstruction(interpreter, ctx, ins)).rejects.toThrow(
-      'Current transaction does not have a token version'
+      'Current transaction does not have a token version',
     );
   });
 
@@ -841,7 +842,7 @@ describe('tokenVersion validation in output instructions', () => {
     });
 
     await expect(execAuthorityOutputInstruction(interpreter, ctx, ins)).rejects.toThrow(
-      'Current transaction does not have a token version'
+      'Current transaction does not have a token version',
     );
   });
 });

--- a/__tests__/template/transaction/instructions.test.ts
+++ b/__tests__/template/transaction/instructions.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+
 import {
   AddressSchema,
   AuthorityOutputInstruction,
@@ -51,8 +52,8 @@ describe('parsing variable references', () => {
       getVariable(
         '{foo2}',
         { foo2: 'bar' },
-        z.string().transform(o => `${o}1`)
-      )
+        z.string().transform(o => `${o}1`),
+      ),
     ).toBe('bar1');
     expect(getVariable(`{foo3}`, { foo3: 10 }, z.coerce.bigint())).toBe(10n);
     // Validation/refinement should be applied to value
@@ -60,13 +61,13 @@ describe('parsing variable references', () => {
       getVariable(
         'baz',
         {},
-        z.string().transform(o => `${o}1`)
-      )
+        z.string().transform(o => `${o}1`),
+      ),
     ).toBe('baz1');
     expect(getVariable(11, {}, z.coerce.bigint())).toBe(11n);
     // Should work with any schema
     expect(
-      getVariable('{objfoo}', { objfoo: { foo: '10' } }, z.object({ foo: z.coerce.bigint() }))
+      getVariable('{objfoo}', { objfoo: { foo: '10' } }, z.object({ foo: z.coerce.bigint() })),
     ).toStrictEqual({ foo: 10n });
     expect(getVariable('{numfoo}', { numfoo: '12' }, z.coerce.number())).toBe(12);
     expect(getVariable(123, {}, z.coerce.number())).toBe(123);
@@ -140,7 +141,7 @@ describe('should parse template instructions', () => {
         position: 0,
         index: 1,
         txId,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with default, coersion and variable
     expect(
@@ -149,7 +150,7 @@ describe('should parse template instructions', () => {
         index: '10',
         txId: '{foo}',
         foo: 'bar',
-      })
+      }),
     ).toStrictEqual({
       type: 'input/raw',
       position: -1,
@@ -162,21 +163,21 @@ describe('should parse template instructions', () => {
         type: 'output/raw', // wrong type
         index: 1,
         txId,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       RawInputInstruction.safeParse({
         type: 'input/raw',
         index: 'a1', // cannot coerce index
         txId,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       RawInputInstruction.safeParse({
         type: 'input/raw',
         index: 10,
         txId: '00', // invalid txId string
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       RawInputInstruction.safeParse({
@@ -184,7 +185,7 @@ describe('should parse template instructions', () => {
         position: 'abd', // invalid position
         index: 10,
         txId,
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -198,14 +199,14 @@ describe('should parse template instructions', () => {
         address,
         autoChange: false,
         changeAddress: address,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with default
     expect(
       UtxoSelectInstruction.parse({
         type: 'input/utxo',
         fill: 10,
-      })
+      }),
     ).toStrictEqual({
       type: 'input/utxo',
       position: -1,
@@ -221,7 +222,7 @@ describe('should parse template instructions', () => {
         token: '{tokenKey}',
         address: '{addressKey}',
         changeAddress: '{caddr}',
-      })
+      }),
     ).toStrictEqual({
       type: 'input/utxo',
       position: -1,
@@ -235,7 +236,7 @@ describe('should parse template instructions', () => {
     expect(
       UtxoSelectInstruction.safeParse({
         type: 'invalid-type', // wrong type
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -248,7 +249,7 @@ describe('should parse template instructions', () => {
         count: 10,
         position: 0,
         token,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
@@ -256,7 +257,7 @@ describe('should parse template instructions', () => {
         type: 'input/authority',
         authority: 'melt',
         token,
-      })
+      }),
     ).toStrictEqual({
       type: 'input/authority',
       authority: 'melt',
@@ -272,7 +273,7 @@ describe('should parse template instructions', () => {
         count: '{countKey}',
         token: '{tokenKey}',
         address: '{addressKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'input/authority',
       position: -1,
@@ -287,28 +288,28 @@ describe('should parse template instructions', () => {
         type: 'invalid-type', // wrong type
         authority: 'melt',
         token,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       AuthoritySelectInstruction.safeParse({
         // Missing authority
         type: 'input/authority',
         token,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       AuthoritySelectInstruction.safeParse({
         // Missing token
         type: 'input/authority',
         authority: 'melt',
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       AuthoritySelectInstruction.safeParse({
         type: 'input/authority',
         authority: 'melt',
         token: '00', // Cannot use native token with authority
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -322,14 +323,14 @@ describe('should parse template instructions', () => {
         token,
         timelock: 100,
         authority: 'mint',
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
       RawOutputInstruction.parse({
         type: 'output/raw',
         script: 'cafe',
-      })
+      }),
     ).toStrictEqual({
       type: 'output/raw',
       script: 'cafe',
@@ -345,7 +346,7 @@ describe('should parse template instructions', () => {
         amount: '{amountKey}',
         token: '{tokenKey}',
         timelock: '{timelockKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'output/raw',
       position: -1,
@@ -360,20 +361,20 @@ describe('should parse template instructions', () => {
       RawOutputInstruction.safeParse({
         type: 'invalid-type', // wrong type
         script: 'cafe',
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       RawOutputInstruction.safeParse({
         // Missing script
         type: 'output/raw',
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       RawOutputInstruction.safeParse({
         type: 'output/raw',
         script: 'cafe',
         authority: 'none', // Invalid authority
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -387,7 +388,7 @@ describe('should parse template instructions', () => {
         address,
         timelock: 100,
         checkAddress: false,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
@@ -395,7 +396,7 @@ describe('should parse template instructions', () => {
         type: 'output/token',
         amount: '5',
         address,
-      })
+      }),
     ).toStrictEqual({
       type: 'output/token',
       position: -1,
@@ -412,7 +413,7 @@ describe('should parse template instructions', () => {
         token: '{tokenKey}',
         address: '{addressKey}',
         timelock: '{timelockKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'output/token',
       position: -1,
@@ -428,21 +429,21 @@ describe('should parse template instructions', () => {
         type: 'invalid-type', // wrong type
         amount: 10,
         address,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       TokenOutputInstruction.safeParse({
         // Missing amount
         type: 'output/token',
         address,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       TokenOutputInstruction.safeParse({
         // Missing address
         type: 'output/token',
         amount: 10,
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -458,7 +459,7 @@ describe('should parse template instructions', () => {
         timelock: 100,
         checkAddress: false,
         useCreatedToken: false,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
@@ -467,7 +468,7 @@ describe('should parse template instructions', () => {
         token,
         authority: 'mint',
         address,
-      })
+      }),
     ).toStrictEqual({
       type: 'output/authority',
       position: -1,
@@ -486,7 +487,7 @@ describe('should parse template instructions', () => {
         authority: 'melt',
         address: '{addressKey}',
         timelock: '{timelockKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'output/authority',
       position: -1,
@@ -504,7 +505,7 @@ describe('should parse template instructions', () => {
         token,
         authority: 'mint',
         address,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       AuthorityOutputInstruction.safeParse({
@@ -512,7 +513,7 @@ describe('should parse template instructions', () => {
         token,
         authority: 'none', // Invalid authority
         address,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       AuthorityOutputInstruction.safeParse({
@@ -520,7 +521,7 @@ describe('should parse template instructions', () => {
         type: 'output/authority',
         token,
         address,
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       AuthorityOutputInstruction.safeParse({
@@ -528,7 +529,7 @@ describe('should parse template instructions', () => {
         type: 'output/authority',
         token,
         authority: 'mint',
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -540,14 +541,14 @@ describe('should parse template instructions', () => {
         data: 'foo',
         token,
         useCreatedToken: false,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
       DataOutputInstruction.parse({
         type: 'output/data',
         data: 'foo',
-      })
+      }),
     ).toStrictEqual({
       type: 'output/data',
       position: -1,
@@ -561,7 +562,7 @@ describe('should parse template instructions', () => {
         type: 'output/data',
         data: '{dataKey}',
         token: '{tokenKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'output/data',
       position: -1,
@@ -574,13 +575,13 @@ describe('should parse template instructions', () => {
       DataOutputInstruction.safeParse({
         type: 'invalid-type', // wrong type
         data: 'foo',
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       DataOutputInstruction.safeParse({
         // Missing data
         type: 'output/data',
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -589,38 +590,38 @@ describe('should parse template instructions', () => {
       ShuffleInstruction.safeParse({
         type: 'action/shuffle',
         target: 'all',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       ShuffleInstruction.safeParse({
         type: 'action/shuffle',
         target: 'inputs',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       ShuffleInstruction.safeParse({
         type: 'action/shuffle',
         target: 'outputs',
-      }).success
+      }).success,
     ).toBe(true);
     // error cases
     expect(
       ShuffleInstruction.safeParse({
         type: 'action/shuffle',
         target: 'invalid', // invalid target
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       ShuffleInstruction.safeParse({
         // missing target
         type: 'action/shuffle',
-      }).success
+      }).success,
     ).toBe(false);
     expect(
       ShuffleInstruction.safeParse({
         type: 'invalid-type', // invalid type
         target: 'all',
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -632,13 +633,13 @@ describe('should parse template instructions', () => {
         address,
         changeAddress: address,
         timelock: 456,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
       CompleteTxInstruction.parse({
         type: 'action/complete',
-      })
+      }),
     ).toStrictEqual({
       type: 'action/complete',
       skipSelection: false,
@@ -654,7 +655,7 @@ describe('should parse template instructions', () => {
         address: '{addrKey}',
         changeAddress: '{caddrKey}',
         timelock: '{timelockKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'action/complete',
       token: '{tokenKey}',
@@ -670,7 +671,7 @@ describe('should parse template instructions', () => {
     expect(
       CompleteTxInstruction.safeParse({
         type: 'invalid-type', // wrong type
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -683,13 +684,13 @@ describe('should parse template instructions', () => {
         tokenName: 'foo',
         tokenSymbol: 'bar',
         tokenVersion: TokenVersion.DEPOSIT,
-      }).success
+      }).success,
     ).toBe(true);
     // Parse with defaults
     expect(
       ConfigInstruction.parse({
         type: 'action/config',
-      })
+      }),
     ).toStrictEqual({
       type: 'action/config',
       tokenVersion: TokenVersion.DEPOSIT,
@@ -703,7 +704,7 @@ describe('should parse template instructions', () => {
         tokenName: '{tokenNameKey}',
         tokenSymbol: '{tokenSymbolKey}',
         tokenVersion: '{tokenVersionKey}',
-      })
+      }),
     ).toStrictEqual({
       type: 'action/config',
       version: '{versionKey}',
@@ -716,7 +717,7 @@ describe('should parse template instructions', () => {
     expect(
       ConfigInstruction.safeParse({
         type: 'invalid-type', // wrong type
-      }).success
+      }).success,
     ).toBe(false);
   });
 
@@ -726,7 +727,7 @@ describe('should parse template instructions', () => {
         type: 'action/setvar',
         name: 'foo',
         value: 'anything',
-      }).success
+      }).success,
     ).toBe(true);
 
     expect(
@@ -734,7 +735,7 @@ describe('should parse template instructions', () => {
         type: 'action/setvar',
         name: 'foo',
         call: { method: 'get_wallet_address' },
-      }).success
+      }).success,
     ).toBe(true);
 
     expect(
@@ -742,7 +743,7 @@ describe('should parse template instructions', () => {
         type: 'action/setvar',
         name: 'foo',
         call: { method: 'get_wallet_balance', token },
-      }).success
+      }).success,
     ).toBe(true);
   });
 
@@ -754,7 +755,7 @@ describe('should parse template instructions', () => {
         method: 'any_method',
         caller: 'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ',
         args: [123, 'foobar', { foo: [1, 2, 3] }],
-      }).success
+      }).success,
     ).toBe(true);
 
     expect(
@@ -764,7 +765,7 @@ describe('should parse template instructions', () => {
         method: 'any_method',
         caller: '{caller_address}',
         args: [123, '{argument_from_vars}'],
-      }).success
+      }).success,
     ).toBe(true);
   });
 });
@@ -780,13 +781,13 @@ describe('Template schemes', () => {
         type: 'input/raw',
         index: 1,
         txId,
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'input/utxo',
         fill: 10,
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
@@ -794,21 +795,21 @@ describe('Template schemes', () => {
         address,
         authority: 'mint',
         token,
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'output/raw',
         amount: '10',
         script: 'cafe',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'output/token',
         amount: '10',
         address,
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
@@ -817,24 +818,24 @@ describe('Template schemes', () => {
         token,
         authority: 'mint',
         address,
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'output/data',
         data: 'foo',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'action/shuffle',
         target: 'all',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'action/complete',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
@@ -842,14 +843,14 @@ describe('Template schemes', () => {
         version: 3,
         tokenName: 'foo',
         tokenSymbol: 'bar',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
         type: 'action/setvar',
         name: 'foo',
         value: 'anything',
-      }).success
+      }).success,
     ).toBe(true);
     expect(
       TxTemplateInstruction.safeParse({
@@ -857,7 +858,7 @@ describe('Template schemes', () => {
         id: '0000000110eb9ec96e255a09d6ae7d856bff53453773bae5500cee2905db670e',
         method: 'any_method',
         caller: 'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ',
-      }).success
+      }).success,
     ).toBe(true);
   });
 
@@ -879,7 +880,7 @@ describe('Template schemes', () => {
           amount: '10',
           address,
         },
-      ]).success
+      ]).success,
     ).toBe(true);
   });
 });

--- a/__tests__/template/transaction/interpreter.test.ts
+++ b/__tests__/template/transaction/interpreter.test.ts
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { NATIVE_TOKEN_UID } from '../../../src/constants';
+import FeeHeader from '../../../src/headers/fee';
 import HathorWallet from '../../../src/new/wallet';
 import { TxTemplateContext } from '../../../src/template/transaction/context';
 import { WalletTxTemplateInterpreter } from '../../../src/template/transaction/interpreter';
-import FeeHeader from '../../../src/headers/fee';
-import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import { getDefaultLogger } from '../../../src/types';
 
 describe('Wallet tx-template interpreter', () => {

--- a/__tests__/template/transaction/utils.test.ts
+++ b/__tests__/template/transaction/utils.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { selectTokens, selectAuthorities } from '../../../src/template/transaction/utils';
-import { TxTemplateContext } from '../../../src/template/transaction/context';
-import { getDefaultLogger } from '../../../src/types';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import Network from '../../../src/models/network';
+import { TxTemplateContext } from '../../../src/template/transaction/context';
 import { ITxTemplateInterpreter } from '../../../src/template/transaction/types';
+import { selectTokens, selectAuthorities } from '../../../src/template/transaction/utils';
+import { getDefaultLogger } from '../../../src/types';
 
 const DEBUG = false;
 
@@ -65,7 +65,7 @@ describe('selectTokens', () => {
         90n,
         { token },
         true, // autoChange
-        address
+        address,
       );
 
       // Token should be in array because a change output was created
@@ -87,7 +87,7 @@ describe('selectTokens', () => {
         90n,
         { token },
         false, // autoChange = false
-        address
+        address,
       );
 
       // Token should NOT be in array because no output was created
@@ -109,7 +109,7 @@ describe('selectTokens', () => {
         100n, // exact amount, no change needed
         { token },
         true, // autoChange
-        address
+        address,
       );
 
       // Token should NOT be in array because no change output was created

--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { HDPublicKey } from 'bitcore-lib';
+
 import Network from '../../src/models/network';
 import { MemoryStore, Storage } from '../../src/storage';
 import { WalletType } from '../../src/types';

--- a/__tests__/utils/bigint.test.js.ts
+++ b/__tests__/utils/bigint.test.js.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+
 import { bigIntCoercibleSchema, JSONBigInt, parseJsonBigInt } from '../../src/utils/bigint';
 
 const obj = {

--- a/__tests__/utils/buffer.test.ts
+++ b/__tests__/utils/buffer.test.ts
@@ -1,4 +1,9 @@
 import buffer from 'buffer';
+
+import { MAX_OUTPUT_VALUE, MAX_OUTPUT_VALUE_32 } from '../../src/constants';
+import Address from '../../src/models/address';
+import Output from '../../src/models/output';
+import P2PKH from '../../src/models/p2pkh';
 import {
   bigIntToBytes,
   bufferToHex,
@@ -11,10 +16,6 @@ import {
   unpackToFloat,
   unpackToInt,
 } from '../../src/utils/buffer';
-import Output from '../../src/models/output';
-import { MAX_OUTPUT_VALUE, MAX_OUTPUT_VALUE_32 } from '../../src/constants';
-import Address from '../../src/models/address';
-import P2PKH from '../../src/models/p2pkh';
 
 test('Buffer to hex', () => {
   const hexString =
@@ -58,35 +59,35 @@ test('bigint to bytes', () => {
   expect(bigIntToBytes(0n, 4)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 0]));
   expect(bigIntToBytes(1n, 4)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 1]));
   expect(bigIntToBytes(2n ** 31n - 1n, 4)).toStrictEqual(
-    buffer.Buffer.from([0x7f, 0xff, 0xff, 0xff])
+    buffer.Buffer.from([0x7f, 0xff, 0xff, 0xff]),
   );
   expect(() => bigIntToBytes(2n ** 31n, 4)).toThrow();
   expect(bigIntToBytes(-(2n ** 31n), 4)).toStrictEqual(
-    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00])
+    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00]),
   );
   expect(() => bigIntToBytes(-(2n ** 31n) - 1n, 4)).toThrow();
 
   expect(bigIntToBytes(0n, 8)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]));
   expect(bigIntToBytes(1n, 8)).toStrictEqual(buffer.Buffer.from([0, 0, 0, 0, 0, 0, 0, 1]));
   expect(bigIntToBytes(2n ** 31n - 1n, 8)).toStrictEqual(
-    buffer.Buffer.from([0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff])
+    buffer.Buffer.from([0, 0, 0, 0, 0x7f, 0xff, 0xff, 0xff]),
   );
   expect(bigIntToBytes(2n ** 31n, 8)).toStrictEqual(
-    buffer.Buffer.from([0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00])
+    buffer.Buffer.from([0x00, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00]),
   );
   expect(bigIntToBytes(-(2n ** 31n), 8)).toStrictEqual(
-    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x80, 0x00, 0x00, 0x00])
+    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x80, 0x00, 0x00, 0x00]),
   );
   expect(bigIntToBytes(-(2n ** 31n) - 1n, 8)).toStrictEqual(
-    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff])
+    buffer.Buffer.from([0xff, 0xff, 0xff, 0xff, 0x7f, 0xff, 0xff, 0xff]),
   );
 
   expect(bigIntToBytes(2n ** 63n - 1n, 8)).toStrictEqual(
-    buffer.Buffer.from([0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff])
+    buffer.Buffer.from([0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
   );
   expect(() => bigIntToBytes(2n ** 63n, 8)).toThrow();
   expect(bigIntToBytes(-(2n ** 63n), 8)).toStrictEqual(
-    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
+    buffer.Buffer.from([0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
   );
   expect(() => bigIntToBytes(-(2n ** 63n) - 1n, 4)).toThrow();
 });
@@ -98,15 +99,15 @@ test('unpack to bigint', () => {
   expect(unpackToBigInt(8, true, bigIntToBytes(0n, 8))[0]).toStrictEqual(0n);
   expect(unpackToBigInt(8, true, bigIntToBytes(1n, 8))[0]).toStrictEqual(1n);
   expect(unpackToBigInt(8, true, bigIntToBytes(2n ** 31n - 1n, 8))[0]).toStrictEqual(
-    2n ** 31n - 1n
+    2n ** 31n - 1n,
   );
   expect(unpackToBigInt(8, true, bigIntToBytes(2n ** 31n, 8))[0]).toStrictEqual(2n ** 31n);
   expect(unpackToBigInt(8, true, bigIntToBytes(-(2n ** 31n), 8))[0]).toStrictEqual(-(2n ** 31n));
   expect(unpackToBigInt(8, true, bigIntToBytes(-(2n ** 31n) - 1n, 8))[0]).toStrictEqual(
-    -(2n ** 31n) - 1n
+    -(2n ** 31n) - 1n,
   );
   expect(unpackToBigInt(8, true, bigIntToBytes(2n ** 63n - 1n, 8))[0]).toStrictEqual(
-    2n ** 63n - 1n
+    2n ** 63n - 1n,
   );
   expect(unpackToBigInt(8, true, bigIntToBytes(-(2n ** 63n), 8))[0]).toStrictEqual(-(2n ** 63n));
 });

--- a/__tests__/utils/crypto.test.ts
+++ b/__tests__/utils/crypto.test.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import CryptoJS from 'crypto-js';
 import bitcore from 'bitcore-lib';
+import CryptoJS from 'crypto-js';
+
 import { DecryptionError, InvalidPasswdError } from '../../src/errors';
 import {
   hashData,
@@ -27,7 +28,7 @@ test('validateHash', () => {
       salt: hashedData.salt,
       iterations: hashedData.iterations,
       pbkdf2Hasher: hashedData.pbkdf2Hasher,
-    })
+    }),
   ).toBe(true);
 
   const wrongSalt = CryptoJS.lib.WordArray.random(128 / 8).toString();
@@ -36,7 +37,7 @@ test('validateHash', () => {
       salt: wrongSalt,
       iterations: hashedData.iterations,
       pbkdf2Hasher: hashedData.pbkdf2Hasher,
-    })
+    }),
   ).toBe(false);
 });
 
@@ -51,7 +52,7 @@ test('encryption test', () => {
       salt: encrypted.salt,
       iterations: encrypted.iterations,
       pbkdf2Hasher: encrypted.pbkdf2Hasher,
-    })
+    }),
   ).toBe(true);
 
   // Decryption should only work with the correct password and data
@@ -84,7 +85,7 @@ test('check password', () => {
 test('sign message', () => {
   const message = 'please sign me';
   const xpriv = new bitcore.HDPrivateKey(
-    'tnpr4nfUjEyefVuczz8pYwkHUDD9Q96mP3q7jc3oDgdV6FEkTArttdZLrMWhCvRmvJ48jnKR5dHDrA13sk1qFwUujnzZt2ry9EgDzty3UjdhFsD'
+    'tnpr4nfUjEyefVuczz8pYwkHUDD9Q96mP3q7jc3oDgdV6FEkTArttdZLrMWhCvRmvJ48jnKR5dHDrA13sk1qFwUujnzZt2ry9EgDzty3UjdhFsD',
   );
   const firstAddressHDPrivKey = xpriv.derive("m/44'/280'/0'/0/0"); // first address
   const { privateKey } = firstAddressHDPrivKey;

--- a/__tests__/utils/fee.test.ts
+++ b/__tests__/utils/fee.test.ts
@@ -12,10 +12,10 @@ import {
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
 } from '../../src/constants';
-import { Fee } from '../../src/utils/fee';
 import Output from '../../src/models/output';
 import { MemoryStore, Storage } from '../../src/storage';
 import { IDataInput, IStorage, OutputValueType } from '../../src/types';
+import { Fee } from '../../src/utils/fee';
 import tokens from '../../src/utils/tokens';
 import { OutputType } from '../../src/wallet/types';
 import { mockGetToken } from '../__mock_helpers__/get-token.mock';

--- a/__tests__/utils/helpers.test.ts
+++ b/__tests__/utils/helpers.test.ts
@@ -6,18 +6,9 @@
  */
 
 import buffer from 'buffer';
-import helpers from '../../src/utils/helpers';
-import Network from '../../src/models/network';
-import dateFormatter from '../../src/utils/date';
-import Address from '../../src/models/address';
-import P2PKH from '../../src/models/p2pkh';
-import P2SH from '../../src/models/p2sh';
-import ScriptData from '../../src/models/script_data';
-import { OP_PUSHDATA1 } from '../../src/opcodes';
-import { DEFAULT_TX_VERSION, CREATE_TOKEN_TX_VERSION } from '../../src/constants';
-import Transaction from '../../src/models/transaction';
-import CreateTokenTransaction from '../../src/models/create_token_transaction';
+
 import config from '../../src/config';
+import { DEFAULT_TX_VERSION, CREATE_TOKEN_TX_VERSION } from '../../src/constants';
 import {
   AddressError,
   OutputValueError,
@@ -26,6 +17,16 @@ import {
   MaximumNumberInputsError,
   MaximumNumberOutputsError,
 } from '../../src/errors';
+import Address from '../../src/models/address';
+import CreateTokenTransaction from '../../src/models/create_token_transaction';
+import Network from '../../src/models/network';
+import P2PKH from '../../src/models/p2pkh';
+import P2SH from '../../src/models/p2sh';
+import ScriptData from '../../src/models/script_data';
+import Transaction from '../../src/models/transaction';
+import { OP_PUSHDATA1 } from '../../src/opcodes';
+import dateFormatter from '../../src/utils/date';
+import helpers from '../../src/utils/helpers';
 
 test('Round float', () => {
   expect(helpers.roundFloat(1.23)).toBe(1.23);
@@ -122,7 +123,7 @@ test('createTxFromBytes and Hex', () => {
   // Testing fromBytes
   expect(helpers.createTxFromBytes(defaulttxbytes, testnet)).toEqual('default-transaction');
   expect(helpers.createTxFromBytes(createTokentxbytes, testnet)).toEqual(
-    'create-token-transaction'
+    'create-token-transaction',
   );
   expect(() => {
     helpers.createTxFromBytes(errorTxBytes, testnet);
@@ -130,10 +131,10 @@ test('createTxFromBytes and Hex', () => {
 
   // Testing fromHex
   expect(helpers.createTxFromHex(defaulttxbytes.toString('hex'), testnet)).toEqual(
-    'default-transaction'
+    'default-transaction',
   );
   expect(helpers.createTxFromHex(createTokentxbytes.toString('hex'), testnet)).toEqual(
-    'create-token-transaction'
+    'create-token-transaction',
   );
   expect(() => {
     helpers.createTxFromHex(errorTxBytes.toString('hex'), testnet);
@@ -335,7 +336,7 @@ test('fixAxiosConfig', () => {
 
 test('getShortHash', () => {
   expect(helpers.getShortHash(`123456123456${Array(40).fill(0).join('')}654321654321`)).toEqual(
-    '123456123456...654321654321'
+    '123456123456...654321654321',
   );
 });
 

--- a/__tests__/utils/scripts.test.ts
+++ b/__tests__/utils/scripts.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import Network from '../../src/models/network';
 import {
   createP2SHRedeemScript,
   parseP2PKH,
   parseP2SH,
   parseScriptData,
 } from '../../src/utils/scripts';
-import Network from '../../src/models/network';
 
 test('parseP2PKH', () => {
   const testnet = new Network('testnet');
@@ -94,6 +94,6 @@ test('createP2SHRedeemScript', () => {
   const scriptHex =
     '532102a847d31a64c190d2ec082c46eb23aff9c591c59f3be86e90404d45aa42841ac22103ee726ee90b034eb4dcfc4ee9cd7d0b743f41eb93de0c21d750e6110e46cf5986210339f5fa440e0f2754226e04ca5b1c3510416fc54739ba3101d03b3b99d8366e4121025e7c288c0e988f02c8c2b64bd4656743e279fa50c0b287c0985b3635fd85b8b9210383689a51fc5285188b19194ef2e3cf1ee752854f73ca186c9b1b99e0698805ef55ae';
   expect(
-    createP2SHRedeemScript(multisig.data.pubkeys, multisig.data.numSignatures, 0)
+    createP2SHRedeemScript(multisig.data.pubkeys, multisig.data.numSignatures, 0),
   ).toMatchBuffer(Buffer.from(scriptHex, 'hex'));
 });

--- a/__tests__/utils/storage.test.ts
+++ b/__tests__/utils/storage.test.ts
@@ -5,10 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import { HistorySyncMode, WalletType, TokenVersion, SCANNING_POLICY } from '../../src/types';
+import MockAdapter from 'axios-mock-adapter';
+
+import CreateTokenTransaction from '../../src/models/create_token_transaction';
+import Transaction from '../../src/models/transaction';
 import { MemoryStore, Storage } from '../../src/storage';
+import { manualStreamSyncHistory, xpubStreamSyncHistory } from '../../src/sync/stream';
+import { HistorySyncMode, WalletType, TokenVersion, SCANNING_POLICY } from '../../src/types';
 import {
   scanPolicyStartAddresses,
   checkScanningPolicy,
@@ -18,9 +22,6 @@ import {
   apiSyncHistory,
   addCreatedTokenFromTx,
 } from '../../src/utils/storage';
-import { manualStreamSyncHistory, xpubStreamSyncHistory } from '../../src/sync/stream';
-import CreateTokenTransaction from '../../src/models/create_token_transaction';
-import Transaction from '../../src/models/transaction';
 
 describe('scanning policy methods', () => {
   it('start addresses', async () => {
@@ -43,7 +44,7 @@ describe('scanning policy methods', () => {
       Promise.resolve({
         policy: 'gap-limit',
         gapLimit,
-      })
+      }),
     );
     const policyMock = jest.spyOn(storage, 'getScanningPolicy');
 
@@ -273,7 +274,7 @@ describe('_updateTokensData', () => {
     tokensSet.add('mock-token');
     jest.useFakeTimers();
     const promiseObj = _updateTokensData(storage, tokensSet).catch(
-      err => `Catched error: ${err.message}`
+      err => `Catched error: ${err.message}`,
     );
     await jest.advanceTimersToNextTimerAsync();
     await jest.advanceTimersToNextTimerAsync();
@@ -283,7 +284,7 @@ describe('_updateTokensData', () => {
     await jest.advanceTimersToNextTimerAsync();
     await jest.advanceTimersToNextTimerAsync();
     await expect(promiseObj).resolves.toEqual(
-      `Catched error: Too many attempts at fetchTokenData for ${mockToken.uid}`
+      `Catched error: Too many attempts at fetchTokenData for ${mockToken.uid}`,
     );
 
     // Verify
@@ -329,7 +330,7 @@ describe('_updateTokensData', () => {
     let beforeTime;
     let afterTime;
     const promiseObj = _updateTokensData(storage, tokensSet).catch(
-      err => `Catched error: ${err.message}`
+      err => `Catched error: ${err.message}`,
     );
     beforeTime = jest.now();
     await jest.advanceTimersToNextTimerAsync();
@@ -362,7 +363,7 @@ describe('_updateTokensData', () => {
     expect(afterTime - beforeTime).toEqual(16000);
 
     await expect(promiseObj).resolves.toEqual(
-      `Catched error: Too many attempts at fetchTokenData for ${mockToken.uid}`
+      `Catched error: Too many attempts at fetchTokenData for ${mockToken.uid}`,
     );
 
     // Verify

--- a/__tests__/utils/tokens.test.ts
+++ b/__tests__/utils/tokens.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import tokens from '../../src/utils/tokens';
-import { NATIVE_TOKEN_UID } from '../../src/constants';
 import walletApi from '../../src/api/wallet';
-import { MemoryStore, Storage } from '../../src/storage';
+import { NATIVE_TOKEN_UID } from '../../src/constants';
 import { TokenValidationError } from '../../src/errors';
+import { MemoryStore, Storage } from '../../src/storage';
 import { TokenVersion } from '../../src/types';
+import tokens from '../../src/utils/tokens';
 
 test('Validate configuration string', async () => {
   const uid = '0000360f5e95c492352a6f1cab81b33d56694299f1da2b437107b2b1edde9687';
@@ -25,33 +25,33 @@ test('Validate configuration string', async () => {
 
   // Invalid config string should throw
   await expect(tokens.validateTokenToAddByConfigurationString('invalid-string')).rejects.toThrow(
-    'Invalid configuration string'
+    'Invalid configuration string',
   );
   await expect(tokens.validateTokenToAddByConfigurationString('invalid-string')).rejects.toThrow(
-    TokenValidationError
+    TokenValidationError,
   );
   await expect(
-    tokens.validateTokenToAddByConfigurationString('invalid-string', storage)
+    tokens.validateTokenToAddByConfigurationString('invalid-string', storage),
   ).rejects.toThrow(TokenValidationError);
 
   // Should throw if uid does not match the expected uid
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, undefined, 'expected-uid')
+    tokens.validateTokenToAddByConfigurationString(configString, undefined, 'expected-uid'),
   ).rejects.toThrow('Configuration string uid does not match');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, undefined, 'expected-uid')
+    tokens.validateTokenToAddByConfigurationString(configString, undefined, 'expected-uid'),
   ).rejects.toThrow(TokenValidationError);
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage, 'expected-uid')
+    tokens.validateTokenToAddByConfigurationString(configString, storage, 'expected-uid'),
   ).rejects.toThrow(TokenValidationError);
 
   // should throw if token is already registered
   await store.registerToken({ uid, name, symbol, version: TokenVersion.DEPOSIT });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow('You already have this token');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow(TokenValidationError);
   await store.unregisterToken(uid);
 
@@ -63,10 +63,10 @@ test('Validate configuration string', async () => {
     version: TokenVersion.DEPOSIT,
   });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow('You already have a token with this name');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow(TokenValidationError);
   await store.unregisterToken(uid2);
 
@@ -77,10 +77,10 @@ test('Validate configuration string', async () => {
     version: TokenVersion.DEPOSIT,
   });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow('You already have a token with this symbol');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow(TokenValidationError);
   await store.unregisterToken(uid2);
 
@@ -89,30 +89,30 @@ test('Validate configuration string', async () => {
     cb({ success: false, message: 'boom!' });
   });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow('boom!');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow(TokenValidationError);
 
   apiSpy.mockImplementation((_, cb) => {
     cb({ success: true, name: 'Another name', symbol });
   });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow('Token name does not match');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow(TokenValidationError);
 
   apiSpy.mockImplementation((_, cb) => {
     cb({ success: true, name, symbol: 'Another symbol' });
   });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow('Token symbol does not match');
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).rejects.toThrow(TokenValidationError);
 
   // With no conflicts in storage and the api confirming the token is valid
@@ -121,7 +121,7 @@ test('Validate configuration string', async () => {
     cb({ success: true, name, symbol, version: TokenVersion.DEPOSIT });
   });
   await expect(
-    tokens.validateTokenToAddByConfigurationString(configString, storage)
+    tokens.validateTokenToAddByConfigurationString(configString, storage),
   ).resolves.toEqual({ uid, name, symbol });
 
   apiSpy.mockRestore();

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { PrivateKey, crypto, HDPrivateKey } from 'bitcore-lib';
-import transaction from '../../src/utils/transaction';
-import { UtxoError } from '../../src/errors';
+
+import txApi from '../../src/api/txApi';
 import {
   BLOCK_VERSION,
   CREATE_TOKEN_TX_VERSION,
@@ -19,15 +19,16 @@ import {
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
 } from '../../src/constants';
-import txApi from '../../src/api/txApi';
-import { MemoryStore, Storage } from '../../src/storage';
+import { UtxoError } from '../../src/errors';
+import Address from '../../src/models/address';
 import Input from '../../src/models/input';
-import Transaction from '../../src/models/transaction';
 import Output from '../../src/models/output';
 import P2PKH from '../../src/models/p2pkh';
-import Address from '../../src/models/address';
+import Transaction from '../../src/models/transaction';
 import NanoContractHeader from '../../src/nano_contracts/header';
+import { MemoryStore, Storage } from '../../src/storage';
 import { TokenVersion } from '../../src/types';
+import transaction from '../../src/utils/transaction';
 
 test('isAuthorityOutput', () => {
   expect(transaction.isAuthorityOutput({ token_data: TOKEN_AUTHORITY_MASK })).toBe(true);
@@ -41,16 +42,16 @@ test('isAuthorityOutput', () => {
 test('isMint', () => {
   expect(transaction.isMint({ value: 0n, token_data: TOKEN_AUTHORITY_MASK })).toBe(false);
   expect(transaction.isMint({ value: TOKEN_MINT_MASK, token_data: TOKEN_AUTHORITY_MASK })).toBe(
-    true
+    true,
   );
   expect(
     transaction.isMint({
       value: TOKEN_MINT_MASK | TOKEN_MELT_MASK,
       token_data: TOKEN_AUTHORITY_MASK,
-    })
+    }),
   ).toBe(true);
   expect(
-    transaction.isMint({ value: TOKEN_MINT_MASK, token_data: TOKEN_AUTHORITY_MASK | 126 })
+    transaction.isMint({ value: TOKEN_MINT_MASK, token_data: TOKEN_AUTHORITY_MASK | 126 }),
   ).toBe(true);
 
   expect(transaction.isMint({ value: TOKEN_MINT_MASK, token_data: 0 })).toBe(false);
@@ -61,16 +62,16 @@ test('isMint', () => {
 test('isMelt', () => {
   expect(transaction.isMelt({ value: 0n, token_data: TOKEN_AUTHORITY_MASK })).toBe(false);
   expect(transaction.isMelt({ value: TOKEN_MELT_MASK, token_data: TOKEN_AUTHORITY_MASK })).toBe(
-    true
+    true,
   );
   expect(
     transaction.isMelt({
       value: TOKEN_MINT_MASK | TOKEN_MELT_MASK,
       token_data: TOKEN_AUTHORITY_MASK,
-    })
+    }),
   ).toBe(true);
   expect(
-    transaction.isMelt({ value: TOKEN_MELT_MASK, token_data: TOKEN_AUTHORITY_MASK | 126 })
+    transaction.isMelt({ value: TOKEN_MELT_MASK, token_data: TOKEN_AUTHORITY_MASK | 126 }),
   ).toBe(true);
 
   expect(transaction.isMelt({ value: TOKEN_MELT_MASK, token_data: 0 })).toBe(false);
@@ -88,7 +89,7 @@ test('getSignature', () => {
 
   // A signature made with this util matches the public key
   expect(
-    crypto.ECDSA.verify(hashdata, crypto.Signature.fromDER(signatureDER), privkey.toPublicKey())
+    crypto.ECDSA.verify(hashdata, crypto.Signature.fromDER(signatureDER), privkey.toPublicKey()),
   ).toBe(true);
 });
 
@@ -129,7 +130,7 @@ test('getSignatureForTx signing nano contract when we are not the caller', async
     Buffer.from('cafe', 'hex'),
     [],
     1,
-    new Address('WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp')
+    new Address('WYBwT3xLpDnHNtYZiU52oanupVeDKhAvNp'),
   );
   const tx = new Transaction([input], [], { headers: [nano] });
   expect(tx.isNanoContract()).toBeTruthy();
@@ -152,8 +153,8 @@ test('getSignatureForTx signing nano contract when we are not the caller', async
     crypto.ECDSA.verify(
       hashdata,
       crypto.Signature.fromDER(sigData.inputSignatures[0].signature),
-      xpriv.deriveChild(10).publicKey
-    )
+      xpriv.deriveChild(10).publicKey,
+    ),
   ).toBe(true);
 });
 
@@ -206,7 +207,7 @@ test('signTransaction', async () => {
   expect(input0.data).toEqual(null);
   const sig1 = input1.data.slice(1, 1 + input1.data[0]);
   expect(
-    crypto.ECDSA.verify(hashdata, crypto.Signature.fromDER(sig1), xpriv.deriveChild(10).publicKey)
+    crypto.ECDSA.verify(hashdata, crypto.Signature.fromDER(sig1), xpriv.deriveChild(10).publicKey),
   ).toBe(true);
   expect(input2.data).toEqual(null);
   expect(input3.data).toEqual(Buffer.from('010203', 'hex'));
@@ -231,41 +232,41 @@ test('Utxo selection', () => {
   const selectedUtxos = transaction.selectUtxos(utxos, 3n);
   expect(selectedUtxos.utxos.length).toBe(1);
   expect(selectedUtxos.utxos[0].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e',
   );
   expect(selectedUtxos.changeAmount).toBe(2n);
 
   const selectedUtxos2 = transaction.selectUtxos(utxos, 5n);
   expect(selectedUtxos2.utxos.length).toBe(1);
   expect(selectedUtxos2.utxos[0].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e',
   );
   expect(selectedUtxos2.changeAmount).toBe(0n);
 
   const selectedUtxos3 = transaction.selectUtxos(utxos, 6n);
   expect(selectedUtxos3.utxos.length).toBe(1);
   expect(selectedUtxos3.utxos[0].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2d'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2d',
   );
   expect(selectedUtxos3.changeAmount).toBe(4n);
 
   const selectedUtxos4 = transaction.selectUtxos(utxos, 11n);
   expect(selectedUtxos4.utxos.length).toBe(2);
   expect(selectedUtxos4.utxos[0].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2d'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2d',
   );
   expect(selectedUtxos4.utxos[1].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e',
   );
   expect(selectedUtxos4.changeAmount).toBe(4n);
 
   const selectedUtxos5 = transaction.selectUtxos(utxos, 15n);
   expect(selectedUtxos5.utxos.length).toBe(2);
   expect(selectedUtxos5.utxos[0].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2d'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2d',
   );
   expect(selectedUtxos5.utxos[1].txId).toBe(
-    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e'
+    '0000a8756b1585d772e852f2d364fb88fcc503421ea25d709e17b4f9613fcd2e',
   );
   expect(selectedUtxos5.changeAmount).toBe(0n);
 
@@ -309,7 +310,7 @@ test('utxo from history output', () => {
       authorities: 0n,
       heightlock: null, // heightlock is not checked on this method.
       locked: false, // The method does not check the lock.
-    }
+    },
   );
 
   // Custom token without timelock
@@ -334,7 +335,7 @@ test('utxo from history output', () => {
       authorities: 0n,
       heightlock: null, // heightlock is not checked on this method.
       locked: false, // The method does not check the lock.
-    }
+    },
   );
 
   // Custom token authority
@@ -359,7 +360,7 @@ test('utxo from history output', () => {
       authorities: 2n,
       heightlock: null, // heightlock is not checked on this method.
       locked: false, // The method does not check the lock.
-    }
+    },
   );
 });
 
@@ -384,11 +385,11 @@ test('getTokenDataFromOutput', () => {
   expect(transaction.getTokenDataFromOutput(utxoCustom, ['02', '01', '03'])).toEqual(2);
   const utxoCustomAuth = { type: 'p2pkh', token: '01', authorities: 1n };
   expect(transaction.getTokenDataFromOutput(utxoCustomAuth, ['03', '02', '01'])).toEqual(
-    3 | TOKEN_AUTHORITY_MASK
+    3 | TOKEN_AUTHORITY_MASK,
   );
   const utxoCustomAuth2 = { type: 'p2pkh', token: '01', authorities: 2n };
   expect(transaction.getTokenDataFromOutput(utxoCustomAuth2, ['02', '01'])).toEqual(
-    2 | TOKEN_AUTHORITY_MASK
+    2 | TOKEN_AUTHORITY_MASK,
   );
 });
 
@@ -526,14 +527,14 @@ test('getTxType', () => {
   expect(transaction.getTxType({ version: BLOCK_VERSION })).toBe('Block');
   expect(transaction.getTxType({ version: DEFAULT_TX_VERSION })).toBe('Transaction');
   expect(transaction.getTxType({ version: CREATE_TOKEN_TX_VERSION })).toBe(
-    'Create Token Transaction'
+    'Create Token Transaction',
   );
   expect(transaction.getTxType({ version: MERGED_MINED_BLOCK_VERSION })).toBe(
-    'Merged Mining Block'
+    'Merged Mining Block',
   );
   expect(transaction.getTxType({ version: POA_BLOCK_VERSION })).toBe('Proof-of-Authority Block');
   expect(transaction.getTxType({ version: ON_CHAIN_BLUEPRINTS_VERSION })).toBe(
-    'On-Chain Blueprint'
+    'On-Chain Blueprint',
   );
   expect(transaction.getTxType({ version: 999 })).toBe('Unknown');
 });
@@ -663,12 +664,12 @@ test('convertTransactionToHistoryTx', async () => {
     tx.hash = 'resolve-fail-case';
     tx.inputs = [new Input('resolve-fail', 0)];
     await expect(transaction.convertTransactionToHistoryTx(tx, storage)).rejects.toThrow(
-      'failed api call'
+      'failed api call',
     );
     tx.hash = 'no-outputs-case';
     tx.inputs = [new Input('no-outputs', 0)];
     await expect(transaction.convertTransactionToHistoryTx(tx, storage)).rejects.toThrow(
-      'Index outside of tx output array bounds'
+      'Index outside of tx output array bounds',
     );
 
     tx.hash = 'fail-case';

--- a/__tests__/utils/utxo.test.ts
+++ b/__tests__/utils/utxo.test.ts
@@ -6,8 +6,8 @@
  */
 
 import { MemoryStore, Storage } from '../../src/storage';
-import { bestUtxoSelection, fastUtxoSelection } from '../../src/utils/utxo';
 import { IStore } from '../../src/types';
+import { bestUtxoSelection, fastUtxoSelection } from '../../src/utils/utxo';
 
 describe('bestUtxoSelection', () => {
   const utxos = [

--- a/__tests__/utils/wallet.test.ts
+++ b/__tests__/utils/wallet.test.ts
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import Mnemonic from 'bitcore-mnemonic';
 import { crypto, util, HDPrivateKey, HDPublicKey } from 'bitcore-lib';
-import wallet from '../../src/utils/wallet';
+import Mnemonic from 'bitcore-mnemonic';
+
+import { HD_WALLET_ENTROPY, HATHOR_BIP44_CODE, P2SH_ACCT_PATH } from '../../src/constants';
 import {
   XPubError,
   InvalidWords,
@@ -15,10 +16,10 @@ import {
   InvalidPasswdError,
 } from '../../src/errors';
 import Network from '../../src/models/network';
-import { HD_WALLET_ENTROPY, HATHOR_BIP44_CODE, P2SH_ACCT_PATH } from '../../src/constants';
-import { hexToBuffer } from '../../src/utils/buffer';
 import { WalletType, WALLET_FLAGS } from '../../src/types';
+import { hexToBuffer } from '../../src/utils/buffer';
 import { checkPassword } from '../../src/utils/crypto';
+import wallet from '../../src/utils/wallet';
 
 test('Words', () => {
   const words = wallet.generateWalletWords();
@@ -90,13 +91,13 @@ test('Xpriv and xpub', () => {
     derivedXpriv.publicKey.toBuffer(),
     chainCode,
     fingerprint,
-    'testnet'
+    'testnet',
   );
   expect(derivedXpub).toBe(derivedXpriv.xpubkey);
 
   // getPublicKeyFromXpub without an index will return the public key at the current derivation level
   expect(wallet.getPublicKeyFromXpub(derivedXpriv.xpubkey).toString()).toEqual(
-    derivedXpriv.publicKey.toString()
+    derivedXpriv.publicKey.toString(),
   );
 
   // To pubkey compressed
@@ -109,7 +110,7 @@ test('Xpriv and xpub', () => {
 
   // Invalid uncompressed public key must throw error
   expect(() => wallet.toPubkeyCompressed(hexToBuffer(`${uncompressedPubKeyHex}ab`))).toThrow(
-    UncompressedPubKeyError
+    UncompressedPubKeyError,
   );
 });
 
@@ -361,13 +362,13 @@ test('createP2SHRedeemScript', () => {
   const redeemScript0 =
     '5221027105a304d7f3935b64824303687cf96a2400a29a9a69fcfc286a090e71f5acf92102374bba4d4a3d19222db84b5334527fe49e746e3aeac7d18ae14c9ac5a1c1bd0721027892436f6b36eb31edaee157cfa029b1735525626cf7247eb17de5a3db2427ad53ae';
   expect(wallet.createP2SHRedeemScript(xpubs, numSignatures, 0).toString('hex')).toBe(
-    redeemScript0
+    redeemScript0,
   );
 
   const redeemScript1 =
     '522103483dd29818452ddcc11eaa04e00a84f0d733102caa1b124b349c7d4e8f6226972103262d9d3d2339298a0fdee45553ca60765a3486c872271dd1b56e6224ee7ec0d621027af464c0c85f656544bb0b34b3e3e525b7b76a9ab9faa3bbec8d0ceeed62647b53ae';
   expect(wallet.createP2SHRedeemScript(xpubs, numSignatures, 1).toString('hex')).toBe(
-    redeemScript1
+    redeemScript1,
   );
 });
 
@@ -384,7 +385,7 @@ test('getP2SHInputData', () => {
   expect(
     wallet
       .getP2SHInputData([signature, signature], Buffer.from(redeemScript0, 'hex'))
-      .toString('hex')
+      .toString('hex'),
   ).toBe(sig0);
 
   // Create a valid input data with another script
@@ -395,7 +396,7 @@ test('getP2SHInputData', () => {
   expect(
     wallet
       .getP2SHInputData([signature, signature], Buffer.from(redeemScript1, 'hex'))
-      .toString('hex')
+      .toString('hex'),
   ).toBe(sig1);
 
   // The script is a Multisig 2/3
@@ -405,8 +406,8 @@ test('getP2SHInputData', () => {
   expect(() =>
     wallet.getP2SHInputData(
       [signature, signature, signature, signature],
-      Buffer.from(redeemScript0, 'hex')
-    )
+      Buffer.from(redeemScript0, 'hex'),
+    ),
   ).toThrow();
 });
 
@@ -460,7 +461,7 @@ test('access data from xpub', () => {
   expect(
     wallet.generateAccessDataFromXpub(xpubkeyAcct, {
       multisig: { numSignatures: 2, pubkeys: [xpubkeyAcct, xpubkeyChange] },
-    })
+    }),
   ).toMatchObject({
     xpubkey: xpubAcct.derive(0).xpubkey,
     walletType: WalletType.MULTISIG,
@@ -538,7 +539,7 @@ test('access data from xpriv', () => {
         numSignatures: 2,
         pubkeys: [xpubkeyRoot, xpubkeyAcct, xpubkeyChange],
       },
-    })
+    }),
   ).toMatchObject({
     xpubkey: xprivRoot.deriveNonCompliantChild(`${P2SH_ACCT_PATH}/0`).xpubkey,
     walletType: WalletType.MULTISIG,
@@ -579,7 +580,11 @@ test('access data from seed', () => {
 
   // P2PKH from seed
   expect(
-    wallet.generateAccessDataFromSeed(seed, { pin: '123', password: '456', networkName: 'testnet' })
+    wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    }),
   ).toMatchObject({
     xpubkey: xpubChange.xpubkey,
     mainKey: expect.objectContaining({
@@ -613,7 +618,7 @@ test('access data from seed', () => {
         numSignatures: 2,
         pubkeys: [xpubkeyAcct, xpubkeyChange],
       },
-    })
+    }),
   ).toMatchObject({
     xpubkey: xprivRoot.deriveNonCompliantChild(`${P2SH_ACCT_PATH}/0`).xpubkey,
     walletType: WalletType.MULTISIG,
@@ -643,10 +648,10 @@ test('change pin and password', async () => {
   expect(checkPassword(accessData.authKey, '123')).toEqual(true);
 
   expect(() => wallet.changeEncryptionPin(accessData, 'invalid-pin', '321')).toThrow(
-    InvalidPasswdError
+    InvalidPasswdError,
   );
   expect(() => wallet.changeEncryptionPassword(accessData, 'invalid-passwd', '456')).toThrow(
-    InvalidPasswdError
+    InvalidPasswdError,
   );
 
   const pinChangedAccessData = wallet.changeEncryptionPin(accessData, '123', '321');
@@ -683,7 +688,7 @@ test('getXprivFromData', () => {
     buffers.parentFingerPrint,
     buffers.depth,
     buffers.childIndex,
-    'testnet'
+    'testnet',
   );
   expect(xpriv).toEqual(hdPrivKey.xprivkey);
 });

--- a/__tests__/wallet/api/swapService.test.ts
+++ b/__tests__/wallet/api/swapService.test.ts
@@ -1,6 +1,7 @@
-import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import AES from 'crypto-js/aes';
+
 import config from '../../../src/config';
 import {
   decryptString,
@@ -50,26 +51,26 @@ describe('hashing and encrypting', () => {
 describe('base url configuration', () => {
   it('should throw when no url parameter was offered', () => {
     expect(() => config.getSwapServiceBaseUrl()).toThrow(
-      'You should either provide a network or call setSwapServiceBaseUrl before calling this.'
+      'You should either provide a network or call setSwapServiceBaseUrl before calling this.',
     );
   });
 
   it('should return mainnet address when requested', () => {
     expect(config.getSwapServiceBaseUrl('mainnet')).toStrictEqual(
-      'https://atomic-swap-service.hathor.network/'
+      'https://atomic-swap-service.hathor.network/',
     );
   });
 
   it('should return testnet address when requested', () => {
     expect(config.getSwapServiceBaseUrl('testnet')).toStrictEqual(
-      'https://atomic-swap-service.testnet.hathor.network/'
+      'https://atomic-swap-service.testnet.hathor.network/',
     );
   });
 
   it('should throw when an invalid network is requested', () => {
     // @ts-expect-error -- Testing invalid inputs
     expect(() => config.getSwapServiceBaseUrl('invalid')).toThrow(
-      `Network invalid doesn't have a correspondent Atomic Swap Service url. You should set it explicitly by calling setSwapServiceBaseUrl.`
+      `Network invalid doesn't have a correspondent Atomic Swap Service url. You should set it explicitly by calling setSwapServiceBaseUrl.`,
     );
   });
 
@@ -85,7 +86,7 @@ describe('create api', () => {
     await expect(create()).rejects.toThrow('Missing serializedPartialTx');
     await expect(
       // @ts-expect-error -- Testing invalid inputs
-      create('PartialTx|0001000000000000000000000063f78c0e0000000000||')
+      create('PartialTx|0001000000000000000000000063f78c0e0000000000||'),
     ).rejects.toThrow('Missing password');
   });
 
@@ -94,7 +95,7 @@ describe('create api', () => {
 
     mockAxiosAdapter.onPost('/').reply(503);
     await expect(
-      create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'abc')
+      create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'abc'),
     ).rejects.toThrow('Request failed with status code 503');
   });
 
@@ -107,7 +108,7 @@ describe('create api', () => {
     };
     mockAxiosAdapter.onPost('/').reply(200, responseData);
     await expect(
-      create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'abc')
+      create('PartialTx|0001000000000000000000000063f78c0e0000000000||', 'abc'),
     ).resolves.toStrictEqual(responseData);
   });
 });
@@ -125,7 +126,7 @@ describe('get api', () => {
 
     mockAxiosAdapter.onGet('/b4a5b077-c599-41e8-a791-85e08efcb1da').reply(503);
     await expect(get('b4a5b077-c599-41e8-a791-85e08efcb1da', 'abc')).rejects.toThrow(
-      'Request failed with status code 503'
+      'Request failed with status code 503',
     );
   });
 
@@ -149,7 +150,7 @@ describe('get api', () => {
       throw new Error('Malformed UTF-8 data');
     });
     await expect(get('b4a5b077-c599-41e8-a791-85e08efcb1da', incorrectPassword)).rejects.toThrow(
-      'Incorrect password: could not decode the proposal'
+      'Incorrect password: could not decode the proposal',
     );
     decryptMock.mockRestore();
   });
@@ -172,7 +173,7 @@ describe('get api', () => {
     mockAxiosAdapter.onGet('/b4a5b077-c599-41e8-a791-85e08efcb1da').reply(200, rawHttpBody);
     const decryptMock = jest.spyOn(AES, 'decrypt').mockImplementationOnce(() => 'invalid string');
     await expect(get('b4a5b077-c599-41e8-a791-85e08efcb1da', incorrectPassword)).rejects.toThrow(
-      'Incorrect password: could not decode the proposal'
+      'Incorrect password: could not decode the proposal',
     );
     decryptMock.mockRestore();
   });
@@ -294,14 +295,14 @@ describe('update api', () => {
       // @ts-expect-error -- Testing invalid inputs
       update({
         proposalId: 'abc',
-      })
+      }),
     ).rejects.toThrow('password');
     await expect(
       // @ts-expect-error -- Testing invalid inputs
       update({
         proposalId: 'abc',
         password: '123',
-      })
+      }),
     ).rejects.toThrow('partialTx');
     await expect(
       // @ts-expect-error -- Testing invalid inputs
@@ -309,7 +310,7 @@ describe('update api', () => {
         proposalId: 'abc',
         password: '123',
         partialTx: 'abc123',
-      })
+      }),
     ).rejects.toThrow('version');
     await expect(
       update({
@@ -318,7 +319,7 @@ describe('update api', () => {
         partialTx: 'abc123',
         // @ts-expect-error -- Testing invalid inputs
         version: 'a',
-      })
+      }),
     ).rejects.toThrow('Invalid version number');
   });
 
@@ -332,7 +333,7 @@ describe('update api', () => {
         password: 'abc',
         partialTx: 'PartialTx|0001000000000000000000000063f78c0e0000000000||',
         version: 0,
-      })
+      }),
     ).rejects.toThrow('Request failed with status code 503');
   });
 
@@ -346,7 +347,7 @@ describe('update api', () => {
         password: 'abc',
         partialTx: 'PartialTx|0001000000000000000000000063f78c0e0000000000||',
         version: 0,
-      })
+      }),
     ).resolves.toStrictEqual({ success: false });
   });
 
@@ -360,7 +361,7 @@ describe('update api', () => {
         password: 'abc',
         partialTx: 'PartialTx|0001000000000000000000000063f78c0e0000000000||',
         version: 0,
-      })
+      }),
     ).resolves.toStrictEqual({ success: true });
   });
 
@@ -376,7 +377,7 @@ describe('update api', () => {
         version: 0,
         signatures:
           'PartialTxInputData|0001010204002f91917e63ce0f9d21a6b50adc45539f0ffe1d35b|0:4630440220514e0867c310232eb9ab1c18274a10b5bf163b8cd681',
-      })
+      }),
     ).resolves.toStrictEqual({ success: true });
   });
 });

--- a/__tests__/wallet/api/walletApi.test.ts
+++ b/__tests__/wallet/api/walletApi.test.ts
@@ -1,9 +1,10 @@
 import { AxiosInstance, AxiosResponse } from 'axios';
-import walletApi from '../../../src/wallet/api/walletApi';
-import Network from '../../../src/models/network';
-import HathorWalletServiceWallet from '../../../src/wallet/wallet';
+
 import config from '../../../src/config';
 import { WalletRequestError } from '../../../src/errors';
+import Network from '../../../src/models/network';
+import walletApi from '../../../src/wallet/api/walletApi';
+import HathorWalletServiceWallet from '../../../src/wallet/wallet';
 
 const seed =
   'connect sunny silent cabin leopard start turtle tortoise dial timber woman genre pave tuna rice indicate gown draft palm collect retreat meadow assume spray';
@@ -46,7 +47,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.getAddresses(wallet, 0)).rejects.toThrow(
-      'Error getting wallet addresses.'
+      'Error getting wallet addresses.',
     );
 
     // Should fail if response data success attribute is false
@@ -58,7 +59,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.getAddresses(wallet, 0)).rejects.toThrow(
-      'Error getting wallet addresses.'
+      'Error getting wallet addresses.',
     );
 
     // Should return with data on success
@@ -434,7 +435,7 @@ describe('walletApi', () => {
       'xpubsig',
       'authxpub',
       'authxpubsig',
-      Date.now()
+      Date.now(),
     );
 
     expect(result).toEqual(mockWalletStatus);
@@ -462,7 +463,7 @@ describe('walletApi', () => {
     });
 
     await expect(
-      walletApi.createWallet(wallet, 'xpubkey', 'xpubsig', 'authxpub', 'authxpubsig', Date.now())
+      walletApi.createWallet(wallet, 'xpubkey', 'xpubsig', 'authxpub', 'authxpubsig', Date.now()),
     ).rejects.toThrow();
   });
 
@@ -702,7 +703,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.createReadOnlyAuthToken(wallet, xpubkey)).rejects.toThrow(
-      'Error requesting read-only auth token.'
+      'Error requesting read-only auth token.',
     );
 
     // Should throw on success: false
@@ -712,7 +713,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.createReadOnlyAuthToken(wallet, xpubkey)).rejects.toThrow(
-      'Error requesting read-only auth token.'
+      'Error requesting read-only auth token.',
     );
   });
 
@@ -739,7 +740,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.deleteTxProposal(wallet, txProposalId)).rejects.toThrow(
-      'Error deleting tx proposal.'
+      'Error deleting tx proposal.',
     );
 
     // Should throw on invalid schema
@@ -769,7 +770,7 @@ describe('walletApi', () => {
     const resultTrue = await walletApi.getHasTxOutsideFirstAddress(wallet);
     expect(resultTrue).toEqual(mockResponseTrue);
     expect(mockAxiosInstance.get).toHaveBeenCalledWith(
-      'wallet/addresses/has-transactions-outside-first-address'
+      'wallet/addresses/has-transactions-outside-first-address',
     );
 
     // Test successful response with hasTransactions: false
@@ -793,7 +794,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.getHasTxOutsideFirstAddress(wallet)).rejects.toThrow(
-      'Error checking if wallet has transactions outside first address.'
+      'Error checking if wallet has transactions outside first address.',
     );
 
     // Should throw on success: false
@@ -803,7 +804,7 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.getHasTxOutsideFirstAddress(wallet)).rejects.toThrow(
-      'Error checking if wallet has transactions outside first address.'
+      'Error checking if wallet has transactions outside first address.',
     );
 
     // Should throw on invalid schema (missing hasTransactions)

--- a/__tests__/wallet/api/walletServiceAxios.test.ts
+++ b/__tests__/wallet/api/walletServiceAxios.test.ts
@@ -1,7 +1,7 @@
-import { axiosInstance } from '../../../src/wallet/api/walletServiceAxios';
-import Network from '../../../src/models/network';
-import HathorWalletServiceWallet from '../../../src/wallet/wallet';
 import config from '../../../src/config';
+import Network from '../../../src/models/network';
+import { axiosInstance } from '../../../src/wallet/api/walletServiceAxios';
+import HathorWalletServiceWallet from '../../../src/wallet/wallet';
 
 const seed =
   'connect sunny silent cabin leopard start turtle tortoise dial timber woman genre pave tuna rice indicate gown draft palm collect retreat meadow assume spray';

--- a/__tests__/wallet/connection.test.ts
+++ b/__tests__/wallet/connection.test.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
-import WalletConnection from '../../src/wallet/connection';
+
 import { getDefaultLogger } from '../../src/types';
+import WalletConnection from '../../src/wallet/connection';
 
 // Mock the logger to prevent console output during tests
 jest.mock('../../src/types', () => {

--- a/__tests__/wallet/enableSingleAddressMode.test.ts
+++ b/__tests__/wallet/enableSingleAddressMode.test.ts
@@ -1,7 +1,7 @@
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
+import Network from '../../src/models/network';
 import { SCANNING_POLICY } from '../../src/types';
 import walletApi from '../../src/wallet/api/walletApi';
-import Network from '../../src/models/network';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
 import { defaultWalletSeed } from '../__mock_helpers__/wallet-service.fixtures';
 
 describe('enableSingleAddressMode', () => {
@@ -42,7 +42,7 @@ describe('enableSingleAddressMode', () => {
     });
 
     await expect(wallet.enableSingleAddressMode()).rejects.toThrow(
-      'Cannot enable single-address policy: wallet has transactions on addresses other than the first'
+      'Cannot enable single-address policy: wallet has transactions on addresses other than the first',
     );
   });
 

--- a/__tests__/wallet/mineTransaction.test.ts
+++ b/__tests__/wallet/mineTransaction.test.ts
@@ -1,5 +1,4 @@
 import Network from '../../src/models/network';
-
 import helpers from '../../src/utils/helpers';
 import MineTransaction from '../../src/wallet/mineTransaction';
 

--- a/__tests__/wallet/partialTxProposal.test.ts
+++ b/__tests__/wallet/partialTxProposal.test.ts
@@ -5,29 +5,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import PartialTxProposal from '../../src/wallet/partialTxProposal';
-import { Utxo } from '../../src/wallet/types';
-import Network from '../../src/models/network';
-import P2PKH from '../../src/models/p2pkh';
-import P2SH from '../../src/models/p2sh';
-import Transaction from '../../src/models/transaction';
-import Address from '../../src/models/address';
-import dateFormatter from '../../src/utils/date';
-import {
-  ProposalInput,
-  ProposalOutput,
-  PartialTx,
-  PartialTxInputData,
-} from '../../src/models/partial_tx';
 import {
   NATIVE_TOKEN_UID,
   TOKEN_MINT_MASK,
   TOKEN_MELT_MASK,
   DEFAULT_TX_VERSION,
 } from '../../src/constants';
-
+import Address from '../../src/models/address';
+import Network from '../../src/models/network';
+import P2PKH from '../../src/models/p2pkh';
+import P2SH from '../../src/models/p2sh';
+import {
+  ProposalInput,
+  ProposalOutput,
+  PartialTx,
+  PartialTxInputData,
+} from '../../src/models/partial_tx';
+import Transaction from '../../src/models/transaction';
 import { MemoryStore, Storage } from '../../src/storage';
 import { IUtxo } from '../../src/types';
+import dateFormatter from '../../src/utils/date';
+import PartialTxProposal from '../../src/wallet/partialTxProposal';
+import { Utxo } from '../../src/wallet/types';
 
 // beforeAll(() => {
 //   transaction.updateMaxInputsConstant(MAX_INPUTS);
@@ -67,7 +66,7 @@ test('fromPartialTx', async () => {
     [
       new ProposalOutput(5n, scriptFromAddressP2PKH(ADDR2)),
       new ProposalOutput(10n, scriptFromAddressP2PKH(ADDR3), { token: FAKE_UID }),
-    ]
+    ],
   );
 
   const serialized = partialTx.serialize();
@@ -176,7 +175,7 @@ test('addSend', async () => {
     FAKE_UID,
     6n, // change 10 - 4 = 6
     ADDR3,
-    { isChange: true }
+    { isChange: true },
   );
   expect(spyAddr).not.toHaveBeenCalled();
   expect(spyUtxos).not.toHaveBeenCalled();
@@ -203,7 +202,7 @@ test('addSend', async () => {
     FAKE_UID,
     2n, // change 10 - 8 = 2
     ADDR2,
-    { isChange: true }
+    { isChange: true },
   );
   expect(spyAddr).toHaveBeenCalled();
 
@@ -382,7 +381,7 @@ test('setSignatures', async () => {
   // Ensure it doesn't allow adding signatures for the wrong tx hash
   spyComplete.mockImplementationOnce(() => true);
   expect(() => proposal.setSignatures(serializedSignatures)).toThrow(
-    'Signatures do not match tx hash'
+    'Signatures do not match tx hash',
   );
 
   // Adds the serialized signatures on a complete partialTx for the correct tx
@@ -473,7 +472,7 @@ test('calculateBalance', async () => {
         token: fakeUid2,
         authorities: TOKEN_MELT_MASK,
       }),
-    ]
+    ],
   );
   /**
    * Summary of the test fixture

--- a/__tests__/wallet/readOnlyWallet.test.ts
+++ b/__tests__/wallet/readOnlyWallet.test.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
+import { WalletRequestError } from '../../src/errors';
 import Network from '../../src/models/network';
 import walletApi from '../../src/wallet/api/walletApi';
-import { WalletRequestError } from '../../src/errors';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
 
 // Mock walletApi methods
 jest.mock('../../src/wallet/api/walletApi', () => ({
@@ -67,7 +67,7 @@ describe('Read-Only Wallet Access', () => {
       wallet.xpub = null;
 
       await expect(wallet.getReadOnlyAuthToken()).rejects.toThrow(
-        'xpub is required to get read-only auth token.'
+        'xpub is required to get read-only auth token.',
       );
     });
 
@@ -233,7 +233,7 @@ describe('Read-Only Wallet Access', () => {
 
       await expect(wallet.startReadOnly()).rejects.toThrow(WalletRequestError);
       await expect(wallet.startReadOnly()).rejects.toThrow(
-        'Wallet must be initialized and ready before starting in read-only mode.'
+        'Wallet must be initialized and ready before starting in read-only mode.',
       );
     });
 
@@ -248,7 +248,7 @@ describe('Read-Only Wallet Access', () => {
       wallet.xpub = null;
 
       await expect(wallet.startReadOnly()).rejects.toThrow(
-        'xpub is required to start wallet in read-only mode.'
+        'xpub is required to start wallet in read-only mode.',
       );
     });
 

--- a/__tests__/wallet/sendManyOutputsSendTransaction.test.ts
+++ b/__tests__/wallet/sendManyOutputsSendTransaction.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { NATIVE_TOKEN_UID } from '../../src/constants';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
+import { WalletFromXPubGuard } from '../../src/errors';
+import Network from '../../src/models/network';
+import helpers from '../../src/utils/helpers';
 import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
 import { OutputType } from '../../src/wallet/types';
-import Network from '../../src/models/network';
-import { WalletFromXPubGuard } from '../../src/errors';
-import helpers from '../../src/utils/helpers';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
 
 // Mock the helpers module
 jest.mock('../../src/utils/helpers');
@@ -94,7 +94,7 @@ describe('sendManyOutputsSendTransaction', () => {
     expect(sendTx).toBeInstanceOf(SendTransactionWalletService);
     expect(mockHelpers.getOutputTypeFromAddress).toHaveBeenCalledWith(
       'WP1rVhxzT3YTWg8VbBKkacLqLU2LrouWDx',
-      wallet.network
+      wallet.network,
     );
 
     // Validate transaction outputs
@@ -159,7 +159,7 @@ describe('sendManyOutputsSendTransaction', () => {
     ];
 
     await expect(wallet.sendManyOutputsSendTransaction(outputs)).rejects.toThrow(
-      WalletFromXPubGuard
+      WalletFromXPubGuard,
     );
   });
 
@@ -177,7 +177,7 @@ describe('sendManyOutputsSendTransaction', () => {
     ];
 
     await expect(wallet.sendManyOutputsSendTransaction(outputs)).rejects.toThrow(
-      'Wallet not ready'
+      'Wallet not ready',
     );
   });
 
@@ -193,7 +193,7 @@ describe('sendManyOutputsSendTransaction', () => {
     ];
 
     await expect(wallet.sendManyOutputsSendTransaction(outputs)).rejects.toThrow(
-      'Pin is required.'
+      'Pin is required.',
     );
   });
 

--- a/__tests__/wallet/sendTransactionWalletService.test.ts
+++ b/__tests__/wallet/sendTransactionWalletService.test.ts
@@ -6,16 +6,16 @@
  */
 
 import { NATIVE_TOKEN_UID, FEE_PER_OUTPUT } from '../../src/constants';
+import { SendTxError, WalletError } from '../../src/errors';
+import FeeHeader from '../../src/headers/fee';
+import Address from '../../src/models/address';
+import Network from '../../src/models/network';
+import { TokenVersion } from '../../src/types';
 import SendTransactionWalletService, {
   AddressPathMap,
 } from '../../src/wallet/sendTransactionWalletService';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
 import { OutputType } from '../../src/wallet/types';
-import Network from '../../src/models/network';
-import Address from '../../src/models/address';
-import { TokenVersion } from '../../src/types';
-import FeeHeader from '../../src/headers/fee';
-import { SendTxError, WalletError } from '../../src/errors';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
 
 describe('prepareTxData', () => {
   let wallet;
@@ -143,7 +143,7 @@ describe('prepareTxData', () => {
           token: NATIVE_TOKEN_UID,
           value: 2n,
         }),
-      ])
+      ]),
     );
 
     // Check outputs
@@ -180,7 +180,7 @@ describe('prepareTxData', () => {
           authorities: 0n,
           timelock: null,
         }),
-      ])
+      ]),
     );
   });
 
@@ -271,7 +271,7 @@ describe('prepareTxData', () => {
     sendTransaction = new SendTransactionWalletService(wallet, { inputs, outputs });
 
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'Invalid input selection. Input non-existent-tx at index 0.'
+      'Invalid input selection. Input non-existent-tx at index 0.',
     );
   });
 
@@ -304,7 +304,7 @@ describe('prepareTxData', () => {
     sendTransaction = new SendTransactionWalletService(wallet, { inputs, outputs });
 
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'Invalid input selection. Input wrong-token-tx at index 0 has token 02 that is not on the outputs.'
+      'Invalid input selection. Input wrong-token-tx at index 0 has token 02 that is not on the outputs.',
     );
   });
 
@@ -362,7 +362,7 @@ describe('prepareTxData', () => {
 
     // Check change output
     const changeOutput = txData.outputs.find(
-      o => o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc'
+      o => o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
     );
     expect(changeOutput).toBeDefined();
     expect(changeOutput.value).toBe(5n);
@@ -383,7 +383,7 @@ describe('prepareTxData', () => {
     sendTransaction = new SendTransactionWalletService(wallet, { outputs });
 
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'No utxos available to fill the request. Token: 01 - Amount: 10.'
+      'No utxos available to fill the request. Token: 01 - Amount: 10.',
     );
   });
 
@@ -416,7 +416,7 @@ describe('prepareTxData', () => {
     sendTransaction = new SendTransactionWalletService(wallet, { inputs, outputs });
 
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'Invalid input selection. Sum of inputs for token 01 is smaller than the sum of outputs.'
+      'Invalid input selection. Sum of inputs for token 01 is smaller than the sum of outputs.',
     );
   });
 
@@ -500,7 +500,7 @@ describe('prepareTxData', () => {
         index: 0,
         token: '01',
         value: 10n,
-      })
+      }),
     );
 
     // Verify getUtxoFromId was called only once (during validation, not during final processing)
@@ -550,7 +550,7 @@ describe('prepareTxData', () => {
     sendTransaction = new SendTransactionWalletService(wallet, { outputs });
 
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'Output is missing address or token.'
+      'Output is missing address or token.',
     );
   });
 
@@ -615,7 +615,7 @@ describe('prepareTxData', () => {
 
     // Verify change outputs exist for both tokens
     const changeOutputs = txData.outputs.filter(
-      o => o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc'
+      o => o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
     );
     expect(changeOutputs).toHaveLength(2);
     expect(changeOutputs.find(o => o.token === '01' && o.value === 2n)).toBeDefined();
@@ -733,7 +733,7 @@ describe('prepareTxData', () => {
 
     // Verify all tokens have proper change outputs
     const changeOutputs = txData.outputs.filter(
-      o => o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc'
+      o => o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
     );
     expect(changeOutputs).toHaveLength(3);
   });
@@ -995,7 +995,7 @@ describe('prepareTxData', () => {
     sendTransaction = new SendTransactionWalletService(wallet, { inputs, outputs });
 
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'Invalid input selection. Input wrong-mapping at index 0 has token 02 that is not on the outputs.'
+      'Invalid input selection. Input wrong-mapping at index 0 has token 02 that is not on the outputs.',
     );
   });
 
@@ -1134,7 +1134,7 @@ describe('prepareTxData', () => {
     const promise = sendTransaction.prepareTxData();
     await expect(promise).rejects.toBeInstanceOf(SendTxError);
     await expect(promise).rejects.toThrow(
-      'Invalid input selection. Input unnecessary-htr-tx at index 0 has token 00 that is not on the outputs.'
+      'Invalid input selection. Input unnecessary-htr-tx at index 0 has token 00 that is not on the outputs.',
     );
   });
 
@@ -1191,7 +1191,7 @@ describe('prepareTxData', () => {
     await expect(sendTransaction.prepareTx()).rejects.toThrow(SendTxError);
     sendTransaction = new SendTransactionWalletService(wallet, { inputs, outputs });
     await expect(sendTransaction.prepareTx()).rejects.toThrow(
-      'an HTR input was provided but no HTR is required'
+      'an HTR input was provided but no HTR is required',
     );
   });
 });
@@ -1307,7 +1307,7 @@ describe('selectUtxosToUse', () => {
     };
 
     await expect(sendTransaction.selectUtxosToUse(tokenAmountMap)).rejects.toThrow(
-      'No utxos available to fill the request. Token: 01 - Amount: 100.'
+      'No utxos available to fill the request. Token: 01 - Amount: 100.',
     );
   });
 
@@ -1883,7 +1883,7 @@ describe('prepareTxData - Fee Tokens', () => {
 
     // Verify change outputs exist for fee token
     const feeTokenChange = txData.outputs.find(
-      o => o.token === FEE_TOKEN_UID && o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc'
+      o => o.token === FEE_TOKEN_UID && o.address === 'WPynsVhyU6nP7RSZAkqfijEutC88KgAyFc',
     );
     expect(feeTokenChange).toBeDefined();
     expect(feeTokenChange!.value).toBe(100n);
@@ -1936,7 +1936,7 @@ describe('prepareTxData - Fee Tokens', () => {
 
     // Verify that the error is thrown when no HTR UTXOs are available for fee payment
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      'No utxos available to fill the request. Token: 00'
+      'No utxos available to fill the request. Token: 00',
     );
   });
 
@@ -2059,7 +2059,7 @@ describe('prepareTxData - Fee Tokens', () => {
 
     // Should fail: HTR input (2n) < HTR needed (3n = 1n output + 2n fee)
     await expect(sendTransaction.prepareTxData()).rejects.toThrow(
-      `Invalid input selection. Sum of inputs for token ${NATIVE_TOKEN_UID} is smaller than the sum of outputs.`
+      `Invalid input selection. Sum of inputs for token ${NATIVE_TOKEN_UID} is smaller than the sum of outputs.`,
     );
   });
 
@@ -2291,7 +2291,7 @@ describe('prepareTx - Fee Tokens', () => {
 
     const htrOutputs = transaction.outputs.filter(o => o.tokenData === 0);
     const feeTokenOutputs = transaction.outputs.filter(
-      o => o.tokenData > 0 && transaction.tokens[o.tokenData - 1] === FEE_TOKEN_UID
+      o => o.tokenData > 0 && transaction.tokens[o.tokenData - 1] === FEE_TOKEN_UID,
     );
 
     expect(feeTokenOutputs).toHaveLength(2);
@@ -2437,7 +2437,7 @@ describe('prepareTx - Fee Tokens', () => {
     // Create new instance to test the message (prepareTx mutates internal state)
     sendTransaction = new SendTransactionWalletService(wallet, { outputs });
     await expect(sendTransaction.prepareTx()).rejects.toThrow(
-      `No UTXOs available for the token ${NATIVE_TOKEN_UID}.`
+      `No UTXOs available for the token ${NATIVE_TOKEN_UID}.`,
     );
   });
 
@@ -2518,7 +2518,7 @@ describe('signTx preconditions', () => {
     const sendTransaction = new SendTransactionWalletService(wallet);
     await expect(sendTransaction.signTx('1234')).rejects.toThrow(WalletError);
     await expect(sendTransaction.signTx('1234')).rejects.toThrow(
-      "Can't sign transaction if it's null."
+      "Can't sign transaction if it's null.",
     );
   });
 
@@ -2545,7 +2545,7 @@ describe('signTx preconditions', () => {
     sendTransaction.utxosAddressPath = []; // mismatch: 0 paths vs 1 input
     await expect(sendTransaction.signTx('1234')).rejects.toThrow(SendTxError);
     await expect(sendTransaction.signTx('1234')).rejects.toThrow(
-      'utxosAddressPath length does not match transaction inputs. Call prepareTx() first.'
+      'utxosAddressPath length does not match transaction inputs. Call prepareTx() first.',
     );
   });
 });
@@ -2617,7 +2617,7 @@ describe('validateUtxos', () => {
     const result = await sendTransaction.validateUtxos(
       { '01': { version: TokenVersion.DEPOSIT, amount: 10n } },
       map,
-      { ignoreNative: true }
+      { ignoreNative: true },
     );
 
     // Post-refactor contract: returns void
@@ -2665,7 +2665,7 @@ describe('validateUtxos', () => {
     await sendTransaction.validateUtxos(
       { [NATIVE_TOKEN_UID]: { version: TokenVersion.NATIVE, amount: 5n } },
       map,
-      { onlyNative: true }
+      { onlyNative: true },
     );
 
     expect(map.get(htrInput)).toBe('m/htr');
@@ -2692,7 +2692,7 @@ describe('validateUtxos', () => {
     const map = new AddressPathMap();
     await sendTransaction.validateUtxos(
       { '01': { version: TokenVersion.DEPOSIT, amount: 10n } },
-      map
+      map,
     );
 
     expect(map.get(input)).toBe('m/change');
@@ -2722,7 +2722,7 @@ describe('validateUtxos', () => {
 
     await sendTransaction.validateUtxos(
       { '02': { version: TokenVersion.FEE, amount: 10n } },
-      new AddressPathMap()
+      new AddressPathMap(),
     );
 
     expect(sendTransaction._feeAmount).toBe(FEE_PER_OUTPUT);
@@ -2738,8 +2738,8 @@ describe('validateUtxos', () => {
     await expect(
       sendTransaction.validateUtxos(
         { '01': { version: TokenVersion.DEPOSIT, amount: 10n } },
-        new AddressPathMap()
-      )
+        new AddressPathMap(),
+      ),
     ).rejects.toThrow('Invalid input selection. Input missing at index 0.');
   });
 
@@ -2761,8 +2761,8 @@ describe('validateUtxos', () => {
     await expect(
       sendTransaction.validateUtxos(
         { '01': { version: TokenVersion.DEPOSIT, amount: 10n } },
-        new AddressPathMap()
-      )
+        new AddressPathMap(),
+      ),
     ).rejects.toThrow('has token wrong that is not on the outputs');
   });
 
@@ -2775,8 +2775,8 @@ describe('validateUtxos', () => {
     await expect(
       sendTransaction.validateUtxos(
         { '01': { version: TokenVersion.DEPOSIT, amount: 10n } },
-        new AddressPathMap()
-      )
+        new AddressPathMap(),
+      ),
     ).rejects.toThrow('Token 01 is in the outputs but there are no inputs for it.');
   });
 
@@ -2798,8 +2798,8 @@ describe('validateUtxos', () => {
     await expect(
       sendTransaction.validateUtxos(
         { '01': { version: TokenVersion.DEPOSIT, amount: 10n } },
-        new AddressPathMap()
-      )
+        new AddressPathMap(),
+      ),
     ).rejects.toThrow('Sum of inputs for token 01 is smaller than the sum of outputs');
   });
 });

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -5,23 +5,28 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Must load before any module that imports walletServiceAxios — the helper
+// registers a module-level jest.mock() and Jest only auto-hoists jest.mock
+// calls in the test file itself, not in transitively-imported helpers.
+// eslint-disable-next-line import/order
+import { mockAxiosAdapter } from '../__mock_helpers__/axios-adapter.mock';
+
+// Must load before SendTransactionWalletService to avoid a circular-import
+// race when the jest.mock factory below calls requireActual: the cycle leaves
+// the SendTransactionWalletService default export undefined if loaded first.
+// eslint-disable-next-line import/order
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
+
 import { Message } from 'bitcore-lib';
 import Mnemonic from 'bitcore-mnemonic';
-import { mockAxiosAdapter } from '../__mock_helpers__/axios-adapter.mock';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
-import Network from '../../src/models/network';
-import {
-  GetAddressesObject,
-  WsTransaction,
-  CreateWalletAuthData,
-  AddressInfoObject,
-} from '../../src/wallet/types';
+
 import config from '../../src/config';
 import {
-  buildSuccessTxByIdTokenDataResponse,
-  buildWalletToAuthenticateApiCall,
-  defaultWalletSeed,
-} from '../__mock_helpers__/wallet-service.fixtures';
+  TOKEN_MELT_MASK,
+  TOKEN_MINT_MASK,
+  WALLET_SERVICE_AUTH_DERIVATION_PATH,
+  NATIVE_TOKEN_UID,
+} from '../../src/constants';
 import {
   TxNotFoundError,
   SendTxError,
@@ -29,27 +34,33 @@ import {
   WalletRequestError,
   UtxoError,
 } from '../../src/errors';
-import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
-import transaction from '../../src/utils/transaction';
-import {
-  TOKEN_MELT_MASK,
-  TOKEN_MINT_MASK,
-  WALLET_SERVICE_AUTH_DERIVATION_PATH,
-  NATIVE_TOKEN_UID,
-} from '../../src/constants';
+import Network from '../../src/models/network';
 import { MemoryStore, Storage } from '../../src/storage';
-import walletApi from '../../src/wallet/api/walletApi';
-import walletUtils from '../../src/utils/wallet';
-import { decryptData, verifyMessage } from '../../src/utils/crypto';
 import { AuthorityType, IHistoryTx, IWalletAccessData, TokenVersion } from '../../src/types';
-import { mockGetToken } from '../__mock_helpers__/get-token.mock';
+import { decryptData, verifyMessage } from '../../src/utils/crypto';
 import { Fee } from '../../src/utils/fee';
+import transaction from '../../src/utils/transaction';
+import walletUtils from '../../src/utils/wallet';
+import walletApi from '../../src/wallet/api/walletApi';
+import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
+import {
+  GetAddressesObject,
+  WsTransaction,
+  CreateWalletAuthData,
+  AddressInfoObject,
+} from '../../src/wallet/types';
+import { mockGetToken } from '../__mock_helpers__/get-token.mock';
+import {
+  buildSuccessTxByIdTokenDataResponse,
+  buildWalletToAuthenticateApiCall,
+  defaultWalletSeed,
+} from '../__mock_helpers__/wallet-service.fixtures';
 
 // Mock SendTransactionWalletService class so we don't try to send actual transactions
 // TODO: We should refactor the way we use classes from inside other classes. Using dependency injection would facilitate unit tests a lot and avoid mocks like this.
 jest.mock('../../src/wallet/sendTransactionWalletService', () => {
   const ActualSendTransactionWalletService = jest.requireActual(
-    '../../src/wallet/sendTransactionWalletService'
+    '../../src/wallet/sendTransactionWalletService',
   ).default;
 
   return jest.fn().mockImplementation((...args) => {
@@ -110,7 +121,7 @@ const setupFeeTokenMocks = {
     tokenId: string,
     authorityMask: bigint,
     tokenName = 'Fee Token',
-    tokenSymbol = 'FBT'
+    tokenSymbol = 'FBT',
   ) => {
     mockAxiosAdapter.onPost('wallet/addresses/check_mine').reply(200, {
       success: true,
@@ -173,7 +184,7 @@ const setupFeeTokenMocks = {
     authorityType: AuthorityType,
     addresses: string[],
     tokenName = 'Fee Token',
-    tokenSymbol = 'FBT'
+    tokenSymbol = 'FBT',
   ) => {
     const code = new Mnemonic(seed);
     const xpriv = code.toHDPrivateKey('', network.getNetwork());
@@ -234,7 +245,7 @@ const setupFeeTokenMocks = {
     network: Network,
     tokenId: string,
     authorityType: AuthorityType,
-    addresses: string[]
+    addresses: string[],
   ) => {
     const authorityMask = authorityType === 'mint' ? TOKEN_MINT_MASK : TOKEN_MELT_MASK;
     setupFeeTokenMocks.setupApiMocks(addresses, tokenId, authorityMask);
@@ -268,7 +279,7 @@ test('getAddressAtIndex', async () => {
     Promise.resolve({
       success: true,
       addresses: [address],
-    })
+    }),
   );
 
   const addressAtIndex = await wallet.getAddressAtIndex(0);
@@ -279,7 +290,7 @@ test('getAddressAtIndex', async () => {
     Promise.resolve({
       success: false,
       addresses: [],
-    })
+    }),
   );
 
   await expect(wallet.getAddressAtIndex(0)).rejects.toThrow('Error getting wallet addresses.');
@@ -718,7 +729,7 @@ test('checkAddressesMine', async () => {
   });
 
   await expect(wallet.checkAddressesMine([addr1, addr2, addr3])).rejects.toThrow(
-    'Error checking wallet addresses.'
+    'Error checking wallet addresses.',
   );
 });
 
@@ -769,7 +780,7 @@ test('generateCreateWalletAuthData should return correct auth data', async () =>
 
   const xpubMessage = new Message(String(timestampNow).concat(walletId).concat(xpubAddress));
   const authXpubMessage = new Message(
-    String(timestampNow).concat(walletId).concat(authXpubAddress)
+    String(timestampNow).concat(walletId).concat(authXpubAddress),
   );
 
   expect(authData.xpub).toBe(xpub);
@@ -799,7 +810,7 @@ test('generateCreateWalletAuthData should derive correct auth data from the seed
 
   const authData: CreateWalletAuthData = await wallet.generateCreateWalletAuthData(
     {} as IWalletAccessData,
-    pin
+    pin,
   );
   const timestampNow = Math.floor(Date.now() / 1000); // in seconds
 
@@ -815,7 +826,7 @@ test('generateCreateWalletAuthData should derive correct auth data from the seed
 
   const xpubMessage = new Message(String(timestampNow).concat(walletId).concat(xpubAddress));
   const authXpubMessage = new Message(
-    String(timestampNow).concat(walletId).concat(authXpubAddress)
+    String(timestampNow).concat(walletId).concat(authXpubAddress),
   );
 
   expect(authData.xpub).toBe(xpub);
@@ -997,7 +1008,7 @@ test('prepareMintTokens', async () => {
       createAnotherMint: true,
       mintAuthorityAddress: 'abc',
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // error because of wrong authority output address
@@ -1008,7 +1019,7 @@ test('prepareMintTokens', async () => {
       mintAuthorityAddress: 'abc',
       allowExternalMintAuthorityAddress: true,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // mint data without sign the transaction
@@ -1046,7 +1057,7 @@ test('prepareMintTokens', async () => {
   expect(mintData.outputs).toHaveLength(2);
 
   const authorityOutputs = mintData.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
 
   expect(authorityOutputs).toHaveLength(1);
@@ -1171,7 +1182,7 @@ test('prepareMintTokensData - fee token without enough HTR', async () => {
       createAnotherMint: true,
       mintAuthorityAddress: addresses[2],
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(UtxoError);
 
   _spyGetUtxos.mockRestore();
@@ -1299,7 +1310,7 @@ test('prepareMintTokensData - fee token with change, mint, and melt authority ou
 
   expect(result.outputs).toHaveLength(3);
   const authorityOutputs = result.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
   expect(authorityOutputs).toHaveLength(1);
   expect(authorityOutputs[0].value).toEqual(TOKEN_MINT_MASK);
@@ -1425,7 +1436,7 @@ test('prepareMeltTokens', async () => {
       createAnotherMelt: true,
       meltAuthorityAddress: 'abc',
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // error because of wrong authority output address
@@ -1436,7 +1447,7 @@ test('prepareMeltTokens', async () => {
       meltAuthorityAddress: 'abc',
       allowExternalMeltAuthorityAddress: true,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // melt data without sign the transaction
@@ -1474,7 +1485,7 @@ test('prepareMeltTokens', async () => {
   expect(meltData.outputs).toHaveLength(1);
 
   const authorityOutputs = meltData.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
 
   expect(authorityOutputs).toHaveLength(1);
@@ -1622,7 +1633,7 @@ test('prepareMeltTokensData - fee token without enough HTR', async () => {
       createAnotherMint: true,
       meltAuthorityAddress: addresses[2],
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(UtxoError);
 
   _spyGetUtxos.mockRestore();
@@ -1770,7 +1781,7 @@ test('prepareMeltTokensData - fee token with change and melt authority outputs',
   });
 
   const code = new Mnemonic(
-    'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff'
+    'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff',
   );
   const xpriv = code.toHDPrivateKey('', network.getNetwork());
 
@@ -1821,7 +1832,7 @@ test('prepareMeltTokensData - fee token with change and melt authority outputs',
 
   expect(result.outputs).toHaveLength(3);
   const authorityOutputs = result.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
   expect(authorityOutputs).toHaveLength(1);
   expect(authorityOutputs[0].value).toEqual(TOKEN_MELT_MASK);
@@ -1935,7 +1946,7 @@ test('prepareDelegateAuthorityData', async () => {
       anotherAuthorityAddress: 'invalid-address',
       createAnother: true,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow('Address invalid-address is not valid.');
 
   await expect(
@@ -1943,7 +1954,7 @@ test('prepareDelegateAuthorityData', async () => {
       anotherAuthorityAddress: addresses[2],
       createAnother: false,
       pinCode: null,
-    })
+    }),
   ).rejects.toThrow('PIN not specified in prepareDelegateAuthorityData options');
 
   // Clear mocks
@@ -1974,7 +1985,7 @@ test('prepareDelegateAuthorityData should fail if type is invalid', async () => 
       anotherAuthorityAddress: 'addr2',
       createAnother: true,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow('Type options are mint and melt for delegate authority method.');
 });
 
@@ -1997,7 +2008,7 @@ test('delegateAuthority should throw if wallet is not ready', async () => {
       createAnother: false,
       anotherAuthorityAddress: null,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow('Wallet not ready');
 });
 
@@ -2091,7 +2102,7 @@ test('prepareDestroyAuthority', async () => {
   expect(delegate1.outputs).toHaveLength(0);
   expect(delegate1.inputs).toHaveLength(1);
   expect(delegate1.inputs[0].hash).toStrictEqual(
-    '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f'
+    '002abde4018935e1bbde9600ef79c637adf42385fb1816ec284d702b7bb9ef5f',
   );
 
   // Clear mocks
@@ -2117,7 +2128,7 @@ test('destroyAuthority should throw if wallet is not ready', async () => {
   await expect(
     wallet.destroyAuthority('00', 'mint', 1, {
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow('Wallet not ready');
 });
 
@@ -2178,7 +2189,7 @@ test('getFullTxById', async () => {
 
   mockAxiosAdapter.onGet('wallet/proxy/transactions/tx2').reply(400, {});
   await expect(wallet.getFullTxById('tx2')).rejects.toThrow(
-    'Error getting transaction by its id from the proxied fullnode.'
+    'Error getting transaction by its id from the proxied fullnode.',
   );
 
   mockAxiosAdapter
@@ -2220,7 +2231,7 @@ test('getTxConfirmationData', async () => {
 
   mockAxiosAdapter.onGet('wallet/proxy/transactions/tx1/confirmation_data').reply(400, '');
   await expect(wallet.getTxConfirmationData('tx1')).rejects.toThrow(
-    'Error getting transaction confirmation data by its id from the proxied fullnode.'
+    'Error getting transaction confirmation data by its id from the proxied fullnode.',
   );
 
   mockAxiosAdapter
@@ -2261,7 +2272,7 @@ test('graphvizNeighborsQuery', async () => {
     .reply(500, '');
   // Axios will throw on 500 status code
   await expect(wallet.graphvizNeighborsQuery('tx1', 'test', 1)).rejects.toThrow(
-    'Request failed with status code 500'
+    'Request failed with status code 500',
   );
 
   mockAxiosAdapter
@@ -2419,7 +2430,7 @@ test('createTokens', async () => {
       createMint: true,
       mintAuthorityAddress: 'abc',
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // error because of wrong authority output address
@@ -2429,7 +2440,7 @@ test('createTokens', async () => {
       createMelt: true,
       meltAuthorityAddress: 'abc',
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // error because of invalid external authority output address
@@ -2440,7 +2451,7 @@ test('createTokens', async () => {
       mintAuthorityAddress: 'abc',
       allowExternalMintAuthorityAddress: true,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // error because of invalid external authority output address
@@ -2451,7 +2462,7 @@ test('createTokens', async () => {
       meltAuthorityAddress: 'abc',
       allowExternalMeltAuthorityAddress: true,
       pinCode: '123456',
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // create token without sign the transaction
@@ -2483,7 +2494,7 @@ test('createTokens', async () => {
   expect(tokenData.outputs).toHaveLength(3);
 
   const authorityOutputs = tokenData.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
 
   const mintAuthority = authorityOutputs.filter(o => o.value === TOKEN_MINT_MASK);
@@ -2506,7 +2517,7 @@ test('createTokens', async () => {
   expect(tokenData2.outputs).toHaveLength(2);
 
   const authorityOutputs2 = tokenData2.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
 
   expect(authorityOutputs2).toHaveLength(1);
@@ -2583,7 +2594,7 @@ test('prepareCreateNewToken - fee token with mint authority and change outputs',
     }));
 
   const code = new Mnemonic(
-    'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff'
+    'purse orchard camera cloud piece joke hospital mechanic timber horror shoulder rebuild you decrease garlic derive rebuild random naive elbow depart okay parrot cliff',
   );
   const xpriv = code.toHDPrivateKey('', network.getNetwork());
 
@@ -2607,7 +2618,7 @@ test('prepareCreateNewToken - fee token with mint authority and change outputs',
   expect(result.outputs).toHaveLength(4);
 
   const authorityOutputs = result.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
   expect(authorityOutputs).toHaveLength(2);
 
@@ -2668,7 +2679,7 @@ test('prepareCreateNewToken - fee token without enough HTR for fee', async () =>
       mintAuthorityAddress: addresses[2],
       pinCode: '123456',
       tokenVersion: TokenVersion.FEE,
-    })
+    }),
   ).rejects.toThrow('No utxos available to fill the request. Token: HTR - Amount: 1000.');
 
   _spyGetUtxos.mockRestore();
@@ -2750,7 +2761,7 @@ test('createNFTs', async () => {
       pinCode: '123456',
       data: ['data'],
       isCreateNFT: true,
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // error because of wrong authority output address
@@ -2762,7 +2773,7 @@ test('createNFTs', async () => {
       pinCode: '123456',
       data: ['data'],
       isCreateNFT: true,
-    })
+    }),
   ).rejects.toThrow(SendTxError);
 
   // create token with correct address for authority output
@@ -2780,7 +2791,7 @@ test('createNFTs', async () => {
   expect(tokenData.outputs).toHaveLength(3);
 
   const authorityOutputs = tokenData.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
 
   const authorityOutput = authorityOutputs[0];
@@ -2806,7 +2817,7 @@ test('createNFTs', async () => {
   expect(tokenData2.outputs).toHaveLength(3);
 
   const authorityOutputs2 = tokenData2.outputs.filter(o =>
-    transaction.isAuthorityOutput({ token_data: o.tokenData })
+    transaction.isAuthorityOutput({ token_data: o.tokenData }),
   );
 
   expect(authorityOutputs2).toHaveLength(1);
@@ -2853,7 +2864,7 @@ test('start', async () => {
         createdAt: 0,
         readyAt: 0,
       },
-    })
+    }),
   );
 
   let wallet = new HathorWalletServiceWallet({
@@ -2950,7 +2961,7 @@ test('getAddressPrivKey', async () => {
         createdAt: 0,
         readyAt: 0,
       },
-    })
+    }),
   );
 
   const wallet = new HathorWalletServiceWallet({
@@ -2968,7 +2979,7 @@ test('getAddressPrivKey', async () => {
       await wallet.getAddressPrivKey('1234', 3),
       await wallet.getAddressPrivKey('1234', 4),
       // We need to pass the network because bitcore-lib forces bitcoin network
-    ].map(hdPrivKey => hdPrivKey.privateKey.toAddress(network.getNetwork()).toString())
+    ].map(hdPrivKey => hdPrivKey.privateKey.toAddress(network.getNetwork()).toString()),
   ).toStrictEqual([
     'WgSpcCwYAbtt31S2cqU7hHJkUHdac2EPWG',
     'WPfG7P4YQDJ4MpwTS6qrfGW4fvYvAhPpV7',
@@ -3002,7 +3013,7 @@ test('signMessageWithAddress', async () => {
         createdAt: 0,
         readyAt: 0,
       },
-    })
+    }),
   );
 
   const wallet = new HathorWalletServiceWallet({
@@ -3332,13 +3343,13 @@ describe('getUtxos', () => {
 
   it('should throw error for negative amount', async () => {
     await expect(wallet.getUtxosForAmount(-10n, {})).rejects.toThrow(
-      'Total amount must be a positive integer.'
+      'Total amount must be a positive integer.',
     );
   });
 
   it('should throw error for zero amount', async () => {
     await expect(wallet.getUtxosForAmount(0n, {})).rejects.toThrow(
-      'Total amount must be a positive integer.'
+      'Total amount must be a positive integer.',
     );
   });
 
@@ -3348,7 +3359,7 @@ describe('getUtxos', () => {
     });
 
     await expect(wallet.getUtxosForAmount(100n, {})).rejects.toThrow(
-      "Don't have enough utxos to fill total amount."
+      "Don't have enough utxos to fill total amount.",
     );
   });
 
@@ -3370,7 +3381,7 @@ describe('getUtxos', () => {
     });
 
     await expect(wallet.getUtxosForAmount(100n, {})).rejects.toThrow(
-      "Don't have enough utxos to fill total amount."
+      "Don't have enough utxos to fill total amount.",
     );
   });
 });
@@ -3538,7 +3549,7 @@ describe('HathorWalletServiceWallet start method error conditions', () => {
 
   it('should throw error if pinCode is not provided', async () => {
     await expect(wallet.start({})).rejects.toThrow(
-      'Pin code is required when starting the wallet.'
+      'Pin code is required when starting the wallet.',
     );
   });
 
@@ -3548,7 +3559,7 @@ describe('HathorWalletServiceWallet start method error conditions', () => {
       .mockRejectedValueOnce(new UninitializedWalletError('Wallet not initialized'));
 
     await expect(wallet.start({ pinCode: '123' })).rejects.toThrow(
-      'Password is required when starting the wallet from the seed.'
+      'Password is required when starting the wallet from the seed.',
     );
   });
 
@@ -3566,7 +3577,7 @@ describe('HathorWalletServiceWallet start method error conditions', () => {
     jest.spyOn(walletApi, 'createWallet').mockRejectedValue(new Error('Test error'));
 
     await expect(walletWithoutSeed.start({ pinCode: '123', password: '123' })).rejects.toThrow(
-      'WalletService facade initialized without seed or xprivkey'
+      'WalletService facade initialized without seed or xprivkey',
     );
   });
 
@@ -3588,7 +3599,7 @@ describe('HathorWalletServiceWallet start method error conditions', () => {
     });
 
     await expect(wallet.start({ pinCode: '123', password: '123' })).rejects.toThrow(
-      WalletRequestError
+      WalletRequestError,
     );
   });
 
@@ -4221,7 +4232,7 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
       jest.spyOn(wallet.storage, 'isReadonly').mockResolvedValue(true);
 
       await expect(wallet.getPrivateKeyFromAddress('address')).rejects.toThrow(
-        'getPrivateKeyFromAddress'
+        'getPrivateKeyFromAddress',
       );
     });
 
@@ -4230,7 +4241,7 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
       jest.spyOn(wallet, 'getAddressIndex').mockResolvedValue(null);
 
       await expect(wallet.getPrivateKeyFromAddress('WInvalidAddress')).rejects.toThrow(
-        'Address WInvalidAddress does not belong to this wallet'
+        'Address WInvalidAddress does not belong to this wallet',
       );
     });
 
@@ -4274,7 +4285,7 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
       // Access the private method through bracket notation for testing
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await expect((wallet as any).getAddressIndexIfOwned('WInvalidAddress')).rejects.toThrow(
-        'Address used to sign the transaction (WInvalidAddress) does not belong to the wallet.'
+        'Address used to sign the transaction (WInvalidAddress) does not belong to the wallet.',
       );
     });
 
@@ -4368,7 +4379,7 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
         expect.objectContaining({
           data: ['nft-data'],
           isCreateNFT: true,
-        })
+        }),
       );
       expect(wallet.handleSendPreparedTransaction).toHaveBeenCalledWith(mockPreparedTx);
     });
@@ -4399,7 +4410,7 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
       jest.spyOn(wallet, 'isReady').mockReturnValue(false);
 
       await expect(
-        wallet.createNanoContractTransaction('method', 'WAddress', { args: [] })
+        wallet.createNanoContractTransaction('method', 'WAddress', { args: [] }),
       ).rejects.toThrow('Wallet not ready');
     });
 
@@ -4408,7 +4419,7 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
       jest.spyOn(wallet.storage, 'isReadonly').mockResolvedValue(true);
 
       await expect(
-        wallet.createNanoContractTransaction('method', 'WAddress', { args: [] })
+        wallet.createNanoContractTransaction('method', 'WAddress', { args: [] }),
       ).rejects.toThrow('createNanoContractTransaction');
     });
   });
@@ -4448,11 +4459,13 @@ describe('HathorWalletServiceWallet private key and nano methods', () => {
       jest
         .spyOn(walletApi, 'getHasTxOutsideFirstAddress')
         .mockRejectedValue(
-          new WalletRequestError('Error checking if wallet has transactions outside first address.')
+          new WalletRequestError(
+            'Error checking if wallet has transactions outside first address.',
+          ),
         );
 
       await expect(wallet.hasTxOutsideFirstAddress()).rejects.toThrow(
-        'Error checking if wallet has transactions outside first address.'
+        'Error checking if wallet has transactions outside first address.',
       );
     });
   });

--- a/__tests__/wallet/walletServiceStorageProxy.test.ts
+++ b/__tests__/wallet/walletServiceStorageProxy.test.ts
@@ -6,14 +6,14 @@
  */
 
 // Mock the transaction utils before importing
-import { WalletServiceStorageProxy } from '../../src/wallet/walletServiceStorageProxy';
-import HathorWalletServiceWallet from '../../src/wallet/wallet';
-import Network from '../../src/models/network';
-import { IStorage } from '../../src/types';
-import Transaction from '../../src/models/transaction';
 import Input from '../../src/models/input';
+import Network from '../../src/models/network';
+import Transaction from '../../src/models/transaction';
+import { IStorage } from '../../src/types';
 import transactionUtils from '../../src/utils/transaction';
 import { AddressInfoObject } from '../../src/wallet/types';
+import HathorWalletServiceWallet from '../../src/wallet/wallet';
+import { WalletServiceStorageProxy } from '../../src/wallet/walletServiceStorageProxy';
 
 jest.mock('../../src/utils/transaction', () => ({
   getSignatureForTx: jest.fn(),
@@ -183,7 +183,7 @@ describe('WalletServiceStorageProxy', () => {
       (wallet.getAddressDetails as jest.Mock).mockRejectedValue(new Error('Address not found'));
 
       await expect(proxiedStorage.getAddressInfo('invalid-address')).rejects.toThrow(
-        'Address not found'
+        'Address not found',
       );
     });
   });
@@ -539,11 +539,11 @@ describe('WalletServiceStorageProxy', () => {
 
     it('should handle errors from getCurrentAddress', async () => {
       (wallet.getCurrentAddress as jest.Mock).mockRejectedValue(
-        new Error('Address loading failed')
+        new Error('Address loading failed'),
       );
 
       await expect(proxiedStorage.getCurrentAddress()).rejects.toThrow(
-        'Current address is not loaded'
+        'Current address is not loaded',
       );
     });
   });
@@ -561,7 +561,7 @@ describe('WalletServiceStorageProxy', () => {
       expect(transactionUtils.getSignatureForTx).toHaveBeenCalledWith(
         mockTransaction,
         proxiedStorage,
-        'pin123'
+        'pin123',
       );
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,11 @@
         "eslint-plugin-import": "2.29.1",
         "eslint-plugin-jest": "28.6.0",
         "eslint-plugin-prettier": "5.1.3",
+        "husky": "9.1.7",
         "jest": "29.7.0",
         "jest-html-reporter": "3.10.2",
         "jest-localstorage-mock": "2.4.26",
+        "lint-staged": "16.4.0",
         "mock-socket": "9.3.1",
         "patch-package": "8.0.0",
         "prettier": "3.3.2",
@@ -4551,6 +4553,85 @@
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
       "dev": true
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -4670,6 +4751,13 @@
       "engines": {
         "node": ">=12.20"
       }
+    },
+    "node_modules/colorette": {
+      "version": "2.0.20",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5134,6 +5222,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -5943,6 +6044,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6290,6 +6398,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6629,6 +6750,22 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ieee754": {
@@ -9250,6 +9387,156 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/lint-staged": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+      "integrity": "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^14.0.3",
+        "listr2": "^9.0.5",
+        "picomatch": "^4.0.3",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.0.4",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=20.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      }
+    },
+    "node_modules/lint-staged/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.0.0",
+        "colorette": "^2.0.20",
+        "eventemitter3": "^5.0.1",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
@@ -9281,6 +9568,160 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/logform": {
       "version": "2.7.0",
@@ -9397,6 +9838,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimalistic-assert": {
@@ -10367,6 +10821,52 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -10376,6 +10876,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -10585,6 +11092,52 @@
         "node": ">=6"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10650,6 +11203,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-length": {
@@ -10851,6 +11414,16 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -11453,9 +12026,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11463,6 +12036,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "zod": "3.23.8"
   },
   "scripts": {
+    "prepare": "husky",
     "pretest": "patch-package",
     "test": "jest --env=node --forceExit",
     "test:watch": "jest --watch --env=node",
@@ -66,9 +67,11 @@
     "eslint-plugin-import": "2.29.1",
     "eslint-plugin-jest": "28.6.0",
     "eslint-plugin-prettier": "5.1.3",
+    "husky": "9.1.7",
     "jest": "29.7.0",
     "jest-html-reporter": "3.10.2",
     "jest-localstorage-mock": "2.4.26",
+    "lint-staged": "16.4.0",
     "mock-socket": "9.3.1",
     "patch-package": "8.0.0",
     "prettier": "3.3.2",
@@ -87,5 +90,11 @@
   "bugs": {
     "url": "https://github.com/HathorNetwork/hathor-wallet-lib/issues"
   },
-  "homepage": "https://github.com/HathorNetwork/hathor-wallet-lib#readme"
+  "homepage": "https://github.com/HathorNetwork/hathor-wallet-lib#readme",
+  "lint-staged": {
+    "{src,__tests__}/**/*.{js,ts}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  }
 }

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -6,6 +6,7 @@
  */
 
 import config from '../config';
+
 import axiosWrapperCreateRequestInstance from './axiosWrapper';
 
 /**

--- a/src/api/axiosWrapper.ts
+++ b/src/api/axiosWrapper.ts
@@ -6,8 +6,9 @@
  */
 
 import axios from 'axios';
-import { TIMEOUT } from '../constants';
+
 import config from '../config';
+import { TIMEOUT } from '../constants';
 
 /**
  * Method that creates an axios instance
@@ -27,7 +28,7 @@ export const axiosWrapperCreateRequestInstance = (
   url: string,
   _resolve?: undefined | null, // XXX: We should remove or use this parameter
   timeout?: number | null,
-  additionalHeaders = {}
+  additionalHeaders = {},
 ) => {
   let timeoutRef;
   const additionalHeadersObj = { ...additionalHeaders };

--- a/src/api/explorerServiceAxios.ts
+++ b/src/api/explorerServiceAxios.ts
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import axiosWrapperCreateRequestInstance from './axiosWrapper';
-import { TIMEOUT } from '../constants';
 import config from '../config';
+import { TIMEOUT } from '../constants';
+
+import axiosWrapperCreateRequestInstance from './axiosWrapper';
 
 /**
  * Method that creates an axios instance

--- a/src/api/featuresApi.ts
+++ b/src/api/featuresApi.ts
@@ -6,8 +6,10 @@
  */
 
 import { z } from 'zod';
-import { createRequestInstance } from './axiosInstance';
+
 import { transformJsonBigIntResponse } from '../utils/bigint';
+
+import { createRequestInstance } from './axiosInstance';
 
 export const featureActivationSchema = z
   .object({
@@ -70,7 +72,7 @@ const featuresApi = {
           },
           res => {
             reject(res);
-          }
+          },
         );
     });
   },
@@ -93,7 +95,7 @@ const featuresApi = {
           },
           res => {
             reject(res);
-          }
+          },
         );
     });
   },

--- a/src/api/health.js
+++ b/src/api/health.js
@@ -31,7 +31,7 @@ const healthApi = {
           },
           err => {
             reject(err);
-          }
+          },
         );
     });
   },

--- a/src/api/metadataApi.ts
+++ b/src/api/metadataApi.ts
@@ -6,10 +6,12 @@
  */
 
 import { AxiosError } from 'axios';
-import explorerServiceAxios from './explorerServiceAxios';
-import helpers from '../utils/helpers';
+
 import { METADATA_RETRY_LIMIT, DOWNLOAD_METADATA_RETRY_INTERVAL } from '../constants';
 import { GetDagMetadataApiError } from '../errors';
+import helpers from '../utils/helpers';
+
+import explorerServiceAxios from './explorerServiceAxios';
 
 type MetadataApiResponse = {
   id: string;
@@ -32,7 +34,7 @@ const metadataApi = {
   async getDagMetadata(
     id: string,
     network: string,
-    options: { retries?: number; retryInterval?: number } = {}
+    options: { retries?: number; retryInterval?: number } = {},
   ) {
     type optionsType = {
       retries: number;

--- a/src/api/nano.ts
+++ b/src/api/nano.ts
@@ -6,7 +6,7 @@
  */
 
 import axios, { AxiosError } from 'axios';
-import { createRequestInstance } from './axiosInstance';
+
 import { NanoRequest404Error, NanoRequestError } from '../errors';
 import {
   NanoContractBlueprintInformationAPIResponse,
@@ -18,6 +18,8 @@ import {
   NanoContractStateAPIParameters,
   NanoContractLogsAPIResponse,
 } from '../nano_contracts/types';
+
+import { createRequestInstance } from './axiosInstance';
 
 /**
  * Api calls for nano contracts
@@ -45,7 +47,7 @@ const ncApi = {
     balances: string[],
     calls: string[],
     block_hash: string | null = null,
-    block_height: number | null = null
+    block_height: number | null = null,
   ): Promise<NanoContractStateAPIResponse> {
     const data: NanoContractStateAPIParameters = { id, fields, balances, calls };
 
@@ -93,7 +95,7 @@ const ncApi = {
     id: string,
     count: number | null = null,
     after: string | null = null,
-    before: string | null = null
+    before: string | null = null,
   ): Promise<NanoContractHistoryAPIResponse> {
     const data = { id, count, after, before };
     const axiosInstance = await createRequestInstance();
@@ -159,7 +161,7 @@ const ncApi = {
    * @inner
    */
   async getBlueprintSourceCode(
-    blueprintId: string
+    blueprintId: string,
   ): Promise<NanoContractBlueprintSourceCodeAPIResponse> {
     const data = { blueprint_id: blueprintId };
     const axiosInstance = await createRequestInstance();
@@ -199,7 +201,7 @@ const ncApi = {
     count: number | null = null,
     after: string | null = null,
     before: string | null = null,
-    search: string | null = null
+    search: string | null = null,
   ): Promise<NanoContractBlueprintListAPIResponse> {
     const data = { count, after, before, search };
     const axiosInstance = await createRequestInstance();
@@ -234,7 +236,7 @@ const ncApi = {
     after: string | null = null,
     before: string | null = null,
     search: string | null = null,
-    order: string | null = null
+    order: string | null = null,
   ): Promise<NanoContractBlueprintListAPIResponse> {
     const data = { count, after, before, search, order };
     const axiosInstance = await createRequestInstance();
@@ -271,7 +273,7 @@ const ncApi = {
     after: string | null = null,
     before: string | null = null,
     search: string | null = null,
-    order: string | null = null
+    order: string | null = null,
   ): Promise<NanoContractCreationListAPIResponse> {
     const data = { count, after, before, search, order };
     const axiosInstance = await createRequestInstance();

--- a/src/api/schemas/txApi.ts
+++ b/src/api/schemas/txApi.ts
@@ -6,8 +6,9 @@
  */
 
 import { z } from 'zod';
-import { bigIntCoercibleSchema } from '../../utils/bigint';
+
 import { IHistoryNanoContractContextSchema } from '../../schemas';
+import { bigIntCoercibleSchema } from '../../utils/bigint';
 
 const p2pkhDecodedScriptSchema = z.object({
   type: z.literal('P2PKH'),

--- a/src/api/schemas/wallet.ts
+++ b/src/api/schemas/wallet.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+
 import { IHistoryTxSchema } from '../../schemas';
 import { bigIntCoercibleSchema } from '../../utils/bigint';
 

--- a/src/api/txApi.ts
+++ b/src/api/txApi.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createRequestInstance } from './axiosInstance';
 import { transformJsonBigIntResponse } from '../utils/bigint';
+
+import { createRequestInstance } from './axiosInstance';
 import {
   FullNodeTxApiResponse,
   GraphvizNeighboursResponse,
@@ -43,7 +44,7 @@ const txApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -104,7 +105,7 @@ const txApi = {
         },
         res => {
           Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -128,7 +129,7 @@ const txApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -152,7 +153,7 @@ const txApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -177,7 +178,7 @@ const txApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -201,7 +202,7 @@ const txApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -221,7 +222,7 @@ const txApi = {
     tx: string,
     graphType: string,
     maxLevel: number,
-    resolve: (response: GraphvizNeighboursResponse) => void
+    resolve: (response: GraphvizNeighboursResponse) => void,
   ): Promise<void> {
     // TODO: This method uses a callback pattern but also returns a Promise, which is an anti-pattern
     // NOTE: createRequestInstance has legacy typing (resolve?: null) that doesn't match actual usage.
@@ -234,7 +235,7 @@ const txApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 

--- a/src/api/txMining.js
+++ b/src/api/txMining.js
@@ -39,7 +39,7 @@ const txMiningApi = {
         },
         error => {
           return Promise.reject(error);
-        }
+        },
       );
   },
 
@@ -62,7 +62,7 @@ const txMiningApi = {
         },
         error => {
           return Promise.reject(error);
-        }
+        },
       );
   },
 
@@ -85,7 +85,7 @@ const txMiningApi = {
         },
         error => {
           return Promise.reject(error);
-        }
+        },
       );
   },
 
@@ -106,7 +106,7 @@ const txMiningApi = {
           },
           err => {
             reject(err);
-          }
+          },
         );
     });
   },

--- a/src/api/txMiningAxios.ts
+++ b/src/api/txMiningAxios.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import axiosWrapperCreateRequestInstance from './axiosWrapper';
 import config from '../config';
+
+import axiosWrapperCreateRequestInstance from './axiosWrapper';
 
 /**
  * Create axios instance settings base URL and content type

--- a/src/api/version.ts
+++ b/src/api/version.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { createRequestInstance } from './axiosInstance';
 import { ApiVersion } from '../types';
+
+import { createRequestInstance } from './axiosInstance';
 
 /**
  * Api calls for version
@@ -36,7 +37,7 @@ const versionApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -59,7 +60,7 @@ const versionApi = {
           },
           err => {
             reject(err);
-          }
+          },
         );
     });
   },

--- a/src/api/wallet.ts
+++ b/src/api/wallet.ts
@@ -6,9 +6,11 @@
  */
 
 import { AxiosResponse } from 'axios';
-import { createRequestInstance } from './axiosInstance';
+
 import { SEND_TOKENS_TIMEOUT } from '../constants';
 import { transformJsonBigIntResponse } from '../utils/bigint';
+
+import { createRequestInstance } from './axiosInstance';
 import {
   AddressHistorySchema,
   addressHistorySchema,
@@ -51,7 +53,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -130,7 +132,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -157,7 +159,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -193,7 +195,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -215,7 +217,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -237,7 +239,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -260,7 +262,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 
@@ -298,7 +300,7 @@ const walletApi = {
         },
         res => {
           return Promise.reject(res);
-        }
+        },
       );
   },
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import networkInstance from './network';
-import Network from './models/network';
 import { GetWalletServiceUrlError, GetWalletServiceWsUrlError } from './errors';
+import Network from './models/network';
+import networkInstance from './network';
 
 // Default server and network user will connect when none have been chosen
 export const DEFAULT_SERVER = 'https://node1.mainnet.hathor.network/v1a/';
@@ -66,7 +66,7 @@ export class Config {
       return TX_MINING_TESTNET_URL;
     }
     throw new Error(
-      `Network ${networkInstance.name} doesn't have a correspondent tx mining service url. You should set it explicitly.`
+      `Network ${networkInstance.name} doesn't have a correspondent tx mining service url. You should set it explicitly.`,
     );
   }
 
@@ -131,7 +131,7 @@ export class Config {
 
     if (!network) {
       throw new Error(
-        'You should either provide a network or call setSwapServiceBaseUrl before calling this.'
+        'You should either provide a network or call setSwapServiceBaseUrl before calling this.',
       );
     }
 
@@ -143,7 +143,7 @@ export class Config {
       return SWAP_SERVICE_TESTNET_BASE_URL;
     }
     throw new Error(
-      `Network ${network} doesn't have a correspondent Atomic Swap Service url. You should set it explicitly by calling setSwapServiceBaseUrl.`
+      `Network ${network} doesn't have a correspondent Atomic Swap Service url. You should set it explicitly by calling setSwapServiceBaseUrl.`,
     );
   }
 
@@ -206,7 +206,7 @@ export class Config {
 
     if (!network) {
       throw new Error(
-        'You should either provide a network or call setExplorerServiceBaseUrl before calling this.'
+        'You should either provide a network or call setExplorerServiceBaseUrl before calling this.',
       );
     }
 
@@ -218,7 +218,7 @@ export class Config {
       return EXPLORER_SERVICE_TESTNET_BASE_URL;
     }
     throw new Error(
-      `Network ${network} doesn't have a correspondent explorer service url. You should set it explicitly.`
+      `Network ${network} doesn't have a correspondent explorer service url. You should set it explicitly.`,
     );
   }
 

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6,12 +6,13 @@
  */
 
 import { EventEmitter } from 'events';
-import networkInstance from './network';
+
 import config from './config';
-import GenericWebSocket from './websocket';
-import WalletServiceWebSocket from './wallet/websocket';
-import { ConnectionState } from './wallet/types';
+import networkInstance from './network';
 import { ILogger, getDefaultLogger } from './types';
+import { ConnectionState } from './wallet/types';
+import WalletServiceWebSocket from './wallet/websocket';
+import GenericWebSocket from './websocket';
 
 export const DEFAULT_PARAMS = {
   network: 'mainnet',

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,6 +7,7 @@
 
 // eslint-disable-next-line max-classes-per-file -- This file is supposed to export classes
 import { AxiosResponse } from 'axios';
+
 import { ErrorMessages } from './errorMessages';
 
 /**
@@ -341,7 +342,7 @@ export class NanoRequestError extends RequestError {
   constructor(
     message: string,
     originError: unknown | null = null,
-    response: AxiosResponse | null = null
+    response: AxiosResponse | null = null,
   ) {
     super(message);
     this.originError = originError;

--- a/src/headers/fee.ts
+++ b/src/headers/fee.ts
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { getVertexHeaderIdBuffer, getVertexHeaderIdFromBuffer, VertexHeaderId } from './types';
-import Header from './base';
+import { MAX_FEE_HEADER_ENTRIES } from '../constants';
 import Network from '../models/network';
 import { IFeeEntry, OutputValueType } from '../types';
 import { bytesToOutputValue, intToBytes, outputValueToBytes, unpackToInt } from '../utils/buffer';
-import { MAX_FEE_HEADER_ENTRIES } from '../constants';
+
+import Header from './base';
+import { getVertexHeaderIdBuffer, getVertexHeaderIdFromBuffer, VertexHeaderId } from './types';
 
 /**
  * FeeHeader represents the fee payment information in a transaction.
@@ -206,7 +207,7 @@ class FeeHeader extends Header {
     // Check maximum number of entries
     if (this.entries.length > MAX_FEE_HEADER_ENTRIES) {
       throw new Error(
-        `Fee header can have at most ${MAX_FEE_HEADER_ENTRIES} entries, got ${this.entries.length}`
+        `Fee header can have at most ${MAX_FEE_HEADER_ENTRIES} entries, got ${this.entries.length}`,
       );
     }
 

--- a/src/headers/parser.ts
+++ b/src/headers/parser.ts
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { VertexHeaderId } from './types';
-import { HeaderStaticType } from './base';
 import NanoContractHeader from '../nano_contracts/header';
+
+import { HeaderStaticType } from './base';
 import FeeHeader from './fee';
+import { VertexHeaderId } from './types';
 
 export default class HeaderParser {
   static getSupportedHeaders(): Record<VertexHeaderId, HeaderStaticType> {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,129 +1,128 @@
-import * as constants from './constants';
-import dateFormatter from './utils/date';
-import websocket from './websocket';
-import * as errors from './errors';
-import * as ErrorMessages from './errorMessages';
-import walletApi from './api/wallet';
+import * as axios from './api/axiosInstance';
+import featuresApi from './api/featuresApi';
+import healthApi from './api/health';
+import metadataApi from './api/metadataApi';
+import ncApi from './api/nano';
 import txApi from './api/txApi';
 import txMiningApi from './api/txMining';
-import healthApi from './api/health';
 import versionApi from './api/version';
-import * as axios from './api/axiosInstance';
-import metadataApi from './api/metadataApi';
-import featuresApi from './api/featuresApi';
-import { Storage } from './storage/storage';
-import { MemoryStore } from './storage/memory_store';
-import network from './network';
-import HathorWallet from './new/wallet';
-import Connection from './new/connection';
-import WalletServiceConnection from './wallet/connection';
-import SendTransaction from './new/sendTransaction';
+import walletApi from './api/wallet';
+import config from './config';
+import * as constants from './constants';
+import * as ErrorMessages from './errorMessages';
+import * as errors from './errors';
+import FeeHeader from './headers/fee';
 import Address from './models/address';
+import CreateTokenTransaction from './models/create_token_transaction';
+import * as enums from './models/enum';
+import Input from './models/input';
+import Network from './models/network';
 import Output from './models/output';
 import P2PKH from './models/p2pkh';
 import P2SH from './models/p2sh';
 import P2SHSignature from './models/p2sh_signature';
-import ScriptData from './models/script_data';
-import Input from './models/input';
-import Transaction from './models/transaction';
-import CreateTokenTransaction from './models/create_token_transaction';
-import Network from './models/network';
-import FeeHeader from './headers/fee';
-import * as addressUtils from './utils/address';
-import * as cryptoUtils from './utils/crypto';
-import tokensUtils from './utils/tokens';
-import walletUtils from './utils/wallet';
-import helpersUtils from './utils/helpers';
-import * as numberUtils from './utils/numbers';
-import * as scriptsUtils from './utils/scripts';
-import transactionUtils from './utils/transaction';
-import * as bufferUtils from './utils/buffer';
-import HathorWalletServiceWallet from './wallet/wallet';
-import walletServiceApi from './wallet/api/walletApi';
-import SendTransactionWalletService from './wallet/sendTransactionWalletService';
-import { WalletServiceStorageProxy } from './wallet/walletServiceStorageProxy';
-import config from './config';
-import * as PushNotification from './pushNotification';
 import { PartialTx, PartialTxInputData } from './models/partial_tx';
-import PartialTxProposal from './wallet/partialTxProposal';
-import * as swapService from './wallet/api/swapService';
-import { AtomicSwapServiceConnection } from './swapService/swapConnection';
-import ncApi from './api/nano';
-import * as nanoUtils from './nano_contracts/utils';
+import ScriptData from './models/script_data';
+import Transaction from './models/transaction';
 import NanoContractTransactionParser from './nano_contracts/parser';
-import * as bigIntUtils from './utils/bigint';
+import * as nanoUtils from './nano_contracts/utils';
+import network from './network';
+import Connection from './new/connection';
+import SendTransaction from './new/sendTransaction';
+import HathorWallet from './new/wallet';
+import * as PushNotification from './pushNotification';
+import { MemoryStore } from './storage/memory_store';
+import { Storage } from './storage/storage';
+import { AtomicSwapServiceConnection } from './swapService/swapConnection';
+import { stopGLLBackgroundTask } from './sync/gll';
 import {
   TransactionTemplate,
   TransactionTemplateBuilder,
   WalletTxTemplateInterpreter,
 } from './template/transaction';
-import { stopGLLBackgroundTask } from './sync/gll';
-import * as enums from './models/enum';
+import * as addressUtils from './utils/address';
+import * as bigIntUtils from './utils/bigint';
+import * as bufferUtils from './utils/buffer';
+import * as cryptoUtils from './utils/crypto';
+import dateFormatter from './utils/date';
 import { Fee } from './utils/fee';
+import helpersUtils from './utils/helpers';
+import * as numberUtils from './utils/numbers';
+import * as scriptsUtils from './utils/scripts';
+import tokensUtils from './utils/tokens';
+import transactionUtils from './utils/transaction';
+import walletUtils from './utils/wallet';
+import * as swapService from './wallet/api/swapService';
+import walletServiceApi from './wallet/api/walletApi';
+import WalletServiceConnection from './wallet/connection';
+import PartialTxProposal from './wallet/partialTxProposal';
+import SendTransactionWalletService from './wallet/sendTransactionWalletService';
+import HathorWalletServiceWallet from './wallet/wallet';
+import { WalletServiceStorageProxy } from './wallet/walletServiceStorageProxy';
+import websocket from './websocket';
 
 export {
-  PartialTx,
-  PartialTxInputData,
-  PartialTxProposal,
-  dateFormatter,
-  websocket,
-  walletApi,
-  txApi,
-  txMiningApi,
-  healthApi,
-  versionApi,
-  metadataApi,
-  featuresApi,
-  errors,
-  ErrorMessages,
-  constants,
-  axios,
-  Storage,
-  MemoryStore,
-  network,
-  HathorWallet,
-  Connection,
-  AtomicSwapServiceConnection,
-  WalletServiceConnection,
-  SendTransaction,
   Address,
+  addressUtils,
+  AtomicSwapServiceConnection,
+  axios,
+  bigIntUtils,
+  bufferUtils,
+  config,
+  Connection,
+  constants,
+  CreateTokenTransaction,
+  cryptoUtils,
+  dateFormatter,
+  dateFormatter as dateUtils,
+  enums,
+  ErrorMessages,
+  errors,
+  featuresApi,
+  Fee,
+  FeeHeader,
+  HathorWallet,
+  HathorWalletServiceWallet,
+  healthApi,
+  helpersUtils,
+  Input,
+  MemoryStore,
+  metadataApi,
+  NanoContractTransactionParser,
+  nanoUtils,
+  ncApi,
+  network,
+  Network,
+  numberUtils,
   Output,
   P2PKH,
   P2SH,
   P2SHSignature,
-  ScriptData,
-  Input,
-  Transaction,
-  CreateTokenTransaction,
-  Network,
-  FeeHeader,
-  Fee,
-  addressUtils,
-  cryptoUtils,
-  dateFormatter as dateUtils,
-  tokensUtils,
-  walletUtils,
-  numberUtils,
-  helpersUtils,
-  scriptsUtils,
-  bufferUtils,
-  transactionUtils,
-  HathorWalletServiceWallet,
-  walletServiceApi,
-  SendTransactionWalletService,
-  WalletServiceStorageProxy,
-  config,
+  PartialTx,
+  PartialTxInputData,
+  PartialTxProposal,
   PushNotification,
+  ScriptData,
+  scriptsUtils,
+  SendTransaction,
+  SendTransactionWalletService,
+  stopGLLBackgroundTask,
+  Storage,
   swapService,
-  ncApi,
-  nanoUtils,
-  NanoContractTransactionParser,
-  bigIntUtils,
+  tokensUtils,
+  Transaction,
   TransactionTemplate,
   TransactionTemplateBuilder,
+  txApi,
+  txMiningApi,
+  versionApi,
+  walletApi,
+  walletServiceApi,
+  WalletServiceConnection,
+  WalletServiceStorageProxy,
   WalletTxTemplateInterpreter,
-  stopGLLBackgroundTask,
-  enums,
+  walletUtils,
+  websocket,
 };
 
 // Re-export all types from every module.

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -7,11 +7,13 @@
 
 import { encoding, util } from 'bitcore-lib';
 import _ from 'lodash';
+
 import { AddressError } from '../errors';
+import helpers from '../utils/helpers';
+
 import Network from './network';
 import P2PKH from './p2pkh';
 import P2SH from './p2sh';
-import helpers from '../utils/helpers';
 
 class Address {
   // String with address as base58
@@ -84,7 +86,7 @@ class Address {
     // Validate address length
     if (addressBytes.length !== 25) {
       throw new AddressError(
-        `${errorMessage} Address has ${addressBytes.length} bytes and should have 25.`
+        `${errorMessage} Address has ${addressBytes.length} bytes and should have 25.`,
       );
     }
 
@@ -94,7 +96,7 @@ class Address {
     const correctChecksum = helpers.getChecksum(addressSlice);
     if (!util.buffer.equals(checksum, correctChecksum)) {
       throw new AddressError(
-        `${errorMessage} Invalid checksum. Expected: ${correctChecksum} != Received: ${checksum}.`
+        `${errorMessage} Invalid checksum. Expected: ${correctChecksum} != Received: ${checksum}.`,
       );
     }
 
@@ -106,7 +108,7 @@ class Address {
     const firstByte = addressBytes[0];
     if (!this.network.isVersionByteValid(firstByte)) {
       throw new AddressError(
-        `${errorMessage} Invalid network byte. Expected: ${this.network.versionBytes.p2pkh} or ${this.network.versionBytes.p2sh} and received ${firstByte}.`
+        `${errorMessage} Invalid network byte. Expected: ${this.network.versionBytes.p2pkh} or ${this.network.versionBytes.p2sh} and received ${firstByte}.`,
       );
     }
     return true;

--- a/src/models/create_token_transaction.ts
+++ b/src/models/create_token_transaction.ts
@@ -6,23 +6,26 @@
  */
 
 import buffer from 'buffer';
+
 import { clone } from 'lodash';
+
 import {
   CREATE_TOKEN_TX_VERSION,
   MAX_TOKEN_NAME_SIZE,
   MAX_TOKEN_SYMBOL_SIZE,
   DEFAULT_SIGNAL_BITS,
 } from '../constants';
-import { unpackToInt, unpackLen, intToBytes } from '../utils/buffer';
-import Input from './input';
-import Output from './output';
-import Transaction from './transaction';
-import Network from './network';
 import { CreateTokenTxInvalid, InvalidOutputsError, NftValidationError } from '../errors';
-import ScriptData from './script_data';
-import { OutputType } from '../wallet/types';
-import { TokenVersion } from '../types';
 import type Header from '../headers/base';
+import { TokenVersion } from '../types';
+import { unpackToInt, unpackLen, intToBytes } from '../utils/buffer';
+import { OutputType } from '../wallet/types';
+
+import Input from './input';
+import Network from './network';
+import Output from './output';
+import ScriptData from './script_data';
+import Transaction from './transaction';
 
 type optionsType = {
   signalBits?: number;
@@ -48,7 +51,7 @@ class CreateTokenTransaction extends Transaction {
     symbol: string,
     inputs: Input[],
     outputs: Output[],
-    options: optionsType = {}
+    options: optionsType = {},
   ) {
     const defaultOptions: optionsType = {
       signalBits: DEFAULT_SIGNAL_BITS,
@@ -109,19 +112,19 @@ class CreateTokenTransaction extends Transaction {
 
     if (!this.name || !this.symbol) {
       throw new CreateTokenTxInvalid(
-        'Token name and symbol are required when creating a new token'
+        'Token name and symbol are required when creating a new token',
       );
     }
 
     if (this.name.length > MAX_TOKEN_NAME_SIZE) {
       throw new CreateTokenTxInvalid(
-        `Token name size is ${this.name.length} but maximum size is ${MAX_TOKEN_NAME_SIZE}`
+        `Token name size is ${this.name.length} but maximum size is ${MAX_TOKEN_NAME_SIZE}`,
       );
     }
 
     if (this.symbol.length > MAX_TOKEN_SYMBOL_SIZE) {
       throw new CreateTokenTxInvalid(
-        `Token symbol size is ${this.symbol.length} but maximum size is ${MAX_TOKEN_SYMBOL_SIZE}`
+        `Token symbol size is ${this.symbol.length} but maximum size is ${MAX_TOKEN_SYMBOL_SIZE}`,
       );
     }
 
@@ -162,7 +165,7 @@ class CreateTokenTransaction extends Transaction {
 
     if (lenName > MAX_TOKEN_NAME_SIZE) {
       throw new CreateTokenTxInvalid(
-        `Token name size is ${lenName} but maximum size is ${MAX_TOKEN_NAME_SIZE}`
+        `Token name size is ${lenName} but maximum size is ${MAX_TOKEN_NAME_SIZE}`,
       );
     }
 
@@ -173,7 +176,7 @@ class CreateTokenTransaction extends Transaction {
 
     if (lenSymbol > MAX_TOKEN_SYMBOL_SIZE) {
       throw new CreateTokenTxInvalid(
-        `Token symbol size is ${lenSymbol} but maximum size is ${MAX_TOKEN_SYMBOL_SIZE}`
+        `Token symbol size is ${lenSymbol} but maximum size is ${MAX_TOKEN_SYMBOL_SIZE}`,
       );
     }
 

--- a/src/models/input.ts
+++ b/src/models/input.ts
@@ -6,8 +6,9 @@
  */
 
 import _ from 'lodash';
-import { hexToBuffer, unpackToInt, unpackToHex, unpackLen, intToBytes } from '../utils/buffer';
+
 import { TX_HASH_SIZE_BYTES } from '../constants';
+import { hexToBuffer, unpackToInt, unpackToHex, unpackLen, intToBytes } from '../utils/buffer';
 
 type optionsType = {
   data?: Buffer | null | undefined;

--- a/src/models/output.ts
+++ b/src/models/output.ts
@@ -6,6 +6,7 @@
  */
 
 import _ from 'lodash';
+
 import {
   TOKEN_AUTHORITY_MASK,
   TOKEN_INDEX_MASK,
@@ -13,10 +14,7 @@ import {
   TOKEN_MINT_MASK,
 } from '../constants';
 import { OutputValueError } from '../errors';
-import P2PKH from './p2pkh';
-import P2SH from './p2sh';
-import ScriptData from './script_data';
-import Network from './network';
+import { OutputValueType } from '../types';
 import {
   bytesToOutputValue,
   unpackLen,
@@ -25,7 +23,11 @@ import {
   outputValueToBytes,
 } from '../utils/buffer';
 import { parseScript as utilsParseScript } from '../utils/scripts';
-import { OutputValueType } from '../types';
+
+import Network from './network';
+import P2PKH from './p2pkh';
+import P2SH from './p2sh';
+import ScriptData from './script_data';
 
 type optionsType = {
   tokenData?: number | undefined;

--- a/src/models/p2pkh.ts
+++ b/src/models/p2pkh.ts
@@ -6,6 +6,7 @@
  */
 
 import { util } from 'bitcore-lib';
+
 import {
   OP_GREATERTHAN_TIMESTAMP,
   OP_DUP,
@@ -13,10 +14,11 @@ import {
   OP_EQUALVERIFY,
   OP_CHECKSIG,
 } from '../opcodes';
+import { IHistoryOutputDecoded } from '../types';
 import { intToBytes } from '../utils/buffer';
 import helpers from '../utils/helpers';
+
 import Address from './address';
-import { IHistoryOutputDecoded } from '../types';
 
 type optionsType = {
   timelock?: number | null | undefined;

--- a/src/models/p2sh.ts
+++ b/src/models/p2sh.ts
@@ -6,11 +6,13 @@
  */
 
 import { util } from 'bitcore-lib';
+
 import { OP_GREATERTHAN_TIMESTAMP, OP_HASH160, OP_EQUAL } from '../opcodes';
-import helpers from '../utils/helpers';
-import { intToBytes } from '../utils/buffer';
-import Address from './address';
 import { IHistoryOutputDecoded } from '../types';
+import { intToBytes } from '../utils/buffer';
+import helpers from '../utils/helpers';
+
+import Address from './address';
 
 type optionsType = {
   timelock?: number | null | undefined;

--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -8,18 +8,6 @@
 // eslint-disable-next-line max-classes-per-file -- These classes are well organized within this file
 import { get } from 'lodash';
 
-import Input from './input';
-import Output from './output';
-import Transaction from './transaction';
-import Network from './network';
-
-import P2PKH from './p2pkh';
-import P2SH from './p2sh';
-
-import transactionUtils from '../utils/transaction';
-import helpers from '../utils/helpers';
-import { IndexOOBError, UnsupportedScriptError } from '../errors';
-
 import txApi from '../api/txApi';
 import {
   DEFAULT_TX_VERSION,
@@ -29,7 +17,17 @@ import {
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
 } from '../constants';
+import { IndexOOBError, UnsupportedScriptError } from '../errors';
 import { IDataInput, IDataOutput, IDataTx, OutputValueType } from '../types';
+import helpers from '../utils/helpers';
+import transactionUtils from '../utils/transaction';
+
+import Input from './input';
+import Network from './network';
+import Output from './output';
+import P2PKH from './p2pkh';
+import P2SH from './p2sh';
+import Transaction from './transaction';
 
 /**
  * Extended version of the Input class with extra data
@@ -55,7 +53,7 @@ export class ProposalInput extends Input {
     }: {
       token?: string;
       authorities?: OutputValueType;
-    } = {}
+    } = {},
   ) {
     super(hash, index);
     this.value = value;
@@ -116,7 +114,7 @@ export class ProposalOutput extends Output {
       token?: string;
       isChange?: boolean;
       authorities?: OutputValueType;
-    } = {}
+    } = {},
   ) {
     let tokenData = 0;
     if (authorities > 0) {
@@ -314,7 +312,7 @@ export class PartialTx {
     }: {
       token?: string;
       authorities?: OutputValueType;
-    } = {}
+    } = {},
   ) {
     this.inputs.push(new ProposalInput(txId, index, value, address, { token, authorities }));
   }
@@ -343,7 +341,7 @@ export class PartialTx {
       token?: string;
       isChange?: boolean;
       authorities?: OutputValueType;
-    } = {}
+    } = {},
   ) {
     this.outputs.push(new ProposalOutput(value, script, { token, authorities, isChange }));
   }
@@ -376,7 +374,7 @@ export class PartialTx {
     });
     const tx = this.getTx();
     const inputArr = this.inputs.map(i =>
-      [i.address, i.token, i.authorities.toString(16), i.value.toString(16)].join(',')
+      [i.address, i.token, i.authorities.toString(16), i.value.toString(16)].join(','),
     );
     const arr = [
       PartialTxPrefix,
@@ -503,7 +501,7 @@ export class PartialTx {
               authorityCheck &&
                 input.token === tokenUid &&
                 input.value === utxo.value &&
-                input.address === utxo.decoded.address
+                input.address === utxo.decoded.address,
             );
           })
           .then(_ => {

--- a/src/models/promise_queue.ts
+++ b/src/models/promise_queue.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 import EventEmitter from 'events';
+
 import PriorityQueue from './priority_queue';
 
 type TaskOptions = { signal?: AbortSignal };
@@ -188,7 +189,7 @@ export default class PromiseQueue extends EventEmitter {
         () => {
           reject(signal.reason);
         },
-        { once: true }
+        { once: true },
       );
     });
   }
@@ -233,7 +234,7 @@ export default class PromiseQueue extends EventEmitter {
             this.emit('finished_job');
             this.#next();
           }
-        })
+        }),
       );
       // Try to start the job we enqueued and any other we can start
       this.processQueue();

--- a/src/models/script_data.ts
+++ b/src/models/script_data.ts
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { util } from 'bitcore-lib';
 import buffer from 'buffer';
+
+import { util } from 'bitcore-lib';
+
 import { OP_CHECKSIG } from '../opcodes';
-import helpers from '../utils/helpers';
 import { IHistoryOutputDecoded } from '../types';
+import helpers from '../utils/helpers';
 
 class ScriptData {
   // String of data to store on the script

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -5,10 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { crypto as cryptoBL, util } from 'bitcore-lib';
 import buffer from 'buffer';
-import { clone } from 'lodash';
 import crypto from 'crypto';
+
+import { crypto as cryptoBL, util } from 'bitcore-lib';
+import { clone } from 'lodash';
+
 import {
   BLOCK_VERSION,
   DEFAULT_SIGNAL_BITS,
@@ -21,6 +23,13 @@ import {
   TX_HASH_SIZE_BYTES,
   TX_WEIGHT_CONSTANTS,
 } from '../constants';
+import { MaximumNumberInputsError, MaximumNumberOutputsError } from '../errors';
+import type Header from '../headers/base';
+import FeeHeader from '../headers/fee';
+import HeaderParser from '../headers/parser';
+import { getVertexHeaderIdFromBuffer } from '../headers/types';
+import NanoContractHeader from '../nano_contracts/header';
+import { OutputValueType } from '../types';
 import {
   bufferToHex,
   hexToBuffer,
@@ -30,16 +39,10 @@ import {
   intToBytes,
   floatToBytes,
 } from '../utils/buffer';
+
 import Input from './input';
-import Output from './output';
 import Network from './network';
-import { MaximumNumberInputsError, MaximumNumberOutputsError } from '../errors';
-import { OutputValueType } from '../types';
-import type Header from '../headers/base';
-import NanoContractHeader from '../nano_contracts/header';
-import FeeHeader from '../headers/fee';
-import HeaderParser from '../headers/parser';
-import { getVertexHeaderIdFromBuffer } from '../headers/types';
+import Output from './output';
 
 enum txType {
   BLOCK = 'Block',
@@ -401,13 +404,13 @@ class Transaction {
   validate() {
     if (this.inputs.length > MAX_INPUTS) {
       throw new MaximumNumberInputsError(
-        `Transaction has ${this.inputs.length} inputs and can have at most ${MAX_INPUTS}.`
+        `Transaction has ${this.inputs.length} inputs and can have at most ${MAX_INPUTS}.`,
       );
     }
 
     if (this.outputs.length > MAX_OUTPUTS) {
       throw new MaximumNumberOutputsError(
-        `Transaction has ${this.outputs.length} outputs and can have at most ${MAX_OUTPUTS}.`
+        `Transaction has ${this.outputs.length} outputs and can have at most ${MAX_OUTPUTS}.`,
       );
     }
   }

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -6,11 +6,7 @@
  */
 
 import { concat, uniq } from 'lodash';
-import Transaction from '../models/transaction';
-import CreateTokenTransaction from '../models/create_token_transaction';
-import { getAddressType } from '../utils/address';
-import tokensUtils from '../utils/tokens';
-import transactionUtils from '../utils/transaction';
+
 import {
   DEFAULT_TX_VERSION,
   FEE_PER_OUTPUT,
@@ -20,8 +16,28 @@ import {
   TOKEN_MINT_MASK,
   TOKEN_MELT_MASK,
 } from '../constants';
-import HathorWallet from '../new/wallet';
 import { NanoContractTransactionError, UtxoError } from '../errors';
+import { Header } from '../headers';
+import FeeHeader from '../headers/fee';
+import Address from '../models/address';
+import CreateTokenTransaction from '../models/create_token_transaction';
+import Transaction from '../models/transaction';
+import HathorWallet from '../new/wallet';
+import {
+  AuthorityType,
+  IDataInput,
+  IDataOutput,
+  IDataOutputWithToken,
+  TokenVersion,
+} from '../types';
+import { getAddressType } from '../utils/address';
+import { Fee } from '../utils/fee';
+import leb128 from '../utils/leb128';
+import tokensUtils from '../utils/tokens';
+import transactionUtils from '../utils/transaction';
+import { Utxo } from '../wallet/types';
+
+import NanoContractHeader from './header';
 import {
   NanoContractActionHeader,
   NanoContractActionType,
@@ -36,20 +52,6 @@ import {
   mapActionToActionHeader,
   validateAndParseBlueprintMethodArgs,
 } from './utils';
-import {
-  AuthorityType,
-  IDataInput,
-  IDataOutput,
-  IDataOutputWithToken,
-  TokenVersion,
-} from '../types';
-import NanoContractHeader from './header';
-import Address from '../models/address';
-import leb128 from '../utils/leb128';
-import FeeHeader from '../headers/fee';
-import { Fee } from '../utils/fee';
-import { Utxo } from '../wallet/types';
-import { Header } from '../headers';
 
 class NanoContractTransactionBuilder {
   blueprintId: string | null | undefined;
@@ -145,7 +147,7 @@ class NanoContractTransactionBuilder {
     const parseResult = INanoContractActionSchema.array().safeParse(actions);
     if (!parseResult.success) {
       throw new NanoContractTransactionError(
-        `Invalid actions. Error: ${parseResult.error.message}.`
+        `Invalid actions. Error: ${parseResult.error.message}.`,
       );
     }
     this.actions = parseResult.data;
@@ -270,7 +272,7 @@ class NanoContractTransactionBuilder {
   async calculateFee(
     inputs: IDataInput[],
     outputs: IDataOutput[],
-    tokens: string[]
+    tokens: string[],
   ): Promise<{ fee: bigint; dataOutputFee: bigint }> {
     this.assertWallet();
 
@@ -281,7 +283,7 @@ class NanoContractTransactionBuilder {
       inputs,
       outputs as IDataOutputWithToken[],
       tokens,
-      this.actions ?? undefined
+      this.actions ?? undefined,
     );
     fee += calculatedFee;
 
@@ -305,7 +307,7 @@ class NanoContractTransactionBuilder {
    */
   setVertexType(
     vertexType: NanoContractVertexType,
-    createTokenOptions: NanoContractBuilderCreateTokenOptions | null = null
+    createTokenOptions: NanoContractBuilderCreateTokenOptions | null = null,
   ) {
     this.vertexType = vertexType;
     this.createTokenOptions = createTokenOptions;
@@ -322,12 +324,12 @@ class NanoContractTransactionBuilder {
    * @inner
    */
   async executeDeposit(
-    action: NanoContractAction
+    action: NanoContractAction,
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     this.assertWallet();
     if (action.type !== NanoContractActionType.DEPOSIT) {
       throw new NanoContractTransactionError(
-        "Can't execute a deposit with an action which type is different than deposit."
+        "Can't execute a deposit with an action which type is different than deposit.",
       );
     }
 
@@ -359,7 +361,7 @@ class NanoContractTransactionBuilder {
         htrToCreateToken = tokensUtils.getTransactionHTRDeposit(
           this.createTokenOptions!.amount,
           dataArray.length,
-          this.wallet.storage
+          this.wallet.storage,
         );
       }
       amount += htrToCreateToken;
@@ -430,13 +432,13 @@ class NanoContractTransactionBuilder {
     this.assertWallet();
     if (action.type !== NanoContractActionType.WITHDRAWAL) {
       throw new NanoContractTransactionError(
-        "Can't execute a withdrawal with an action which type is different than withdrawal."
+        "Can't execute a withdrawal with an action which type is different than withdrawal.",
       );
     }
 
     if (!action.amount || !action.token) {
       throw new NanoContractTransactionError(
-        'Amount and token are required for withdrawal action.'
+        'Amount and token are required for withdrawal action.',
       );
     }
 
@@ -446,7 +448,7 @@ class NanoContractTransactionBuilder {
     if (this.isCreateTokenTransaction) {
       if (this.createTokenOptions === null) {
         throw new NanoContractTransactionError(
-          'For a token creation transaction we must have the options defined.'
+          'For a token creation transaction we must have the options defined.',
         );
       }
 
@@ -460,7 +462,7 @@ class NanoContractTransactionBuilder {
         const htrToCreateToken = tokensUtils.getTransactionHTRDeposit(
           this.createTokenOptions!.amount,
           dataArray.length,
-          this.wallet.storage
+          this.wallet.storage,
         );
         withdrawalAmount -= htrToCreateToken;
       }
@@ -473,13 +475,13 @@ class NanoContractTransactionBuilder {
 
     if (withdrawalAmount < 0n) {
       throw new NanoContractTransactionError(
-        `Withdrawal amount ${withdrawalAmount} for token ${action.token} is less than 0.`
+        `Withdrawal amount ${withdrawalAmount} for token ${action.token} is less than 0.`,
       );
     }
 
     if (!action.address) {
       throw new NanoContractTransactionError(
-        'Address is required for withdrawal action that creates outputs.'
+        'Address is required for withdrawal action that creates outputs.',
       );
     }
 
@@ -504,18 +506,18 @@ class NanoContractTransactionBuilder {
    * @inner
    */
   async executeGrantAuthority(
-    action: NanoContractAction
+    action: NanoContractAction,
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     this.assertWallet();
     if (action.type !== NanoContractActionType.GRANT_AUTHORITY) {
       throw new NanoContractTransactionError(
-        "Can't execute a grant authority with an action which type is different than grant authority."
+        "Can't execute a grant authority with an action which type is different than grant authority.",
       );
     }
 
     if (!action.authority || !action.token) {
       throw new NanoContractTransactionError(
-        'Authority and token are required for grant authority action.'
+        'Authority and token are required for grant authority action.',
       );
     }
 
@@ -532,12 +534,12 @@ class NanoContractTransactionBuilder {
         many: false,
         only_available_utxos: true,
         filter_address: action.address,
-      }
+      },
     );
 
     if (!utxos || utxos.length === 0) {
       throw new NanoContractTransactionError(
-        'Not enough authority utxos to execute the grant authority.'
+        'Not enough authority utxos to execute the grant authority.',
       );
     }
 
@@ -582,13 +584,13 @@ class NanoContractTransactionBuilder {
     this.assertWallet();
     if (action.type !== NanoContractActionType.ACQUIRE_AUTHORITY) {
       throw new NanoContractTransactionError(
-        "Can't execute an acquire authority with an action which type is different than acquire authority."
+        "Can't execute an acquire authority with an action which type is different than acquire authority.",
       );
     }
 
     if (!action.address || !action.authority || !action.token) {
       throw new NanoContractTransactionError(
-        'Address, authority, and token are required for acquire authority action.'
+        'Address, authority, and token are required for acquire authority action.',
       );
     }
 
@@ -622,7 +624,7 @@ class NanoContractTransactionBuilder {
       // Get the blueprint id from the nano transaction in the full node
       if (!this.ncId) {
         throw new NanoContractTransactionError(
-          `Nano contract ID cannot be null for method ${this.method}`
+          `Nano contract ID cannot be null for method ${this.method}`,
         );
       }
 
@@ -645,7 +647,7 @@ class NanoContractTransactionBuilder {
       this.blueprintId,
       this.method,
       this.args,
-      this.wallet.getNetworkObject()
+      this.wallet.getNetworkObject(),
     );
   }
 
@@ -661,7 +663,7 @@ class NanoContractTransactionBuilder {
   async serializeArgs() {
     if (!this.parsedArgs) {
       throw new NanoContractTransactionError(
-        'Arguments should be parsed and validated before serialization.'
+        'Arguments should be parsed and validated before serialization.',
       );
     }
     const serializedArray: Buffer[] = [leb128.encodeUnsigned(this.parsedArgs?.length ?? 0)];
@@ -812,7 +814,7 @@ class NanoContractTransactionBuilder {
     inputs: IDataInput[],
     outputs: IDataOutput[],
     tokens: string[],
-    headers: Header[] = []
+    headers: Header[] = [],
   ): Promise<Transaction | CreateTokenTransaction> {
     this.assertWallet();
     if (this.vertexType === NanoContractVertexType.TRANSACTION) {
@@ -823,14 +825,14 @@ class NanoContractTransactionBuilder {
           outputs,
           tokens,
         },
-        this.wallet.getNetworkObject()
+        this.wallet.getNetworkObject(),
       );
     }
 
     if (this.isCreateTokenTransaction) {
       if (this.createTokenOptions === null) {
         throw new NanoContractTransactionError(
-          'Create token options cannot be null when creating a create token transaction.'
+          'Create token options cannot be null when creating a create token transaction.',
         );
       }
 
@@ -857,7 +859,7 @@ class NanoContractTransactionBuilder {
             this.contractPaysFees,
           skipFeeCalculation: this.isCreatingFeeToken || this.contractPaysFees,
           tokenVersion: this.createTokenOptions.tokenVersion,
-        }
+        },
       );
 
       data.inputs = concat(data.inputs, inputs);
@@ -908,7 +910,7 @@ class NanoContractTransactionBuilder {
       // Validate against maxFee if set
       if (this.maxFee !== null && totalFee > this.maxFee) {
         throw new NanoContractTransactionError(
-          `Calculated fee (${totalFee}) exceeds maximum fee (${this.maxFee}).`
+          `Calculated fee (${totalFee}) exceeds maximum fee (${this.maxFee}).`,
         );
       }
 
@@ -923,7 +925,7 @@ class NanoContractTransactionBuilder {
       // to build a more complex tx.
       if (totalFee > 0n && this.contractPaysFees) {
         const htrOutputIndex = outputs.findIndex(
-          output => 'token' in output && output.token === NATIVE_TOKEN_UID && !output.authorities
+          output => 'token' in output && output.token === NATIVE_TOKEN_UID && !output.authorities,
         );
         if (htrOutputIndex === -1) {
           throw new NanoContractTransactionError('No available HTR output to deduct fee from.');
@@ -932,7 +934,7 @@ class NanoContractTransactionBuilder {
         htrOutput.value -= totalFee;
         if (htrOutput.value < 0n) {
           throw new NanoContractTransactionError(
-            `HTR withdrawal amount insufficient to cover fee. Withdrawal: ${htrOutput.value}, Fee: ${totalFee}`
+            `HTR withdrawal amount insufficient to cover fee. Withdrawal: ${htrOutput.value}, Fee: ${totalFee}`,
           );
         }
         if (htrOutput.value === 0n) {
@@ -960,7 +962,7 @@ class NanoContractTransactionBuilder {
         nanoHeaderActions,
         seqnum,
         this.caller!,
-        null
+        null,
       );
 
       tx.headers.push(nanoHeader);

--- a/src/nano_contracts/fields/address.ts
+++ b/src/nano_contracts/fields/address.ts
@@ -7,11 +7,13 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType"] }] */
 
 import { z } from 'zod';
-import { BufferROExtract } from '../types';
-import { NCFieldBase } from './base';
+
 import Address from '../../models/address';
 import Network from '../../models/network';
 import helpersUtils from '../../utils/helpers';
+import { BufferROExtract } from '../types';
+
+import { NCFieldBase } from './base';
 
 export const AddressSchema = z
   .string()
@@ -65,7 +67,7 @@ export class AddressField extends NCFieldBase<string, Address> {
     // Check network version
     if (decoded[0] !== buf[0]) {
       throw new Error(
-        `Asked to deserialize an address with version byte ${buf[0]} but the network from the deserializer object has version byte ${decoded[0]}.`
+        `Asked to deserialize an address with version byte ${buf[0]} but the network from the deserializer object has version byte ${decoded[0]}.`,
       );
     }
     // Check checksum bytes
@@ -74,7 +76,7 @@ export class AddressField extends NCFieldBase<string, Address> {
     if (!calcChecksum.equals(recvChecksum)) {
       // Checksum value generated does not match value from fullnode
       throw new Error(
-        `When parsing and Address(${address.base58}) we calculated checksum(${calcChecksum.toString('hex')}) but it does not match the checksum it came with ${recvChecksum.toString('hex')}.`
+        `When parsing and Address(${address.base58}) we calculated checksum(${calcChecksum.toString('hex')}) but it does not match the checksum it came with ${recvChecksum.toString('hex')}.`,
       );
     }
     this.value = address;

--- a/src/nano_contracts/fields/amount.ts
+++ b/src/nano_contracts/fields/amount.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { leb128 } from './encoding';
 

--- a/src/nano_contracts/fields/bool.ts
+++ b/src/nano_contracts/fields/bool.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { bool } from './encoding';
 

--- a/src/nano_contracts/fields/bytes.ts
+++ b/src/nano_contracts/fields/bytes.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { bytes } from './encoding';
 

--- a/src/nano_contracts/fields/bytes32.ts
+++ b/src/nano_contracts/fields/bytes32.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { sizedBytes } from './encoding';
 

--- a/src/nano_contracts/fields/callerId.ts
+++ b/src/nano_contracts/fields/callerId.ts
@@ -6,10 +6,11 @@
  */
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType"] }] */
 
-import { BufferROExtract } from '../types';
-import { NCFieldBase } from './base';
 import Network from '../../models/network';
+import { BufferROExtract } from '../types';
+
 import { AddressField } from './address';
+import { NCFieldBase } from './base';
 import { Bytes32Field, Bytes32Schema } from './bytes32';
 
 /**

--- a/src/nano_contracts/fields/collection.ts
+++ b/src/nano_contracts/fields/collection.ts
@@ -7,6 +7,7 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType"] }] */
 
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { leb128 } from './encoding';
 

--- a/src/nano_contracts/fields/dict.ts
+++ b/src/nano_contracts/fields/dict.ts
@@ -8,6 +8,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { leb128 } from './encoding';
 

--- a/src/nano_contracts/fields/encoding/bytes.ts
+++ b/src/nano_contracts/fields/encoding/bytes.ts
@@ -7,6 +7,7 @@
 
 import { NC_ARGS_MAX_BYTES_LENGTH } from '../../../constants';
 import { BufferROExtract } from '../../types';
+
 import * as leb128 from './leb128';
 
 export function encode(buf: Buffer) {

--- a/src/nano_contracts/fields/encoding/index.ts
+++ b/src/nano_contracts/fields/encoding/index.ts
@@ -1,5 +1,5 @@
-export * as bytes from './bytes';
-export * as utf8 from './utf8';
-export * as sizedBytes from './sizedBytes';
 export * as bool from './bool';
+export * as bytes from './bytes';
 export * as leb128 from './leb128';
+export * as sizedBytes from './sizedBytes';
+export * as utf8 from './utf8';

--- a/src/nano_contracts/fields/encoding/leb128.ts
+++ b/src/nano_contracts/fields/encoding/leb128.ts
@@ -14,7 +14,7 @@ export function encode_unsigned(value: bigint | number, maxBytes: number | null 
 
 export function decode_unsigned(
   value: Buffer,
-  maxBytes: number | null = null
+  maxBytes: number | null = null,
 ): BufferROExtract<bigint> {
   return leb128Util.decodeUnsigned(value, maxBytes);
 }
@@ -25,7 +25,7 @@ export function encode_signed(value: bigint | number, maxBytes: number | null = 
 
 export function decode_signed(
   value: Buffer,
-  maxBytes: number | null = null
+  maxBytes: number | null = null,
 ): BufferROExtract<bigint> {
   return leb128Util.decodeSigned(value, maxBytes);
 }

--- a/src/nano_contracts/fields/encoding/utf8.ts
+++ b/src/nano_contracts/fields/encoding/utf8.ts
@@ -6,6 +6,7 @@
  */
 
 import { BufferROExtract } from '../../types';
+
 import * as bytes from './bytes';
 
 export function encode(value: string) {

--- a/src/nano_contracts/fields/index.ts
+++ b/src/nano_contracts/fields/index.ts
@@ -5,22 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { StrField } from './str';
-import { IntField } from './int';
+import { AddressField } from './address';
+import { AmountField } from './amount';
+import { NCFieldBase } from './base';
+import { BoolField } from './bool';
 import { BytesField } from './bytes';
 import { Bytes32Field } from './bytes32';
-import { BoolField } from './bool';
-import { AddressField } from './address';
 import { CallerIdField } from './callerId';
-import { TimestampField } from './timestamp';
-import { AmountField } from './amount';
-import { TokenUidField } from './token';
-import { OptionalField } from './optional';
-import { TupleField } from './tuple';
-import { SignedDataField } from './signedData';
-import { NCFieldBase } from './base';
-import { DictField } from './dict';
 import { CollectionField } from './collection';
+import { DictField } from './dict';
+import { IntField } from './int';
+import { OptionalField } from './optional';
+import { SignedDataField } from './signedData';
+import { StrField } from './str';
+import { TimestampField } from './timestamp';
+import { TokenUidField } from './token';
+import { TupleField } from './tuple';
 
 export { NCFieldBase } from './base';
 

--- a/src/nano_contracts/fields/int.ts
+++ b/src/nano_contracts/fields/int.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { leb128 } from './encoding';
 

--- a/src/nano_contracts/fields/optional.ts
+++ b/src/nano_contracts/fields/optional.ts
@@ -7,6 +7,7 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType"] }] */
 
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 
 export class OptionalField extends NCFieldBase<unknown | null, unknown | null> {

--- a/src/nano_contracts/fields/signedData.ts
+++ b/src/nano_contracts/fields/signedData.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { BytesField } from './bytes';
 

--- a/src/nano_contracts/fields/str.ts
+++ b/src/nano_contracts/fields/str.ts
@@ -7,7 +7,9 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { utf8 } from './encoding';
 

--- a/src/nano_contracts/fields/timestamp.ts
+++ b/src/nano_contracts/fields/timestamp.ts
@@ -7,9 +7,11 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
-import { BufferROExtract } from '../types';
-import { NCFieldBase } from './base';
+
 import { signedIntToBytes, unpackToInt } from '../../utils/buffer';
+import { BufferROExtract } from '../types';
+
+import { NCFieldBase } from './base';
 
 export class TimestampField extends NCFieldBase<number, number> {
   value: number;

--- a/src/nano_contracts/fields/token.ts
+++ b/src/nano_contracts/fields/token.ts
@@ -7,8 +7,10 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType", "createNew"] }] */
 
 import { z } from 'zod';
+
 import { NATIVE_TOKEN_UID } from '../../constants';
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 import { sizedBytes } from './encoding';
 

--- a/src/nano_contracts/fields/tuple.ts
+++ b/src/nano_contracts/fields/tuple.ts
@@ -7,6 +7,7 @@
 /* eslint class-methods-use-this: ["error", { "exceptMethods": ["getType"] }] */
 
 import { BufferROExtract } from '../types';
+
 import { NCFieldBase } from './base';
 
 export class TupleField extends NCFieldBase<unknown[], unknown[]> {

--- a/src/nano_contracts/header.ts
+++ b/src/nano_contracts/header.ts
@@ -5,8 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { NanoContractActionHeader } from './types';
+import Header from '../headers/base';
+import {
+  getVertexHeaderIdBuffer,
+  getVertexHeaderIdFromBuffer,
+  VertexHeaderId,
+} from '../headers/types';
+import Address from '../models/address';
+import Network from '../models/network';
 import type Transaction from '../models/transaction';
+import { OutputValueType } from '../types';
 import {
   bytesToOutputValue,
   hexToBuffer,
@@ -17,15 +25,8 @@ import {
 } from '../utils/buffer';
 import helpersUtils from '../utils/helpers';
 import leb128Util from '../utils/leb128';
-import {
-  getVertexHeaderIdBuffer,
-  getVertexHeaderIdFromBuffer,
-  VertexHeaderId,
-} from '../headers/types';
-import Header from '../headers/base';
-import Address from '../models/address';
-import Network from '../models/network';
-import { OutputValueType } from '../types';
+
+import { NanoContractActionHeader } from './types';
 
 class NanoContractHeader extends Header {
   // It's the blueprint id when this header is calling a initialize method
@@ -60,7 +61,7 @@ class NanoContractHeader extends Header {
     actions: NanoContractActionHeader[],
     seqnum: number,
     address: Address,
-    script: Buffer | null = null
+    script: Buffer | null = null,
   ) {
     super();
     this.id = id;

--- a/src/nano_contracts/ncTypes/parser.ts
+++ b/src/nano_contracts/ncTypes/parser.ts
@@ -6,9 +6,10 @@
  */
 
 import { z } from 'zod';
-import ncFields, { NCFieldBase } from '../fields';
+
 import Network from '../../models/network';
 import { ILogger } from '../../types';
+import ncFields, { NCFieldBase } from '../fields';
 
 const simpleTypes = z.enum([
   'str',
@@ -117,7 +118,7 @@ function fieldFromTypeNode(type: TypeNode, network: Network, logger?: ILogger): 
     case 'dict':
       return ncFields.DictField.new(
         fieldFromTypeNode(type.key, network),
-        fieldFromTypeNode(type.value, network)
+        fieldFromTypeNode(type.value, network),
       );
     case 'list':
       return ncFields.ListField.new(fieldFromTypeNode(type.element, network));

--- a/src/nano_contracts/on_chain_blueprint.ts
+++ b/src/nano_contracts/on_chain_blueprint.ts
@@ -8,6 +8,7 @@
  */
 
 import zlib from 'zlib';
+
 import { ON_CHAIN_BLUEPRINTS_INFO_VERSION, ON_CHAIN_BLUEPRINTS_VERSION } from '../constants';
 import Transaction from '../models/transaction';
 import { intToBytes } from '../utils/buffer';

--- a/src/nano_contracts/parser.ts
+++ b/src/nano_contracts/parser.ts
@@ -6,13 +6,15 @@
  */
 
 import { get, has } from 'lodash';
-import Address from '../models/address';
-import Network from '../models/network';
+
 import ncApi from '../api/nano';
 import { NanoContractTransactionParseError } from '../errors';
-import { MethodArgInfo, IParsedArgument } from './types';
+import Address from '../models/address';
+import Network from '../models/network';
 import leb128 from '../utils/leb128';
+
 import { getFieldParser, normalizeTypeString } from './ncTypes/parser';
+import { MethodArgInfo, IParsedArgument } from './types';
 
 class NanoContractTransactionParser {
   blueprintId: string;
@@ -32,7 +34,7 @@ class NanoContractTransactionParser {
     method: string,
     address: string,
     network: Network,
-    args: string | null
+    args: string | null,
   ) {
     this.blueprintId = blueprintId;
     this.method = method;
@@ -59,14 +61,14 @@ class NanoContractTransactionParser {
     if (!has(blueprintInformation, `public_methods.${this.method}`)) {
       // If this.method is not in the blueprint information public methods, then there's an error
       throw new NanoContractTransactionParseError(
-        'Failed to parse nano contract transaction. Method not found.'
+        'Failed to parse nano contract transaction. Method not found.',
       );
     }
 
     const methodArgs = get(
       blueprintInformation,
       `public_methods.${this.method}.args`,
-      []
+      [],
     ) as MethodArgInfo[];
     let argsBuffer = Buffer.from(this.args, 'hex');
 
@@ -95,7 +97,7 @@ class NanoContractTransactionParser {
         size = result.bytesRead;
       } catch (err: unknown) {
         throw new NanoContractTransactionParseError(
-          `Failed to deserialize argument ${normalizedType}.`
+          `Failed to deserialize argument ${normalizedType}.`,
         );
       }
       parsedArgs.push(parsed);

--- a/src/nano_contracts/types.ts
+++ b/src/nano_contracts/types.ts
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 import { z } from 'zod';
+
 import { IHistoryTx, OutputValueType, TokenVersion } from '../types';
 import { bigIntCoercibleSchema } from '../utils/bigint';
+
 import { NCFieldBase } from './fields';
 
 export interface IArgumentField {

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -5,24 +5,31 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { get } from 'lodash';
 import { crypto } from 'bitcore-lib';
+import { get } from 'lodash';
 import { z } from 'zod';
-import transactionUtils from '../utils/transaction';
-import tokensUtils from '../utils/tokens';
-import SendTransaction from '../new/sendTransaction';
-import Network from '../models/network';
-import ScriptData from '../models/script_data';
+
 import ncApi from '../api/nano';
-import { hexToBuffer } from '../utils/buffer';
+import { NANO_CONTRACTS_INITIALIZE_METHOD, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../constants';
+import { NanoContractTransactionError, OracleParseError, WalletFromXPubGuard } from '../errors';
+import Address from '../models/address';
+import Network from '../models/network';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
-import Address from '../models/address';
+import ScriptData from '../models/script_data';
 import Transaction from '../models/transaction';
-import { NanoContractTransactionError, OracleParseError, WalletFromXPubGuard } from '../errors';
-import { FullNodeTxResponse, OutputType, IHathorWallet } from '../wallet/types';
+import SendTransaction from '../new/sendTransaction';
+import HathorWallet from '../new/wallet';
 import { IHistoryTx, IStorage, ITokenData, OutputValueType } from '../types';
+import { hexToBuffer } from '../utils/buffer';
 import { parseScript } from '../utils/scripts';
+import tokensUtils from '../utils/tokens';
+import transactionUtils from '../utils/transaction';
+import { FullNodeTxResponse, OutputType, IHathorWallet } from '../wallet/types';
+
+import { isSignedDataField } from './fields';
+import NanoContractHeader from './header';
+import { getFieldParser, normalizeTypeString } from './ncTypes/parser';
 import {
   MethodArgInfo,
   ActionTypeToActionHeaderType,
@@ -31,11 +38,6 @@ import {
   NanoContractActionType,
   IArgumentField,
 } from './types';
-import { NANO_CONTRACTS_INITIALIZE_METHOD, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../constants';
-import { getFieldParser, normalizeTypeString } from './ncTypes/parser';
-import { isSignedDataField } from './fields';
-import HathorWallet from '../new/wallet';
-import NanoContractHeader from './header';
 
 /**
  * Set the caller address and seqnum on a nano contract header.
@@ -48,7 +50,7 @@ import NanoContractHeader from './header';
 export const setNanoHeaderCallerFromWallet = async (
   nanoHeader: NanoContractHeader,
   address: string,
-  wallet: IHathorWallet
+  wallet: IHathorWallet,
 ): Promise<void> => {
   const newAddress = new Address(address, { network: wallet.getNetworkObject() });
   newAddress.validateAddress();
@@ -70,7 +72,7 @@ export const setNanoHeaderCallerFromWallet = async (
 export const prepareNanoSendTransaction = async (
   tx: Transaction,
   pin: string,
-  storage: IStorage
+  storage: IStorage,
 ): Promise<SendTransaction> => {
   await transactionUtils.signTransaction(tx, storage, pin);
   tx.prepareToSend();
@@ -131,7 +133,7 @@ export async function getOracleSignedDataFromUser(
   argType: string,
   value: unknown,
   wallet: IHathorWallet,
-  options: { pinCode?: string } = {}
+  options: { pinCode?: string } = {},
 ) {
   const field = getFieldParser(argType, wallet.getNetworkObject());
   if (!isSignedDataField(field)) {
@@ -165,7 +167,7 @@ export const getOracleInputData = async (
   contractId: string,
   resultSerialized: Buffer,
   wallet: IHathorWallet,
-  options: { pinCode?: string } = {}
+  options: { pinCode?: string } = {},
 ) => {
   const ncId = Buffer.from(contractId, 'hex');
   const actualValue = Buffer.concat([ncId, resultSerialized]);
@@ -184,7 +186,7 @@ export const unsafeGetOracleInputData = async (
   oracleData: Buffer,
   resultSerialized: Buffer,
   wallet: IHathorWallet,
-  options: { pinCode?: string } = {}
+  options: { pinCode?: string } = {},
 ): Promise<Buffer> => {
   // Parse oracle script to validate if it's an address of this wallet
   const parsedOracleScript = parseScript(oracleData, wallet.getNetworkObject());
@@ -202,7 +204,7 @@ export const unsafeGetOracleInputData = async (
 
     const signatureOracle = transactionUtils.getSignature(
       crypto.Hash.sha256(resultSerialized),
-      oracleKey
+      oracleKey,
     );
     const oraclePubKeyBuffer = oracleKey.publicKey.toBuffer();
     return transactionUtils.createInputData(signatureOracle, oraclePubKeyBuffer);
@@ -228,7 +230,7 @@ export const validateAndParseBlueprintMethodArgs = async (
   blueprintId: string,
   method: string,
   args: unknown[] | null,
-  network: Network
+  network: Network,
 ): Promise<IArgumentField[]> => {
   // Get the blueprint data from full node
   const blueprintInformation = await ncApi.getBlueprintInformation(blueprintId);
@@ -236,7 +238,7 @@ export const validateAndParseBlueprintMethodArgs = async (
   const methodArgs = get(
     blueprintInformation,
     `public_methods.${method}.args`,
-    []
+    [],
   ) as MethodArgInfo[];
   if (!methodArgs) {
     throw new NanoContractTransactionError(`Blueprint does not have method ${method}.`);
@@ -249,7 +251,7 @@ export const validateAndParseBlueprintMethodArgs = async (
   const argsLen = args.length;
   if (argsLen !== methodArgs.length) {
     throw new NanoContractTransactionError(
-      `Method needs ${methodArgs.length} parameters but data has ${args.length}.`
+      `Method needs ${methodArgs.length} parameters but data has ${args.length}.`,
     );
   }
 
@@ -294,7 +296,7 @@ export const isNanoContractCreateTx = (tx: IHistoryTx): boolean => {
  */
 export const mapActionToActionHeader = (
   action: NanoContractAction,
-  tokens: string[]
+  tokens: string[],
 ): NanoContractActionHeader => {
   const headerActionType = ActionTypeToActionHeaderType[action.type];
 
@@ -332,7 +334,7 @@ export const mapActionToActionHeader = (
  * @returns A promise resolving to [null, result] on success or [error, null] on failure.
  */
 export const getResultHelper = async <T>(
-  fn: () => Promise<T>
+  fn: () => Promise<T>,
 ): Promise<[Error | null, T | null]> => {
   try {
     const result = await fn();
@@ -368,11 +370,11 @@ export const getBlueprintId = async (ncId: string, wallet: HathorWallet): Promis
   }
 
   const [stateError, stateResponse] = await getResultHelper(() =>
-    ncApi.getNanoContractState(ncId!, [], [], [])
+    ncApi.getNanoContractState(ncId!, [], [], []),
   );
   if (stateError || !stateResponse?.blueprint_id) {
     throw new NanoContractTransactionError(
-      `Error getting nano contract transaction data with id ${ncId} from the full node: ${stateError?.message || 'Invalid response structure'}`
+      `Error getting nano contract transaction data with id ${ncId} from the full node: ${stateError?.message || 'Invalid response structure'}`,
     );
   }
 

--- a/src/new/connection.ts
+++ b/src/new/connection.ts
@@ -6,12 +6,12 @@
  */
 /* eslint max-classes-per-file: ["error", 2] */
 
-import GenericWebSocket from '../websocket';
-import helpers from '../utils/helpers';
 import BaseConnection, { ConnectionParams } from '../connection';
-import { ConnectionState } from '../wallet/types';
-import { handleSubscribeAddress, handleWsDashboard } from '../utils/connection';
 import { IStorage, ILogger, getDefaultLogger } from '../types';
+import { handleSubscribeAddress, handleWsDashboard } from '../utils/connection';
+import helpers from '../utils/helpers';
+import { ConnectionState } from '../wallet/types';
+import GenericWebSocket from '../websocket';
 
 const STREAM_ABORT_TIMEOUT = 10000; // 10s
 const CAPABILITIES_WAIT_TIMEOUT = 2000; // 2s
@@ -196,7 +196,7 @@ class WalletConnection extends BaseConnection {
     id: string,
     firstIndex: number,
     xpubkey: string,
-    gapLimit: number = -1
+    gapLimit: number = -1,
   ) {
     if (this.streamController?.streamId !== id) {
       throw new Error('There is an on-going stream, cannot start a second one');
@@ -223,7 +223,7 @@ class WalletConnection extends BaseConnection {
     firstIndex: number,
     addresses: [number, string][],
     first: boolean,
-    gapLimit: number = -1
+    gapLimit: number = -1,
   ) {
     if (this.streamController?.streamId !== id) {
       throw new Error('There is an on-going stream, cannot start a second one');

--- a/src/new/sendTransaction.ts
+++ b/src/new/sendTransaction.ts
@@ -6,14 +6,17 @@
  */
 
 import EventEmitter from 'events';
+
 import { shuffle } from 'lodash';
+
 import txApi from '../api/txApi';
 import { NATIVE_TOKEN_UID, SELECT_OUTPUTS_TIMEOUT } from '../constants';
 import { ErrorMessages } from '../errorMessages';
 import { SendTxError, WalletError } from '../errors';
+import Header from '../headers/base';
+import FeeHeader from '../headers/fee';
 import Address from '../models/address';
 import CreateTokenTransaction from '../models/create_token_transaction';
-import { Fee } from '../utils/fee';
 import Transaction from '../models/transaction';
 import {
   IDataInput,
@@ -26,6 +29,7 @@ import {
   OutputValueType,
   WalletType,
 } from '../types';
+import { Fee } from '../utils/fee';
 import helpers from '../utils/helpers';
 import { addCreatedTokenFromTx } from '../utils/storage';
 import tokens from '../utils/tokens';
@@ -33,9 +37,8 @@ import transactionUtils from '../utils/transaction';
 import { bestUtxoSelection } from '../utils/utxo';
 import MineTransaction from '../wallet/mineTransaction';
 import { ISendTransaction as ISendTransactionInterface, OutputType } from '../wallet/types';
+
 import HathorWallet from './wallet';
-import Header from '../headers/base';
-import FeeHeader from '../headers/fee';
 
 export interface ISendInput {
   txId: string;
@@ -250,7 +253,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
       this.storage,
       txData,
       tokenMap,
-      this.changeAddress
+      this.changeAddress,
     );
 
     const partialInputs = [...txData.inputs, ...partialTxData.inputs];
@@ -261,7 +264,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
     const fee = await Fee.calculate(
       partialInputs,
       partialOutputs,
-      await tokens.getTokensByManyIds(this.storage, new Set(tokenMap.keys()))
+      await tokens.getTokensByManyIds(this.storage, new Set(tokenMap.keys())),
     );
 
     if (requiresFees.length > 0 && fee === 0n) {
@@ -295,7 +298,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
         outputs: partialOutputs,
       },
       options,
-      fee
+      fee,
     );
 
     const shouldShuffleOutputs =
@@ -433,7 +436,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
     try {
       this.transaction = transactionUtils.createTransactionFromData(
         this.fullTxData,
-        this.storage.config.getNetwork()
+        this.storage.config.getNetwork(),
       );
       this.transaction.prepareToSend();
       return this.transaction;
@@ -540,7 +543,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
                 // Get the transaction as a history object
                 const historyTx = await transactionUtils.convertTransactionToHistoryTx(
                   transaction,
-                  storage
+                  storage,
                 );
                 // Add token from a create token transaction to the storage
                 // This just returns if the transaction is not a CREATE_TOKEN_TX
@@ -631,7 +634,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
    */
   async run(
     until: 'prepare-tx' | 'sign-tx' | 'mine-tx' | null = null,
-    pin: string | null = null
+    pin: string | null = null,
   ): Promise<Transaction> {
     try {
       if (this._currentStep === 'idle') {
@@ -683,7 +686,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
       await this.storage.utxoSelectAsInput(
         { txId: input.hash, index: input.index },
         selected,
-        SELECT_OUTPUTS_TIMEOUT
+        SELECT_OUTPUTS_TIMEOUT,
       );
     }
   }
@@ -724,7 +727,7 @@ export async function prepareSendTokensData(
   storage: IStorage,
   dataTx: Pick<IDataTx, 'inputs' | 'outputs'>,
   options: IUtxoSelectionOptions = {},
-  fee: bigint = 0n
+  fee: bigint = 0n,
 ): Promise<Pick<IDataTx, 'inputs' | 'outputs'>> {
   try {
     return await _prepareSendTokensData(storage, dataTx, options, fee);
@@ -751,7 +754,7 @@ async function _prepareSendTokensData(
   storage: IStorage,
   dataTx: Pick<IDataTx, 'inputs' | 'outputs'>,
   options: IUtxoSelectionOptions = {},
-  fee: bigint = 0n
+  fee: bigint = 0n,
 ): Promise<Pick<IDataTx, 'inputs' | 'outputs'>> {
   const token = options.token || NATIVE_TOKEN_UID;
   const utxoSelection = options.utxoSelectionMethod || bestUtxoSelection;
@@ -820,7 +823,7 @@ async function _prepareSendTokensData(
 
       if (!(await transactionUtils.canUseUtxo(input, storage))) {
         throw new Error(
-          `Token: ${token}. Output [${input.txId}, ${input.index}] is locked or being used`
+          `Token: ${token}. Output [${input.txId}, ${input.index}] is locked or being used`,
         );
       }
 
@@ -859,7 +862,7 @@ export async function prepareSendManyTokensData(
   storage: IStorage,
   txData: IDataTx,
   tokenMap: Map<string, boolean>,
-  changeAddress: string | null
+  changeAddress: string | null,
 ): Promise<Pick<IDataTx, 'outputs' | 'inputs'>> {
   const partialTxData: Pick<IDataTx, 'outputs' | 'inputs'> = { inputs: [], outputs: [] };
   for (const [token, chooseInputs] of tokenMap) {
@@ -889,7 +892,7 @@ export async function prepareSendManyTokensData(
 export async function checkUnspentInput(
   storage: IStorage,
   input: IDataInput,
-  selectedToken: string
+  selectedToken: string,
 ): Promise<{ success: boolean; message: string }> {
   const tx = await storage.getTx(input.txId);
   if (tx === null) {

--- a/src/new/types.ts
+++ b/src/new/types.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import Address from '../models/address';
+import { NanoContractAction } from '../nano_contracts/types';
 import {
   IStorage,
   ILogger,
@@ -13,9 +15,8 @@ import {
   OutputValueType,
   TokenVersion,
 } from '../types';
-import { NanoContractAction } from '../nano_contracts/types';
+
 import WalletConnection from './connection';
-import Address from '../models/address';
 
 /**
  * Parameters for HathorWallet constructor

--- a/src/new/wallet.ts
+++ b/src/new/wallet.ts
@@ -21,10 +21,23 @@
 
 /* eslint @typescript-eslint/explicit-function-return-type: "error" */
 
-import { cloneDeep, get } from 'lodash';
-import bitcore, { HDPrivateKey } from 'bitcore-lib';
 import EventEmitter from 'events';
+
+import bitcore, { HDPrivateKey } from 'bitcore-lib';
+import { cloneDeep, get } from 'lodash';
 import { z } from 'zod';
+
+import {
+  FullNodeTxApiResponse,
+  GraphvizNeighboursDotResponse,
+  GraphvizNeighboursErrorResponse,
+  GraphvizNeighboursResponse,
+  TransactionAccWeightResponse,
+} from '../api/schemas/txApi';
+import { GeneralTokenInfoSchema } from '../api/schemas/wallet';
+import txApi from '../api/txApi';
+import versionApi from '../api/version';
+import walletApi from '../api/wallet';
 import {
   NATIVE_TOKEN_UID,
   ON_CHAIN_BLUEPRINTS_VERSION,
@@ -32,16 +45,7 @@ import {
   P2SH_ACCT_PATH,
   GAP_LIMIT,
 } from '../constants';
-import tokenUtils from '../utils/tokens';
-import walletApi from '../api/wallet';
-import versionApi from '../api/version';
-import { hexToBuffer } from '../utils/buffer';
-import { signMessage } from '../utils/crypto';
-import helpers from '../utils/helpers';
-import { createP2SHRedeemScript } from '../utils/scripts';
-import walletUtils from '../utils/wallet';
-import SendTransaction from './sendTransaction';
-import Network from '../models/network';
+import { ErrorMessages } from '../errorMessages';
 import {
   AddressError,
   HasTxOutsideFirstAddressError,
@@ -51,8 +55,24 @@ import {
   WalletError,
   WalletFromXPubGuard,
 } from '../errors';
-import { ErrorMessages } from '../errorMessages';
+import Address from '../models/address';
+import Network from '../models/network';
 import P2SHSignature from '../models/p2sh_signature';
+import Queue from '../models/queue';
+import Transaction from '../models/transaction';
+import NanoContractTransactionBuilder from '../nano_contracts/builder';
+import NanoContractHeader from '../nano_contracts/header';
+import OnChainBlueprint, { Code, CodeKind } from '../nano_contracts/on_chain_blueprint';
+import {
+  CreateNanoTxOptions,
+  NanoContractBuilderCreateTokenOptions,
+  NanoContractVertexType,
+} from '../nano_contracts/types';
+import { prepareNanoSendTransaction, setNanoHeaderCallerFromWallet } from '../nano_contracts/utils';
+import { IHistoryTxSchema } from '../schemas';
+import { MemoryStore, Storage } from '../storage';
+import GLL from '../sync/gll';
+import { TransactionTemplate, WalletTxTemplateInterpreter } from '../template/transaction';
 import {
   ApiVersion,
   AddressScanPolicyData,
@@ -76,8 +96,11 @@ import {
   WalletType,
   WalletAddressMode,
 } from '../types';
-import transactionUtils from '../utils/transaction';
-import Queue from '../models/queue';
+import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../utils/address';
+import { hexToBuffer } from '../utils/buffer';
+import { signMessage } from '../utils/crypto';
+import helpers from '../utils/helpers';
+import { createP2SHRedeemScript } from '../utils/scripts';
 import {
   checkScanningPolicy,
   getHistorySyncMethod,
@@ -86,23 +109,13 @@ import {
   processMetadataChanged,
   scanPolicyStartAddresses,
 } from '../utils/storage';
-import txApi from '../api/txApi';
-import { MemoryStore, Storage } from '../storage';
-import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../utils/address';
-import NanoContractTransactionBuilder from '../nano_contracts/builder';
-import { prepareNanoSendTransaction, setNanoHeaderCallerFromWallet } from '../nano_contracts/utils';
-import OnChainBlueprint, { Code, CodeKind } from '../nano_contracts/on_chain_blueprint';
-import {
-  CreateNanoTxOptions,
-  NanoContractBuilderCreateTokenOptions,
-  NanoContractVertexType,
-} from '../nano_contracts/types';
-import { IHistoryTxSchema } from '../schemas';
-import GLL from '../sync/gll';
-import { TransactionTemplate, WalletTxTemplateInterpreter } from '../template/transaction';
-import Address from '../models/address';
+import tokenUtils from '../utils/tokens';
+import transactionUtils from '../utils/transaction';
+import walletUtils from '../utils/wallet';
 import { ConnectionState, FullNodeVersionData, IHathorWallet, Utxo } from '../wallet/types';
-import Transaction from '../models/transaction';
+
+import WalletConnection from './connection';
+import SendTransaction from './sendTransaction';
 import {
   CreateNFTOptions,
   CreateTokenOptions,
@@ -134,16 +147,6 @@ import {
   BuildTxTemplateOptions,
   StartReadOnlyOptions,
 } from './types';
-import {
-  FullNodeTxApiResponse,
-  GraphvizNeighboursDotResponse,
-  GraphvizNeighboursErrorResponse,
-  GraphvizNeighboursResponse,
-  TransactionAccWeightResponse,
-} from '../api/schemas/txApi';
-import { GeneralTokenInfoSchema } from '../api/schemas/wallet';
-import WalletConnection from './connection';
-import NanoContractHeader from '../nano_contracts/header';
 
 const ERROR_MESSAGE_PIN_REQUIRED = 'Pin is required.';
 
@@ -315,7 +318,7 @@ class HathorWallet extends EventEmitter {
       preCalculatedAddresses = null,
       scanPolicy = null,
       logger = null,
-    }: HathorWalletConstructorParams = {} as HathorWalletConstructorParams
+    }: HathorWalletConstructorParams = {} as HathorWalletConstructorParams,
   ) {
     super();
 
@@ -726,7 +729,7 @@ class HathorWallet extends EventEmitter {
       const redeemScript = createP2SHRedeemScript(
         multisigData.pubkeys,
         multisigData.numSignatures,
-        storageAddress.bip32AddressIndex
+        storageAddress.bip32AddressIndex,
       );
       const sigs: Buffer[] = [];
       for (const p2shSig of p2shSignatures) {
@@ -960,7 +963,7 @@ class HathorWallet extends EventEmitter {
       token_id?: string;
       count?: number;
       skip?: number;
-    } = {}
+    } = {},
   ): Promise<GetTxHistoryFullnodeFacadeReturnType[]> {
     const newOptions = {
       token_id: NATIVE_TOKEN_UID,
@@ -1057,7 +1060,7 @@ class HathorWallet extends EventEmitter {
    */
   async getAddressInfo(
     address: string,
-    options: { token?: string } = {}
+    options: { token?: string } = {},
   ): Promise<{
     total_amount_received: bigint;
     total_amount_sent: bigint;
@@ -1228,7 +1231,7 @@ class HathorWallet extends EventEmitter {
    */
   async getUtxosForAmount(
     amount: bigint,
-    options: GetUtxosForAmountOptions = {}
+    options: GetUtxosForAmountOptions = {},
   ): Promise<{ utxos: Utxo[]; changeAmount: bigint }> {
     const newOptions = {
       token: NATIVE_TOKEN_UID,
@@ -1245,7 +1248,7 @@ class HathorWallet extends EventEmitter {
     return transactionUtils.selectUtxos(
       // XXX: Only the `value` property of the UTXO is used in selectUtxos, so the cast is safe
       utxos.filter(utxo => utxo.authorities === 0n) as unknown as Utxo[],
-      amount
+      amount,
     );
   }
 
@@ -1261,7 +1264,7 @@ class HathorWallet extends EventEmitter {
     txId: string,
     index: number,
     value: boolean = true,
-    ttl: number | undefined = undefined
+    ttl: number | undefined = undefined,
   ): Promise<void> {
     await this.storage.utxoSelectAsInput({ txId, index }, value, ttl);
   }
@@ -1277,7 +1280,7 @@ class HathorWallet extends EventEmitter {
    */
   async prepareConsolidateUtxosData(
     destinationAddress: string,
-    options: UtxoOptions = {}
+    options: UtxoOptions = {},
   ): Promise<{
     outputs: Array<{ address: string; value: bigint; token: string }>;
     inputs: Array<{ txId: string; index: number; token: string }>;
@@ -1325,7 +1328,7 @@ class HathorWallet extends EventEmitter {
    */
   async consolidateUtxosSendTransaction(
     destinationAddress: string,
-    options: UtxoOptions = {}
+    options: UtxoOptions = {},
   ): Promise<{
     total_utxos_consolidated: number;
     total_amount: bigint;
@@ -1337,7 +1340,7 @@ class HathorWallet extends EventEmitter {
     }
     const { outputs, inputs, utxos, total_amount } = await this.prepareConsolidateUtxosData(
       destinationAddress,
-      options
+      options,
     );
 
     if (!(await this.isAddressMine(destinationAddress))) {
@@ -1369,7 +1372,7 @@ class HathorWallet extends EventEmitter {
    */
   async consolidateUtxos(
     destinationAddress: string,
-    options: UtxoOptions = {}
+    options: UtxoOptions = {},
   ): Promise<{
     total_utxos_consolidated: number;
     total_amount: bigint;
@@ -1542,7 +1545,7 @@ class HathorWallet extends EventEmitter {
   async sendTransactionInstance(
     address: string,
     value: OutputValueType,
-    options: SendTransactionFullnodeOptions = {}
+    options: SendTransactionFullnodeOptions = {},
   ): Promise<SendTransaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('sendTransaction');
@@ -1572,7 +1575,7 @@ class HathorWallet extends EventEmitter {
   async sendTransaction(
     address: string,
     value: OutputValueType,
-    options: SendTransactionFullnodeOptions = {}
+    options: SendTransactionFullnodeOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.sendTransactionInstance(address, value, options);
     return sendTx.run();
@@ -1588,7 +1591,7 @@ class HathorWallet extends EventEmitter {
    */
   async sendManyOutputsSendTransaction(
     outputs: ProposedOutput[],
-    options: SendManyOutputsOptions = {}
+    options: SendManyOutputsOptions = {},
   ): Promise<SendTransaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('sendManyOutputsTransaction');
@@ -1625,7 +1628,7 @@ class HathorWallet extends EventEmitter {
    */
   async sendManyOutputsTransaction(
     outputs: ProposedOutput[],
-    options: SendManyOutputsOptions = {}
+    options: SendManyOutputsOptions = {},
   ): Promise<Transaction | null> {
     const sendTransaction = await this.sendManyOutputsSendTransaction(outputs, options);
     return sendTransaction.run();
@@ -1715,7 +1718,7 @@ class HathorWallet extends EventEmitter {
     } else {
       this.setState(HathorWallet.CLOSED);
       throw new Error(
-        `Wrong network. server=${info.network} expected=${this.conn.getCurrentNetwork()}`
+        `Wrong network. server=${info.network} expected=${this.conn.getCurrentNetwork()}`,
       );
     }
     return info;
@@ -1808,7 +1811,7 @@ class HathorWallet extends EventEmitter {
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options: CreateTokenOptions = {}
+    options: CreateTokenOptions = {},
   ): Promise<Transaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('createNewToken');
@@ -1869,7 +1872,7 @@ class HathorWallet extends EventEmitter {
         data: newOptions.data,
         isCreateNFT: newOptions.isCreateNFT,
         tokenVersion: newOptions.tokenVersion,
-      }
+      },
     );
     return transactionUtils.prepareTransaction(txData, pin, this.storage, {
       signTx: newOptions.signTx,
@@ -1890,7 +1893,7 @@ class HathorWallet extends EventEmitter {
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options: CreateTokenOptions = {}
+    options: CreateTokenOptions = {},
   ): Promise<SendTransaction> {
     const transaction = await this.prepareCreateNewToken(name, symbol, amount, options);
     return new SendTransaction({ wallet: this, transaction });
@@ -1910,7 +1913,7 @@ class HathorWallet extends EventEmitter {
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options: CreateTokenOptions = {}
+    options: CreateTokenOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.createNewTokenSendTransaction(name, symbol, amount, options);
     return sendTx.runFromMining();
@@ -1967,7 +1970,7 @@ class HathorWallet extends EventEmitter {
   async getAuthorityUtxo(
     tokenUid: string,
     authority: AuthorityType,
-    options: GetAuthorityOptions = {}
+    options: GetAuthorityOptions = {},
   ): Promise<IUtxo[]> {
     let authorityValue: bigint;
     if (authority === AuthorityType.MINT) {
@@ -2014,7 +2017,7 @@ class HathorWallet extends EventEmitter {
   async prepareMintTokensData(
     tokenUid: string,
     amount: OutputValueType,
-    options: MintTokensOptions = {}
+    options: MintTokensOptions = {},
   ): Promise<Transaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('mintTokens');
@@ -2069,7 +2072,7 @@ class HathorWallet extends EventEmitter {
       mintAddress,
       amount,
       this.storage,
-      mintOptions
+      mintOptions,
     );
     return transactionUtils.prepareTransaction(txData, pin, this.storage, {
       signTx: newOptions.signTx,
@@ -2090,7 +2093,7 @@ class HathorWallet extends EventEmitter {
   async mintTokensSendTransaction(
     tokenUid: string,
     amount: OutputValueType,
-    options: MintTokensOptions = {}
+    options: MintTokensOptions = {},
   ): Promise<SendTransaction> {
     const transaction = await this.prepareMintTokensData(tokenUid, amount, options);
     return new SendTransaction({ wallet: this, transaction });
@@ -2111,7 +2114,7 @@ class HathorWallet extends EventEmitter {
   async mintTokens(
     tokenUid: string,
     amount: OutputValueType,
-    options: MintTokensOptions = {}
+    options: MintTokensOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.mintTokensSendTransaction(tokenUid, amount, options);
     return sendTx.runFromMining();
@@ -2130,7 +2133,7 @@ class HathorWallet extends EventEmitter {
   async prepareMeltTokensData(
     tokenUid: string,
     amount: OutputValueType,
-    options: MeltTokensOptions = {}
+    options: MeltTokensOptions = {},
   ): Promise<Transaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('meltTokens');
@@ -2183,7 +2186,7 @@ class HathorWallet extends EventEmitter {
       newOptions.address || (await this.getCurrentAddress()).address,
       amount,
       this.storage,
-      meltOptions
+      meltOptions,
     );
     return transactionUtils.prepareTransaction(txData, pin, this.storage, {
       signTx: newOptions.signTx,
@@ -2204,7 +2207,7 @@ class HathorWallet extends EventEmitter {
   async meltTokensSendTransaction(
     tokenUid: string,
     amount: OutputValueType,
-    options: MeltTokensOptions = {}
+    options: MeltTokensOptions = {},
   ): Promise<SendTransaction> {
     const transaction = await this.prepareMeltTokensData(tokenUid, amount, options);
     return new SendTransaction({ wallet: this, transaction });
@@ -2225,7 +2228,7 @@ class HathorWallet extends EventEmitter {
   async meltTokens(
     tokenUid: string,
     amount: OutputValueType,
-    options: MeltTokensOptions = {}
+    options: MeltTokensOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.meltTokensSendTransaction(tokenUid, amount, options);
     return sendTx.runFromMining();
@@ -2246,7 +2249,7 @@ class HathorWallet extends EventEmitter {
     tokenUid: string,
     type: AuthorityType,
     destinationAddress: string,
-    options: DelegateAuthorityOptions = {}
+    options: DelegateAuthorityOptions = {},
   ): Promise<Transaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('delegateAuthority');
@@ -2286,7 +2289,7 @@ class HathorWallet extends EventEmitter {
       delegateInput[0],
       destinationAddress,
       this.storage,
-      createAnother
+      createAnother,
     );
 
     return transactionUtils.prepareTransaction(txData, pin, this.storage);
@@ -2308,13 +2311,13 @@ class HathorWallet extends EventEmitter {
     tokenUid: string,
     type: AuthorityType,
     destinationAddress: string,
-    options: DelegateAuthorityOptions = {}
+    options: DelegateAuthorityOptions = {},
   ): Promise<SendTransaction> {
     const transaction = await this.prepareDelegateAuthorityData(
       tokenUid,
       type,
       destinationAddress,
-      options
+      options,
     );
     return new SendTransaction({ wallet: this, transaction });
   }
@@ -2336,13 +2339,13 @@ class HathorWallet extends EventEmitter {
     tokenUid: string,
     type: AuthorityType,
     destinationAddress: string,
-    options: DelegateAuthorityOptions = {}
+    options: DelegateAuthorityOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.delegateAuthoritySendTransaction(
       tokenUid,
       type,
       destinationAddress,
-      options
+      options,
     );
     return sendTx.runFromMining();
   }
@@ -2362,7 +2365,7 @@ class HathorWallet extends EventEmitter {
     tokenUid: string,
     type: AuthorityType,
     count: number,
-    options: DestroyAuthorityOptions = {}
+    options: DestroyAuthorityOptions = {},
   ): Promise<Transaction> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('destroyAuthority');
@@ -2422,7 +2425,7 @@ class HathorWallet extends EventEmitter {
     tokenUid: string,
     type: AuthorityType,
     count: number,
-    options: DestroyAuthorityOptions = {}
+    options: DestroyAuthorityOptions = {},
   ): Promise<SendTransaction> {
     const transaction = await this.prepareDestroyAuthorityData(tokenUid, type, count, options);
     return new SendTransaction({ wallet: this, transaction });
@@ -2445,7 +2448,7 @@ class HathorWallet extends EventEmitter {
     tokenUid: string,
     type: AuthorityType,
     count: number,
-    options: DestroyAuthorityOptions = {}
+    options: DestroyAuthorityOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.destroyAuthoritySendTransaction(tokenUid, type, count, options);
     return sendTx.runFromMining();
@@ -2603,7 +2606,7 @@ class HathorWallet extends EventEmitter {
    * */
   async getTxBalance(
     tx: IHistoryTx,
-    optionsParam: { includeAuthorities?: boolean } = {}
+    optionsParam: { includeAuthorities?: boolean } = {},
   ): Promise<Record<string, bigint>> {
     const balance: Record<string, bigint> = {};
     const fullBalance = await transactionUtils.getTxBalance(tx, this.storage);
@@ -2652,7 +2655,7 @@ class HathorWallet extends EventEmitter {
     symbol: string,
     amount: OutputValueType,
     data: string,
-    options: CreateNFTOptions = {}
+    options: CreateNFTOptions = {},
   ): Promise<SendTransaction> {
     const newOptions: CreateTokenOptions = {
       address: null,
@@ -2689,7 +2692,7 @@ class HathorWallet extends EventEmitter {
     symbol: string,
     amount: OutputValueType,
     data: string,
-    options: CreateNFTOptions = {}
+    options: CreateNFTOptions = {},
   ): Promise<Transaction | null> {
     const sendTx = await this.createNFTSendTransaction(name, symbol, amount, data, options);
     return sendTx.runFromMining();
@@ -2707,7 +2710,7 @@ class HathorWallet extends EventEmitter {
 
     for await (const { tx: spentTx, input, index } of this.storage.getSpentTxs(tx.inputs)) {
       const addressInfo = await this.storage.getAddressInfo(
-        spentTx.outputs[input.index].decoded.address!
+        spentTx.outputs[input.index].decoded.address!,
       );
       if (addressInfo === null) {
         continue;
@@ -2734,7 +2737,7 @@ class HathorWallet extends EventEmitter {
    */
   async getSignatures(
     tx: Transaction,
-    { pinCode = null }: { pinCode?: string | null } = {}
+    { pinCode = null }: { pinCode?: string | null } = {},
   ): Promise<Array<ISignature>> {
     if (await this.isReadonly()) {
       throw new WalletFromXPubGuard('getSignatures');
@@ -2855,7 +2858,7 @@ class HathorWallet extends EventEmitter {
   async graphvizNeighborsQuery(
     txId: string,
     graphType: string,
-    maxLevel: number
+    maxLevel: number,
   ): Promise<GraphvizNeighboursDotResponse> {
     const graphvizData: GraphvizNeighboursResponse = await new Promise<GraphvizNeighboursResponse>(
       (resolve, reject) => {
@@ -2863,7 +2866,7 @@ class HathorWallet extends EventEmitter {
           .getGraphvizNeighbors(txId, graphType, maxLevel, resolve)
           .then(() => reject(new Error('API client did not use the callback')))
           .catch(err => reject(err));
-      }
+      },
     );
 
     const isGraphvizError = (d: unknown): d is GraphvizNeighboursErrorResponse =>
@@ -2923,7 +2926,7 @@ class HathorWallet extends EventEmitter {
      */
     const hydrateWithTokenUid = <T extends { token_data: number }>(
       io: T,
-      tokens: Array<{ uid: string }>
+      tokens: Array<{ uid: string }>,
     ): T & { token: string } => {
       const { token_data } = io;
 
@@ -2952,7 +2955,7 @@ class HathorWallet extends EventEmitter {
     }
 
     fullTx.tx.outputs = fullTx.tx.outputs.map(output =>
-      hydrateWithTokenUid(output, fullTx.tx.tokens)
+      hydrateWithTokenUid(output, fullTx.tx.tokens),
     );
     fullTx.tx.inputs = fullTx.tx.inputs.map(input => hydrateWithTokenUid(input, fullTx.tx.tokens));
 
@@ -2972,7 +2975,7 @@ class HathorWallet extends EventEmitter {
        * @returns Token config
        */
       const getToken = (
-        tokenUid: string
+        tokenUid: string,
       ): { uid: string; name: string | null; symbol: string | null } => {
         if (tokenUid === NATIVE_TOKEN_UID) {
           return this.storage.getNativeTokenData();
@@ -3047,7 +3050,7 @@ class HathorWallet extends EventEmitter {
     method: string,
     address: string,
     data: FullnodeCreateNanoTxData,
-    options: Omit<CreateNanoTxOptions, 'signTx'> = {}
+    options: Omit<CreateNanoTxOptions, 'signTx'> = {},
   ): Promise<Transaction | null> {
     const sendTransaction = await this.createNanoContractTransaction(method, address, data, {
       ...options,
@@ -3068,7 +3071,7 @@ class HathorWallet extends EventEmitter {
     method: string,
     address: string,
     data: FullnodeCreateNanoTxData,
-    options: CreateNanoTxOptions = {}
+    options: CreateNanoTxOptions = {},
   ): Promise<SendTransaction> {
     if (await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('createNanoContractTransaction');
@@ -3085,7 +3088,7 @@ class HathorWallet extends EventEmitter {
     const addressInfo = await this.storage.getAddressInfo(address);
     if (!addressInfo) {
       throw new NanoContractTransactionError(
-        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`,
       );
     }
 
@@ -3135,14 +3138,14 @@ class HathorWallet extends EventEmitter {
     address: string,
     data: FullnodeCreateNanoTxData,
     createTokenOptions: CreateNanoTokenTxOptions,
-    options: CreateNanoTxOptions = {}
+    options: CreateNanoTxOptions = {},
   ): Promise<Transaction | null> {
     const sendTransaction = await this.createNanoContractCreateTokenTransaction(
       method,
       address,
       data,
       createTokenOptions,
-      options
+      options,
     );
     return sendTransaction.runFromMining();
   }
@@ -3161,7 +3164,7 @@ class HathorWallet extends EventEmitter {
     address: string,
     data: FullnodeCreateNanoTxData,
     createTokenOptions: CreateNanoTokenTxOptions,
-    options: CreateNanoTxOptions = {}
+    options: CreateNanoTxOptions = {},
   ): Promise<SendTransaction> {
     if (await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('createNanoContractCreateTokenTransaction');
@@ -3195,7 +3198,7 @@ class HathorWallet extends EventEmitter {
       const isAddressMine = await this.isAddressMine(newCreateTokenOptions.mintAuthorityAddress);
       if (!isAddressMine) {
         throw new NanoContractTransactionError(
-          'The mint authority address must belong to your wallet.'
+          'The mint authority address must belong to your wallet.',
         );
       }
     }
@@ -3208,7 +3211,7 @@ class HathorWallet extends EventEmitter {
       const isAddressMine = await this.isAddressMine(newCreateTokenOptions.meltAuthorityAddress);
       if (!isAddressMine) {
         throw new NanoContractTransactionError(
-          'The melt authority address must belong to your wallet.'
+          'The melt authority address must belong to your wallet.',
         );
       }
     }
@@ -3220,7 +3223,7 @@ class HathorWallet extends EventEmitter {
     const addressInfo = await this.storage.getAddressInfo(address);
     if (!addressInfo) {
       throw new NanoContractTransactionError(
-        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`,
       );
     }
     // Build and send transaction
@@ -3234,7 +3237,7 @@ class HathorWallet extends EventEmitter {
       .setArgs(data.args!)
       .setVertexType(
         NanoContractVertexType.CREATE_TOKEN_TRANSACTION,
-        newCreateTokenOptions as NanoContractBuilderCreateTokenOptions
+        newCreateTokenOptions as NanoContractBuilderCreateTokenOptions,
       );
 
     // Set max fee if declared
@@ -3316,7 +3319,7 @@ class HathorWallet extends EventEmitter {
   async syncHistory(
     startIndex: number,
     count: number,
-    shouldProcessHistory: boolean = false
+    shouldProcessHistory: boolean = false,
   ): Promise<void> {
     if (!(await getSupportedSyncMode(this.storage)).includes(this.historySyncMode)) {
       throw new Error('Trying to use an unsupported sync method for this wallet.');
@@ -3324,14 +3327,14 @@ class HathorWallet extends EventEmitter {
     let syncMode = this.historySyncMode;
     if (
       [HistorySyncMode.MANUAL_STREAM_WS, HistorySyncMode.XPUB_STREAM_WS].includes(
-        this.historySyncMode
+        this.historySyncMode,
       ) &&
       !(await this.conn.hasCapability('history-streaming'))
     ) {
       // History sync mode is streaming but fullnode is not streaming capable.
       // We revert to the http polling default.
       this.logger.debug(
-        'Either fullnode does not support history-streaming or has not sent a capabilities event'
+        'Either fullnode does not support history-streaming or has not sent a capabilities event',
       );
       this.logger.debug('Falling back to http polling API');
       syncMode = HistorySyncMode.POLLING_HTTP_API;
@@ -3373,7 +3376,7 @@ class HathorWallet extends EventEmitter {
    */
   async buildTxTemplate(
     template: z.input<typeof TransactionTemplate>,
-    options: BuildTxTemplateOptions = {}
+    options: BuildTxTemplateOptions = {},
   ): Promise<Transaction> {
     const newOptions = {
       signTx: false,
@@ -3401,7 +3404,7 @@ class HathorWallet extends EventEmitter {
    */
   async runTxTemplate(
     template: z.input<typeof TransactionTemplate>,
-    pinCode?: string
+    pinCode?: string,
   ): Promise<Transaction | null> {
     const transaction = await this.buildTxTemplate(template, {
       signTx: true,
@@ -3420,7 +3423,7 @@ class HathorWallet extends EventEmitter {
   async createAndSendOnChainBlueprintTransaction(
     code: string,
     address: string,
-    options: CreateOnChainBlueprintTxOptions = {}
+    options: CreateOnChainBlueprintTxOptions = {},
   ): Promise<Transaction | null> {
     const sendTransaction = await this.createOnChainBlueprintTransaction(code, address, options);
     return sendTransaction.runFromMining();
@@ -3436,7 +3439,7 @@ class HathorWallet extends EventEmitter {
   async createOnChainBlueprintTransaction(
     code: string,
     address: string,
-    options: CreateOnChainBlueprintTxOptions = {}
+    options: CreateOnChainBlueprintTxOptions = {},
   ): Promise<SendTransaction> {
     if (await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('createOnChainBlueprintTransaction');
@@ -3451,7 +3454,7 @@ class HathorWallet extends EventEmitter {
     const addressInfo = await this.storage.getAddressInfo(address);
     if (!addressInfo) {
       throw new NanoContractTransactionError(
-        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`,
       );
     }
     const pubkeyStr = await this.storage.getAddressPubkey(addressInfo.bip32AddressIndex);
@@ -3486,7 +3489,7 @@ class HathorWallet extends EventEmitter {
     const addressInfo = await this.storage.getAddressInfo(address);
     if (!addressInfo) {
       throw new NanoContractTransactionError(
-        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`,
       );
     }
 
@@ -3570,7 +3573,7 @@ class HathorWallet extends EventEmitter {
   async enableSingleAddressMode(): Promise<void> {
     if (await this.hasTxOutsideFirstAddress()) {
       throw new HasTxOutsideFirstAddressError(
-        'Cannot enable single-address policy: wallet has transactions on addresses other than the first'
+        'Cannot enable single-address policy: wallet has transactions on addresses other than the first',
       );
     }
 

--- a/src/pushNotification.ts
+++ b/src/pushNotification.ts
@@ -1,6 +1,6 @@
-import HathorWalletServiceWallet from './wallet/wallet';
-import { axiosInstance } from './wallet/api/walletServiceAxios';
 import { WalletRequestError } from './errors';
+import { axiosInstance } from './wallet/api/walletServiceAxios';
+import HathorWalletServiceWallet from './wallet/wallet';
 
 export class PushNotification {
   /**
@@ -11,7 +11,7 @@ export class PushNotification {
    */
   static async registerDevice(
     wallet: HathorWalletServiceWallet,
-    payload: PushRegisterRequestData
+    payload: PushRegisterRequestData,
   ): Promise<PushNotificationResult> {
     wallet.failIfWalletNotReady();
     const data = await walletServiceClient.pushRegister(wallet, payload);
@@ -26,7 +26,7 @@ export class PushNotification {
    */
   static async updateDevice(
     wallet: HathorWalletServiceWallet,
-    payload: PushUpdateRequestData
+    payload: PushUpdateRequestData,
   ): Promise<PushNotificationResult> {
     wallet.failIfWalletNotReady();
     const data = await walletServiceClient.pushUpdate(wallet, payload);
@@ -41,7 +41,7 @@ export class PushNotification {
    */
   static async unregisterDevice(
     wallet: HathorWalletServiceWallet,
-    deviceId: string
+    deviceId: string,
   ): Promise<PushNotificationResult> {
     wallet.failIfWalletNotReady();
     const data = await walletServiceClient.pushUnregister(wallet, deviceId);
@@ -52,7 +52,7 @@ export class PushNotification {
 const walletServiceClient = {
   async pushRegister(
     wallet: HathorWalletServiceWallet,
-    payload: PushRegisterRequestData
+    payload: PushRegisterRequestData,
   ): Promise<PushRegisterResponseData> {
     const axios = await axiosInstance(wallet, true);
 
@@ -67,7 +67,7 @@ const walletServiceClient = {
 
   async pushUpdate(
     wallet: HathorWalletServiceWallet,
-    payload: PushUpdateRequestData
+    payload: PushUpdateRequestData,
   ): Promise<PushUpdateResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.put<PushUpdateResponseData>('wallet/push/update', payload);
@@ -81,7 +81,7 @@ const walletServiceClient = {
 
   async pushUnregister(
     wallet: HathorWalletServiceWallet,
-    deviceId: string
+    deviceId: string,
   ): Promise<PushUnregisterResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.delete(`wallet/push/unregister/${deviceId}`);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+
 import {
   IAddressMetadataAsRecord,
   IAuthoritiesBalance,

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Storage } from './storage';
 import { MemoryStore } from './memory_store';
+import { Storage } from './storage';
 
 const store = new MemoryStore();
 const storage = new Storage(store);
 
-export { Storage };
 export { MemoryStore };
+export { Storage };
 
 export default storage;

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -6,6 +6,8 @@
  */
 
 import { orderBy, cloneDeep } from 'lodash';
+
+import { GAP_LIMIT, NATIVE_TOKEN_UID } from '../constants';
 import {
   IStore,
   IAddressInfo,
@@ -26,7 +28,6 @@ import {
   INcData,
   TokenVersion,
 } from '../types';
-import { GAP_LIMIT, NATIVE_TOKEN_UID } from '../constants';
 import transactionUtils from '../utils/transaction';
 
 const DEFAULT_ADDRESSES_WALLET_DATA = {
@@ -328,7 +329,7 @@ export class MemoryStore implements IStore {
     if (markAsUsed) {
       // Will move the address index only if we have not reached the gap limit
       await this.setCurrentAddressIndex(
-        Math.min(this.walletData.lastLoadedAddressIndex, this.walletData.currentAddressIndex + 1)
+        Math.min(this.walletData.lastLoadedAddressIndex, this.walletData.currentAddressIndex + 1),
       );
     }
     return addressInfo.base58;
@@ -467,7 +468,7 @@ export class MemoryStore implements IStore {
     }
     if (this.walletData.currentAddressIndex < maxIndex) {
       await this.setCurrentAddressIndex(
-        Math.min(maxIndex + 1, this.walletData.lastLoadedAddressIndex)
+        Math.min(maxIndex + 1, this.walletData.lastLoadedAddressIndex),
       );
     }
     this.walletData.lastUsedAddressIndex = maxIndex;
@@ -927,7 +928,7 @@ export class MemoryStore implements IStore {
   async cleanStorage(
     cleanHistory: boolean = false,
     cleanAddresses: boolean = false,
-    cleanTokens: boolean = false
+    cleanTokens: boolean = false,
   ): Promise<void> {
     if (cleanHistory) {
       this.tokens = new Map<string, ITokenData>();

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -6,7 +6,20 @@
  */
 
 import { HDPublicKey } from 'bitcore-lib';
+
+import config, { Config } from '../config';
+import {
+  NATIVE_TOKEN_UID,
+  MAX_INPUTS,
+  MAX_OUTPUTS,
+  TOKEN_DEPOSIT_PERCENTAGE,
+  DECIMAL_PLACES,
+  DEFAULT_NATIVE_TOKEN_CONFIG,
+} from '../constants';
+import { UninitializedWalletError } from '../errors';
 import Input from '../models/input';
+import Transaction from '../models/transaction';
+import FullNodeConnection from '../new/connection';
 import {
   ApiVersion,
   IStorage,
@@ -41,27 +54,15 @@ import {
   AuthorityType,
   TokenVersion,
 } from '../types';
-import transactionUtils from '../utils/transaction';
+import { getAddressType } from '../utils/address';
+import { decryptData, checkPassword } from '../utils/crypto';
 import {
   processHistory as processHistoryUtil,
   processSingleTx as processSingleTxUtil,
   processUtxoUnlock,
 } from '../utils/storage';
-import config, { Config } from '../config';
-import { decryptData, checkPassword } from '../utils/crypto';
-import FullNodeConnection from '../new/connection';
-import { getAddressType } from '../utils/address';
+import transactionUtils from '../utils/transaction';
 import walletUtils from '../utils/wallet';
-import {
-  NATIVE_TOKEN_UID,
-  MAX_INPUTS,
-  MAX_OUTPUTS,
-  TOKEN_DEPOSIT_PERCENTAGE,
-  DECIMAL_PLACES,
-  DEFAULT_NATIVE_TOKEN_CONFIG,
-} from '../constants';
-import { UninitializedWalletError } from '../errors';
-import Transaction from '../models/transaction';
 
 export const DEFAULT_ADDRESS_META: IAddressMetadata = {
   numTransactions: 0,
@@ -214,7 +215,7 @@ export class Storage implements IStorage {
    * @returns {Promise<(IAddressInfo & Partial<IAddressMetadata> & { seqnum: number })|null>} The address info or null if not found
    */
   async getAddressInfo(
-    base58: string
+    base58: string,
   ): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number }) | null> {
     const address = await this.store.getAddress(base58);
     if (address === null) {
@@ -344,7 +345,7 @@ export class Storage implements IStorage {
    * @returns {AsyncGenerator<{tx: IHistoryTx, input: Input, index: number}>}
    */
   async *getSpentTxs(
-    inputs: Input[]
+    inputs: Input[],
   ): AsyncGenerator<{ tx: IHistoryTx; input: Input; index: number }> {
     for await (const [index, input] of inputs.entries()) {
       const tx = await this.getTx(input.hash);
@@ -475,7 +476,7 @@ export class Storage implements IStorage {
    * @returns {AsyncGenerator<IUtxo, any, unknown>}
    */
   async *selectUtxos(
-    options: Omit<IUtxoFilterOptions, 'reward_lock'> = {}
+    options: Omit<IUtxoFilterOptions, 'reward_lock'> = {},
   ): AsyncGenerator<IUtxo, void, void> {
     const filterSelected = (utxo: IUtxo): boolean => {
       const utxoId = `${utxo.txId}:${utxo.index}`;
@@ -520,7 +521,7 @@ export class Storage implements IStorage {
     token: string,
     authorities: OutputValueType,
     changeAddress: string,
-    chooseInputs: boolean
+    chooseInputs: boolean,
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     const newInputs: IDataInput[] = [];
     const newOutputs: IDataOutput[] = [];
@@ -541,7 +542,7 @@ export class Storage implements IStorage {
       if (!chooseInputs) {
         // We cannot choose inputs, so we fail
         throw new Error(
-          `Insufficient funds in the given inputs for ${token}, missing ${singleBalance} more tokens.`
+          `Insufficient funds in the given inputs for ${token}, missing ${singleBalance} more tokens.`,
         );
       }
       // We have a surplus of this token on the outputs, so we need to find utxos to match
@@ -624,7 +625,7 @@ export class Storage implements IStorage {
   async matchTokenBalance(
     token: string,
     balance: Record<'funds' | AuthorityType, OutputValueType>,
-    { changeAddress, skipAuthorities = true, chooseInputs = true }: IFillTxOptions = {}
+    { changeAddress, skipAuthorities = true, chooseInputs = true }: IFillTxOptions = {},
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     const addressForChange = changeAddress || (await this.getCurrentAddress());
     // balance holds the balance of all tokens on the transaction
@@ -636,7 +637,7 @@ export class Storage implements IStorage {
       token,
       0n,
       addressForChange,
-      chooseInputs
+      chooseInputs,
     );
     newInputs.push(...fundsInputs);
     newOutputs.push(...fundsOutputs);
@@ -649,7 +650,7 @@ export class Storage implements IStorage {
         token,
         1n,
         addressForChange,
-        chooseInputs
+        chooseInputs,
       );
       // match melt
       const { inputs: meltInputs, outputs: meltOutputs } = await this.matchBalanceSelection(
@@ -657,7 +658,7 @@ export class Storage implements IStorage {
         token,
         2n,
         addressForChange,
-        chooseInputs
+        chooseInputs,
       );
 
       newInputs.push(...mintInputs, ...meltInputs);
@@ -683,13 +684,13 @@ export class Storage implements IStorage {
   async fillTx(
     token: string,
     tx: IDataTx,
-    options: IFillTxOptions = {}
+    options: IFillTxOptions = {},
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }> {
     const tokenBalance = await transactionUtils.calculateTxBalanceToFillTx(token, tx);
     const { inputs: newInputs, outputs: newOutputs } = await this.matchTokenBalance(
       token,
       tokenBalance,
-      options
+      options,
     );
 
     // Validate if we will add too many inputs/outputs
@@ -963,7 +964,7 @@ export class Storage implements IStorage {
   async cleanStorage(
     cleanHistory: boolean = false,
     cleanAddresses: boolean = false,
-    cleanTokens: boolean = false
+    cleanTokens: boolean = false,
   ): Promise<void> {
     return this.store.cleanStorage(cleanHistory, cleanAddresses, cleanTokens);
   }
@@ -1030,7 +1031,7 @@ export class Storage implements IStorage {
     const newAccessData = walletUtils.changeEncryptionPassword(
       accessData,
       oldPassword,
-      newPassword
+      newPassword,
     );
 
     // Save the changes made

--- a/src/swapService/swapConnection.ts
+++ b/src/swapService/swapConnection.ts
@@ -6,9 +6,10 @@
  */
 
 import { EventEmitter } from 'events';
+
+import { ILogger, getDefaultLogger } from '../types';
 import { ConnectionState } from '../wallet/types';
 import GenericWebSocket from '../websocket';
-import { ILogger, getDefaultLogger } from '../types';
 
 /**
  * This is a Websocket Connection with the Atomic Swap Service

--- a/src/sync/stream.ts
+++ b/src/sync/stream.ts
@@ -6,7 +6,11 @@
  */
 import { Address as BitcoreAddress, HDPublicKey } from 'bitcore-lib';
 import queueMicrotask from 'queue-microtask';
+
+import Network from '../models/network';
+import Queue from '../models/queue';
 import FullNodeConnection from '../new/connection';
+import { IHistoryTxSchema } from '../schemas';
 import {
   IStorage,
   IHistoryTx,
@@ -15,9 +19,6 @@ import {
   IAddressInfo,
   ILogger,
 } from '../types';
-import Network from '../models/network';
-import Queue from '../models/queue';
-import { IHistoryTxSchema } from '../schemas';
 /* eslint max-classes-per-file: ["error", 2] */
 
 const QUEUE_GRACEFUL_SHUTDOWN_LIMIT = 10000;
@@ -71,7 +72,7 @@ function isStreamSyncHistoryVertex(data: IStreamSyncHistoryData): data is IStrea
 }
 
 function isStreamSyncHistoryAddress(
-  data: IStreamSyncHistoryData
+  data: IStreamSyncHistoryData,
 ): data is IStreamSyncHistoryAddress {
   return data.type === 'stream:history:address';
 }
@@ -177,7 +178,7 @@ class StreamStatsManager {
   ack(seq: number) {
     this.ackCounter += 1;
     this.logger.debug(
-      `[*] ACKed ${seq} with queue at ${this.q.size()}. Sent ACK ${this.ackCounter} times`
+      `[*] ACKed ${seq} with queue at ${this.q.size()}. Sent ACK ${this.ackCounter} times`,
     );
   }
 
@@ -189,7 +190,7 @@ class StreamStatsManager {
     if (!this.inTimer) {
       this.inTimer = setTimeout(() => {
         this.logger.debug(
-          `[+] => in_rate: ${(1000 * this.recvCounter) / this.sampleInterval} items/s`
+          `[+] => in_rate: ${(1000 * this.recvCounter) / this.sampleInterval} items/s`,
         );
         this.inTimer = undefined;
         this.recvCounter = -1;
@@ -207,7 +208,7 @@ class StreamStatsManager {
     if (!this.outTimer) {
       this.outTimer = setTimeout(() => {
         this.logger.debug(
-          `[+] <= out_rate: ${(1000 * this.procCounter) / this.sampleInterval} items/s`
+          `[+] <= out_rate: ${(1000 * this.procCounter) / this.sampleInterval} items/s`,
         );
         this.outTimer = undefined;
         this.procCounter = -1;
@@ -237,7 +238,7 @@ export function loadAddressesCPUIntensive(
   startIndex: number,
   count: number,
   xpubkey: string,
-  networkName: string
+  networkName: string,
 ): [number, string][] {
   const addresses: [number, string][] = [];
   const stopIndex = startIndex + count;
@@ -261,7 +262,7 @@ export async function xpubStreamSyncHistory(
   _count: number,
   storage: IStorage,
   connection: FullNodeConnection,
-  shouldProcessHistory: boolean = false
+  shouldProcessHistory: boolean = false,
 ) {
   let firstIndex = startIndex;
   const scanPolicyData = await storage.getScanningPolicyData();
@@ -276,7 +277,7 @@ export async function xpubStreamSyncHistory(
     firstIndex,
     storage,
     connection,
-    HistorySyncMode.XPUB_STREAM_WS
+    HistorySyncMode.XPUB_STREAM_WS,
   );
   await streamSyncHistory(manager, shouldProcessHistory);
 }
@@ -286,7 +287,7 @@ export async function manualStreamSyncHistory(
   _count: number,
   storage: IStorage,
   connection: FullNodeConnection,
-  shouldProcessHistory: boolean = false
+  shouldProcessHistory: boolean = false,
 ) {
   let firstIndex = startIndex;
   const scanPolicyData = await storage.getScanningPolicyData();
@@ -301,7 +302,7 @@ export async function manualStreamSyncHistory(
     firstIndex,
     storage,
     connection,
-    HistorySyncMode.MANUAL_STREAM_WS
+    HistorySyncMode.MANUAL_STREAM_WS,
   );
   await streamSyncHistory(manager, shouldProcessHistory);
 }
@@ -374,7 +375,7 @@ export class StreamManager extends AbortController {
     startIndex: number,
     storage: IStorage,
     connection: FullNodeConnection,
-    mode: HistorySyncMode
+    mode: HistorySyncMode,
   ) {
     super();
     this.streamId = generateStreamId();
@@ -442,7 +443,7 @@ export class StreamManager extends AbortController {
       {
         once: true,
         signal: this.signal,
-      }
+      },
     );
   }
 
@@ -480,7 +481,7 @@ export class StreamManager extends AbortController {
         this.lastLoadedIndex + 1,
         this.ADDRESSES_PER_MESSAGE,
         this.xpubkey,
-        this.network
+        this.network,
       );
       this.lastLoadedIndex += this.ADDRESSES_PER_MESSAGE;
       this.connection.sendManualStreamingHistory(
@@ -488,7 +489,7 @@ export class StreamManager extends AbortController {
         this.lastLoadedIndex + 1,
         batch,
         false,
-        this.gapLimit
+        this.gapLimit,
       );
 
       // Free main loop to run other tasks and queue next batch
@@ -640,7 +641,7 @@ export class StreamManager extends AbortController {
           this.streamId,
           this.lastLoadedIndex + 1,
           this.xpubkey,
-          this.gapLimit
+          this.gapLimit,
         );
         break;
       case HistorySyncMode.MANUAL_STREAM_WS:
@@ -651,10 +652,10 @@ export class StreamManager extends AbortController {
             this.lastLoadedIndex + 1,
             this.ADDRESSES_PER_MESSAGE,
             this.xpubkey,
-            this.network
+            this.network,
           ),
           true,
-          this.gapLimit
+          this.gapLimit,
         );
         this.lastLoadedIndex += this.ADDRESSES_PER_MESSAGE;
         break;
@@ -716,7 +717,7 @@ function buildListener(manager: StreamManager, resolve: () => void) {
     if (wsData.id !== manager.streamId) {
       // Check that the stream id is the same we sent
       manager.logger.error(
-        `Received stream event for id ${wsData.id} while expecting ${manager.streamId}`
+        `Received stream event for id ${wsData.id} while expecting ${manager.streamId}`,
       );
       return;
     }
@@ -756,7 +757,7 @@ function buildListener(manager: StreamManager, resolve: () => void) {
  */
 export async function streamSyncHistory(
   manager: StreamManager,
-  shouldProcessHistory: boolean
+  shouldProcessHistory: boolean,
 ): Promise<void> {
   await manager.setupStream();
 
@@ -776,7 +777,7 @@ export async function streamSyncHistory(
         () => {
           resolve();
         },
-        { once: true }
+        { once: true },
       );
       // If it is already aborted for some reason, just exit
       if (manager.signal.aborted) {
@@ -792,7 +793,7 @@ export async function streamSyncHistory(
         () => {
           manager.connection.removeListener('stream', listener);
         },
-        { once: true }
+        { once: true },
       );
 
       // Send the start message to the fullnode

--- a/src/template/transaction/builder.ts
+++ b/src/template/transaction/builder.ts
@@ -6,7 +6,9 @@
  */
 
 import { z } from 'zod';
+
 import { JSONBigInt } from '../../utils/bigint';
+
 import {
   TxTemplateInstruction,
   TransactionTemplate,

--- a/src/template/transaction/context.ts
+++ b/src/template/transaction/context.ts
@@ -7,6 +7,16 @@
 /* eslint max-classes-per-file: ["error", 3] */
 
 import { z } from 'zod';
+
+import {
+  CREATE_TOKEN_TX_VERSION,
+  DEFAULT_TX_VERSION,
+  NATIVE_TOKEN_UID,
+  FEE_PER_OUTPUT,
+  FEE_DIVISOR,
+} from '../../constants';
+import Input from '../../models/input';
+import Output from '../../models/output';
 import {
   TokenVersion,
   IHistoryTx,
@@ -15,16 +25,8 @@ import {
   getDefaultLogger,
   AuthorityType,
 } from '../../types';
-import Input from '../../models/input';
-import Output from '../../models/output';
 import transactionUtils from '../../utils/transaction';
-import {
-  CREATE_TOKEN_TX_VERSION,
-  DEFAULT_TX_VERSION,
-  NATIVE_TOKEN_UID,
-  FEE_PER_OUTPUT,
-  FEE_DIVISOR,
-} from '../../constants';
+
 import { NanoAction } from './instructions';
 import { ITxTemplateInterpreter, IWalletTokenDetails } from './types';
 
@@ -205,7 +207,7 @@ export class TxBalance {
   addCreatedTokenOutputAuthority(
     count: number,
     authority: AuthorityType,
-    tokenVersion: TokenVersion
+    tokenVersion: TokenVersion,
   ) {
     const balance = this.getCreatedTokenBalance(tokenVersion);
     if (authority === AuthorityType.MINT) {
@@ -257,7 +259,7 @@ export class NanoContractContext {
     method: string,
     caller: string,
     args: unknown[],
-    actions: z.output<typeof NanoAction>[]
+    actions: z.output<typeof NanoAction>[],
   ) {
     this.id = id;
     this.method = method;
@@ -345,7 +347,7 @@ export class TxTemplateContext {
   useCreateTokenTxContext() {
     if (this.tokens.length !== 0) {
       throw new Error(
-        `Trying to build a create token tx with ${this.tokens.length} tokens on the array`
+        `Trying to build a create token tx with ${this.tokens.length} tokens on the array`,
       );
     }
     this.version = CREATE_TOKEN_TX_VERSION;
@@ -360,7 +362,7 @@ export class TxTemplateContext {
     method: string,
     caller: string,
     args: unknown[],
-    actions: z.output<typeof NanoAction>[]
+    actions: z.output<typeof NanoAction>[],
   ) {
     if (this.nanoContext) {
       throw new Error('Already building a nano contract tx.');
@@ -463,7 +465,7 @@ export class TxTemplateContext {
       throw new Error(
         `Token version not found for token ${token}. ` +
           `Call cacheTokenDetails or addToken first. ` +
-          `Currently cached tokens: [${cachedTokens.join(', ') || 'none'}]`
+          `Currently cached tokens: [${cachedTokens.join(', ') || 'none'}]`,
       );
     }
     return tokenDetails.tokenInfo.version;
@@ -501,7 +503,7 @@ export class TxTemplateContext {
   addFee(token: string, amount: bigint) {
     if (token !== NATIVE_TOKEN_UID && amount % BigInt(FEE_DIVISOR)) {
       throw new Error(
-        `Invalid fee amount for token ${token}: ${amount}. Must be a multiple of ${FEE_DIVISOR}`
+        `Invalid fee amount for token ${token}: ${amount}. Must be a multiple of ${FEE_DIVISOR}`,
       );
     }
     const fee = this._fees.get(token) || 0n;

--- a/src/template/transaction/executor.ts
+++ b/src/template/transaction/executor.ts
@@ -5,8 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { z } from 'zod';
 import { clone, shuffle } from 'lodash';
+import { z } from 'zod';
+
+import {
+  NATIVE_TOKEN_UID,
+  TOKEN_AUTHORITY_MASK,
+  TOKEN_MELT_MASK,
+  TOKEN_MINT_MASK,
+} from '../../constants';
+import Input from '../../models/input';
+import Output from '../../models/output';
+import ScriptData from '../../models/script_data';
+import { AuthorityType, isAuthorityType, OutputValueType, TokenVersion } from '../../types';
+import { createOutputScriptFromAddress } from '../../utils/address';
+import { JSONBigInt } from '../../utils/bigint';
+
+import { TxTemplateContext } from './context';
 import {
   AuthorityOutputInstruction,
   AuthoritySelectInstruction,
@@ -33,27 +48,14 @@ import {
   TxTemplateInstruction,
   UtxoSelectInstruction,
 } from './instructions';
-import { TxTemplateContext } from './context';
-import { IGetUtxosOptions, ITxTemplateInterpreter } from './types';
-import Input from '../../models/input';
-import Output from '../../models/output';
-import {
-  NATIVE_TOKEN_UID,
-  TOKEN_AUTHORITY_MASK,
-  TOKEN_MELT_MASK,
-  TOKEN_MINT_MASK,
-} from '../../constants';
-import { createOutputScriptFromAddress } from '../../utils/address';
-import { JSONBigInt } from '../../utils/bigint';
-import ScriptData from '../../models/script_data';
 import {
   getOracleScript,
   getOracleSignedData,
   getWalletAddress,
   getWalletBalance,
 } from './setvarcommands';
+import { IGetUtxosOptions, ITxTemplateInterpreter } from './types';
 import { selectAuthorities, selectTokens } from './utils';
-import { AuthorityType, isAuthorityType, OutputValueType, TokenVersion } from '../../types';
 
 /**
  * Find and run the executor function for the instruction.
@@ -61,7 +63,7 @@ import { AuthorityType, isAuthorityType, OutputValueType, TokenVersion } from '.
 export async function runInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof TxTemplateInstruction>
+  ins: z.infer<typeof TxTemplateInstruction>,
 ) {
   const instructionExecutor = findInstructionExecution(ins);
   await instructionExecutor(interpreter, ctx, ins);
@@ -72,7 +74,7 @@ export async function runInstruction(
  * Since we parse the instruction we can guarantee the validity.
  */
 export function findInstructionExecution(
-  ins: unknown
+  ins: unknown,
   /* eslint-disable @typescript-eslint/no-explicit-any */
 ): (interpreter: ITxTemplateInterpreter, ctx: TxTemplateContext, ins: any) => Promise<void> {
   /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -114,7 +116,7 @@ export function findInstructionExecution(
 export async function execFeeInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof FeeInstruction>
+  ins: z.infer<typeof FeeInstruction>,
 ) {
   ctx.log(`Begin FeeInstruction: ${JSONBigInt.stringify(ins)}`);
   const { token, amount } = ins;
@@ -136,7 +138,7 @@ export async function execFeeInstruction(
 export async function execRawInputInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof RawInputInstruction>
+  ins: z.infer<typeof RawInputInstruction>,
 ) {
   ctx.log(`Begin RawInputInstruction: ${JSONBigInt.stringify(ins)}`);
   const { position } = ins;
@@ -162,7 +164,7 @@ export async function execRawInputInstruction(
 export async function execUtxoSelectInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof UtxoSelectInstruction>
+  ins: z.infer<typeof UtxoSelectInstruction>,
 ) {
   ctx.log(`Begin UtxoSelectInstruction: ${JSONBigInt.stringify(ins)}`);
   const { position } = ins;
@@ -171,7 +173,7 @@ export async function execUtxoSelectInstruction(
   const address = getVariable<string | undefined>(
     ins.address,
     ctx.vars,
-    UtxoSelectInstruction.shape.address
+    UtxoSelectInstruction.shape.address,
   );
   ctx.log(`fill(${fill}), address(${address}), token(${token})`);
 
@@ -187,7 +189,7 @@ export async function execUtxoSelectInstruction(
     getVariable<string | undefined>(
       ins.changeAddress,
       ctx.vars,
-      UtxoSelectInstruction.shape.changeAddress
+      UtxoSelectInstruction.shape.changeAddress,
     ) ?? (await interpreter.getChangeAddress(ctx));
 
   await selectTokens(interpreter, ctx, fill, options, autoChange, changeAddress, position);
@@ -199,7 +201,7 @@ export async function execUtxoSelectInstruction(
 export async function execAuthoritySelectInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof AuthoritySelectInstruction>
+  ins: z.infer<typeof AuthoritySelectInstruction>,
 ) {
   ctx.log(`Begin AuthoritySelectInstruction: ${JSONBigInt.stringify(ins)}`);
   const position = ins.position ?? -1;
@@ -209,7 +211,7 @@ export async function execAuthoritySelectInstruction(
   const address = getVariable<string | undefined>(
     ins.address,
     ctx.vars,
-    AuthoritySelectInstruction.shape.address
+    AuthoritySelectInstruction.shape.address,
   );
   ctx.log(`count(${count}), address(${address}), token(${token})`);
 
@@ -238,7 +240,7 @@ export async function execAuthoritySelectInstruction(
 export async function execRawOutputInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof RawOutputInstruction>
+  ins: z.infer<typeof RawOutputInstruction>,
 ) {
   ctx.log(`Begin RawOutputInstruction: ${JSONBigInt.stringify(ins)}`);
   const { position, authority, useCreatedToken } = ins;
@@ -248,12 +250,12 @@ export async function execRawOutputInstruction(
   const timelock = getVariable<number | undefined>(
     ins.timelock,
     ctx.vars,
-    RawOutputInstruction.shape.timelock
+    RawOutputInstruction.shape.timelock,
   );
   let amount = getVariable<bigint | undefined>(
     ins.amount,
     ctx.vars,
-    RawOutputInstruction.shape.amount
+    RawOutputInstruction.shape.amount,
   );
   ctx.log(`amount(${amount}) timelock(${timelock}) script(${script}) token(${token})`);
   if (!(authority || amount)) {
@@ -324,7 +326,7 @@ export async function execRawOutputInstruction(
 export async function execDataOutputInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof DataOutputInstruction>
+  ins: z.infer<typeof DataOutputInstruction>,
 ) {
   ctx.log(`Begin DataOutputInstruction: ${JSONBigInt.stringify(ins)}`);
   const { position, useCreatedToken } = ins;
@@ -364,7 +366,7 @@ export async function execDataOutputInstruction(
 export async function execTokenOutputInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof TokenOutputInstruction>
+  ins: z.infer<typeof TokenOutputInstruction>,
 ) {
   ctx.log(`Begin TokenOutputInstruction: ${JSONBigInt.stringify(ins)}`);
   const { position, useCreatedToken } = ins;
@@ -373,7 +375,7 @@ export async function execTokenOutputInstruction(
   const timelock = getVariable<number | undefined>(
     ins.timelock,
     ctx.vars,
-    TokenOutputInstruction.shape.timelock
+    TokenOutputInstruction.shape.timelock,
   );
   const amount = getVariable<bigint>(ins.amount, ctx.vars, TokenOutputInstruction.shape.amount);
   ctx.log(`Creating token output with amount(${amount}) address(${address}) timelock(${timelock})`);
@@ -409,28 +411,28 @@ export async function execTokenOutputInstruction(
 export async function execAuthorityOutputInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof AuthorityOutputInstruction>
+  ins: z.infer<typeof AuthorityOutputInstruction>,
 ) {
   ctx.log(`Begin AuthorityOutputInstruction: ${JSONBigInt.stringify(ins)}`);
   const { authority, position, useCreatedToken } = ins;
   const token = getVariable<string | undefined>(
     ins.token,
     ctx.vars,
-    AuthorityOutputInstruction.shape.token
+    AuthorityOutputInstruction.shape.token,
   );
   const address = getVariable<string>(
     ins.address,
     ctx.vars,
-    AuthorityOutputInstruction.shape.address
+    AuthorityOutputInstruction.shape.address,
   );
   const timelock = getVariable<number | undefined>(
     ins.timelock,
     ctx.vars,
-    AuthorityOutputInstruction.shape.timelock
+    AuthorityOutputInstruction.shape.timelock,
   );
   const count = getVariable<number>(ins.count, ctx.vars, AuthorityOutputInstruction.shape.count);
   ctx.log(
-    `Creating count(${count}) "${authority}" authority outputs with address(${address}) timelock(${timelock})`
+    `Creating count(${count}) "${authority}" authority outputs with address(${address}) timelock(${timelock})`,
   );
 
   let tokenData: number;
@@ -483,7 +485,7 @@ export async function execAuthorityOutputInstruction(
 export async function execShuffleInstruction(
   _interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof ShuffleInstruction>
+  ins: z.infer<typeof ShuffleInstruction>,
 ) {
   ctx.log(`Begin ShuffleInstruction: ${JSONBigInt.stringify(ins)}`);
   const { target } = ins;
@@ -580,33 +582,33 @@ async function completeTokenInputAndOutputs(params: ICompleteTokenInputAndOutput
 export async function execCompleteTxInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof CompleteTxInstruction>
+  ins: z.infer<typeof CompleteTxInstruction>,
 ) {
   ctx.log(`Begin CompleteTxInstruction: ${JSONBigInt.stringify(ins)}`);
   const token = getVariable<string | undefined>(
     ins.token,
     ctx.vars,
-    CompleteTxInstruction.shape.token
+    CompleteTxInstruction.shape.token,
   );
   const changeAddress =
     getVariable<string | undefined>(
       ins.changeAddress,
       ctx.vars,
-      CompleteTxInstruction.shape.changeAddress
+      CompleteTxInstruction.shape.changeAddress,
     ) ?? (await interpreter.getChangeAddress(ctx));
   const address = getVariable<string | undefined>(
     ins.address,
     ctx.vars,
-    CompleteTxInstruction.shape.address
+    CompleteTxInstruction.shape.address,
   );
   const timelock = getVariable<number | undefined>(
     ins.timelock,
     ctx.vars,
-    CompleteTxInstruction.shape.timelock
+    CompleteTxInstruction.shape.timelock,
   );
   const { skipSelection, skipAuthorities, skipChange, calculateFee } = ins;
   ctx.log(
-    `changeAddress(${changeAddress}) address(${address}) timelock(${timelock}) token(${token}), calculateFee(${calculateFee}), skipSelection(${skipSelection}), skipChange(${skipChange}), skipAuthorities(${skipAuthorities})`
+    `changeAddress(${changeAddress}) address(${address}) timelock(${timelock}) token(${token}), calculateFee(${calculateFee}), skipSelection(${skipSelection}), skipChange(${skipChange}), skipAuthorities(${skipAuthorities})`,
   );
 
   const tokensToCheck: Set<string> = new Set();
@@ -780,41 +782,41 @@ export async function execCompleteTxInstruction(
 export async function execConfigInstruction(
   _interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof ConfigInstruction>
+  ins: z.infer<typeof ConfigInstruction>,
 ) {
   ctx.log(`Begin ConfigInstruction: ${JSONBigInt.stringify(ins)}`);
   const version = getVariable<number | undefined>(
     ins.version,
     ctx.vars,
-    ConfigInstruction.shape.version
+    ConfigInstruction.shape.version,
   );
   const signalBits = getVariable<number | undefined>(
     ins.signalBits,
     ctx.vars,
-    ConfigInstruction.shape.signalBits
+    ConfigInstruction.shape.signalBits,
   );
   const tokenName = getVariable<string | undefined>(
     ins.tokenName,
     ctx.vars,
-    ConfigInstruction.shape.tokenName
+    ConfigInstruction.shape.tokenName,
   );
   const tokenSymbol = getVariable<string | undefined>(
     ins.tokenSymbol,
     ctx.vars,
-    ConfigInstruction.shape.tokenSymbol
+    ConfigInstruction.shape.tokenSymbol,
   );
   const tokenVersion = getVariable<TokenVersion | undefined>(
     ins.tokenVersion,
     ctx.vars,
-    ConfigInstruction.shape.tokenVersion
+    ConfigInstruction.shape.tokenVersion,
   );
   const createToken = getVariable<boolean | undefined>(
     ins.createToken,
     ctx.vars,
-    ConfigInstruction.shape.createToken
+    ConfigInstruction.shape.createToken,
   );
   ctx.log(
-    `version(${version}) signalBits(${signalBits}) tokenName(${tokenName}) tokenSymbol(${tokenSymbol}) tokenVersion(${tokenVersion}) createToken(${createToken})`
+    `version(${version}) signalBits(${signalBits}) tokenName(${tokenName}) tokenSymbol(${tokenSymbol}) tokenVersion(${tokenVersion}) createToken(${createToken})`,
   );
 
   if (version) {
@@ -843,7 +845,7 @@ export async function execConfigInstruction(
 export async function execSetVarInstruction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof SetVarInstruction>
+  ins: z.infer<typeof SetVarInstruction>,
 ) {
   ctx.log(`Begin SetVarInstruction: ${JSONBigInt.stringify(ins)}`);
   if (!ins.call) {
@@ -867,7 +869,7 @@ export async function execSetVarInstruction(
     const token = getVariable<string>(
       callArgs.token,
       ctx.vars,
-      SetVarGetWalletBalanceOpts.shape.token
+      SetVarGetWalletBalanceOpts.shape.token,
     );
     const newOptions = clone(callArgs);
     newOptions.token = token;
@@ -900,19 +902,19 @@ export async function execSetVarInstruction(
 async function validateDepositNanoAction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  action: z.infer<typeof NanoDepositAction>
+  action: z.infer<typeof NanoDepositAction>,
 ) {
   const token = getVariable<string>(action.token, ctx.vars, NanoDepositAction.shape.token);
   await ctx.addToken(interpreter, token);
   const amount = getVariable<OutputValueType>(
     action.amount,
     ctx.vars,
-    NanoDepositAction.shape.amount
+    NanoDepositAction.shape.amount,
   );
   const address = getVariable<string | undefined>(
     action.address,
     ctx.vars,
-    NanoDepositAction.shape.address
+    NanoDepositAction.shape.address,
   );
 
   // This is the action without variables, which will be used to create the header
@@ -938,7 +940,7 @@ async function validateDepositNanoAction(
     getVariable<string | undefined>(
       action.changeAddress,
       ctx.vars,
-      NanoDepositAction.shape.changeAddress
+      NanoDepositAction.shape.changeAddress,
     ) ?? (await interpreter.getChangeAddress(ctx));
 
   await selectTokens(interpreter, ctx, amount, options, action.autoChange, changeAddress);
@@ -952,14 +954,14 @@ async function validateDepositNanoAction(
 async function validateWithdrawalNanoAction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  action: z.infer<typeof NanoWithdrawalAction>
+  action: z.infer<typeof NanoWithdrawalAction>,
 ) {
   const token = getVariable<string>(action.token, ctx.vars, NanoWithdrawalAction.shape.token);
   await ctx.addToken(interpreter, token);
   const amount = getVariable<OutputValueType>(
     action.amount,
     ctx.vars,
-    NanoWithdrawalAction.shape.amount
+    NanoWithdrawalAction.shape.amount,
   );
   const address =
     getVariable<string | undefined>(action.address, ctx.vars, NanoWithdrawalAction.shape.address) ??
@@ -989,7 +991,7 @@ async function validateWithdrawalNanoAction(
 async function validateGrantAuthorityNanoAction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  action: z.infer<typeof NanoGrantAuthorityAction>
+  action: z.infer<typeof NanoGrantAuthorityAction>,
 ) {
   const token = getVariable<string>(action.token, ctx.vars, NanoGrantAuthorityAction.shape.token);
   await ctx.addToken(interpreter, token);
@@ -997,7 +999,7 @@ async function validateGrantAuthorityNanoAction(
   const address = getVariable<string | undefined>(
     action.address,
     ctx.vars,
-    NanoGrantAuthorityAction.shape.address
+    NanoGrantAuthorityAction.shape.address,
   );
 
   // This is the action without variables, which will be used to create the header
@@ -1039,7 +1041,7 @@ async function validateGrantAuthorityNanoAction(
 async function validateAcquireAuthorityNanoAction(
   interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  action: z.infer<typeof NanoAcquireAuthorityAction>
+  action: z.infer<typeof NanoAcquireAuthorityAction>,
 ) {
   const token = getVariable<string>(action.token, ctx.vars, NanoAcquireAuthorityAction.shape.token);
   await ctx.addToken(interpreter, token);
@@ -1047,7 +1049,7 @@ async function validateAcquireAuthorityNanoAction(
     getVariable<string | undefined>(
       action.address,
       ctx.vars,
-      NanoAcquireAuthorityAction.shape.address
+      NanoAcquireAuthorityAction.shape.address,
     ) ?? (await interpreter.getAddress());
 
   // This is the action without variables, which will be used to create the header
@@ -1083,7 +1085,7 @@ async function validateAcquireAuthorityNanoAction(
 export async function execNanoMethodInstruction(
   _interpreter: ITxTemplateInterpreter,
   ctx: TxTemplateContext,
-  ins: z.infer<typeof NanoMethodInstruction>
+  ins: z.infer<typeof NanoMethodInstruction>,
 ) {
   ctx.log(`Begin NanoMethodInstruction: ${JSONBigInt.stringify(ins)}`);
 

--- a/src/template/transaction/index.ts
+++ b/src/template/transaction/index.ts
@@ -1,3 +1,3 @@
-export * from './interpreter';
 export * from './builder';
 export { TransactionTemplate } from './instructions';
+export * from './interpreter';

--- a/src/template/transaction/instructions.ts
+++ b/src/template/transaction/instructions.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+
 import { NATIVE_TOKEN_UID } from '../../constants';
 import { AuthorityType, TokenVersion } from '../../types';
 

--- a/src/template/transaction/interpreter.ts
+++ b/src/template/transaction/interpreter.ts
@@ -6,10 +6,34 @@
  */
 
 import { z } from 'zod';
+
 import { FullNodeTxApiResponse } from '../../api/schemas/txApi';
-import { TransactionTemplate, NanoAction } from './instructions';
-import { runInstruction } from './executor';
+import {
+  CREATE_TOKEN_TX_VERSION,
+  DEFAULT_TX_VERSION,
+  NANO_CONTRACTS_INITIALIZE_METHOD,
+  TOKEN_MELT_MASK,
+  TOKEN_MINT_MASK,
+} from '../../constants';
+import type Header from '../../headers/base';
+import FeeHeader from '../../headers/fee';
+import Address from '../../models/address';
+import CreateTokenTransaction from '../../models/create_token_transaction';
+import Network from '../../models/network';
+import Transaction from '../../models/transaction';
+import NanoContractHeader from '../../nano_contracts/header';
+import { ActionTypeToActionHeaderType, NanoContractActionHeader } from '../../nano_contracts/types';
+import { validateAndParseBlueprintMethodArgs } from '../../nano_contracts/utils';
+import HathorWallet from '../../new/wallet';
+import { IFeeEntry, IHistoryTx, OutputValueType } from '../../types';
+import leb128 from '../../utils/leb128';
+import tokensUtils from '../../utils/tokens';
+import transactionUtils from '../../utils/transaction';
+import { IHathorWallet, Utxo } from '../../wallet/types';
+
 import { TxTemplateContext, NanoContractContext } from './context';
+import { runInstruction } from './executor';
+import { TransactionTemplate, NanoAction } from './instructions';
 import {
   ITxTemplateInterpreter,
   IGetUtxosOptions,
@@ -18,28 +42,6 @@ import {
   TxInstance,
   IWalletTokenDetails,
 } from './types';
-import { IFeeEntry, IHistoryTx, OutputValueType } from '../../types';
-import { IHathorWallet, Utxo } from '../../wallet/types';
-import Transaction from '../../models/transaction';
-import Address from '../../models/address';
-import HathorWallet from '../../new/wallet';
-import {
-  CREATE_TOKEN_TX_VERSION,
-  DEFAULT_TX_VERSION,
-  NANO_CONTRACTS_INITIALIZE_METHOD,
-  TOKEN_MELT_MASK,
-  TOKEN_MINT_MASK,
-} from '../../constants';
-import transactionUtils from '../../utils/transaction';
-import leb128 from '../../utils/leb128';
-import tokensUtils from '../../utils/tokens';
-import Network from '../../models/network';
-import CreateTokenTransaction from '../../models/create_token_transaction';
-import NanoContractHeader from '../../nano_contracts/header';
-import { ActionTypeToActionHeaderType, NanoContractActionHeader } from '../../nano_contracts/types';
-import { validateAndParseBlueprintMethodArgs } from '../../nano_contracts/utils';
-import type Header from '../../headers/base';
-import FeeHeader from '../../headers/fee';
 
 export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
   wallet: HathorWallet;
@@ -72,7 +74,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
 
   static mapActionInstructionToAction(
     ctx: TxTemplateContext,
-    action: z.output<typeof NanoAction>
+    action: z.output<typeof NanoAction>,
   ): NanoContractActionHeader {
     const tokens = ctx.tokens.map(t => ({ uid: t, name: '', symbol: '' }));
     const { token } = action;
@@ -131,7 +133,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
       blueprintId,
       nanoCtx.method,
       nanoCtx.args,
-      network
+      network,
     );
 
     const arr: Buffer[] = [leb128.encodeUnsigned(args.length)];
@@ -141,7 +143,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
     const serializedArgs = Buffer.concat(arr);
     const seqnum = await this.wallet.getNanoHeaderSeqnum(address.base58);
     const nanoHeaderActions = nanoCtx.actions.map(action =>
-      WalletTxTemplateInterpreter.mapActionInstructionToAction(ctx, action)
+      WalletTxTemplateInterpreter.mapActionInstructionToAction(ctx, action),
     );
 
     return new NanoContractHeader(
@@ -151,7 +153,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
       nanoHeaderActions,
       seqnum,
       address,
-      null
+      null,
     );
   }
 
@@ -159,7 +161,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
     const entries: IFeeEntry[] = Array.from(ctx.fees.entries()).map(([tokenUid, amount]) => ({
       tokenIndex: tokensUtils.getTokenIndex(
         ctx.tokens.map(t => ({ uid: t })),
-        tokenUid
+        tokenUid,
       ),
       amount,
     }));
@@ -168,7 +170,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
 
   async build(
     instructions: z.infer<typeof TransactionTemplate>,
-    debug: boolean = false
+    debug: boolean = false,
   ): Promise<TxInstance> {
     const context = new TxTemplateContext(this.wallet.logger, debug);
 
@@ -207,7 +209,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
         context.tokenSymbol,
         context.inputs,
         context.outputs,
-        { signalBits: context.signalBits, headers, tokenVersion: context.tokenVersion }
+        { signalBits: context.signalBits, headers, tokenVersion: context.tokenVersion },
       );
     }
     throw new Error('Unsupported Version byte provided');
@@ -216,7 +218,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
   async buildAndSign(
     instructions: z.infer<typeof TransactionTemplate>,
     pinCode: string,
-    debug: boolean = false
+    debug: boolean = false,
   ): Promise<TxInstance> {
     let tx = await this.build(instructions, debug);
     tx = await transactionUtils.signTransaction(tx, this.wallet.storage, pinCode);

--- a/src/template/transaction/setvarcommands.ts
+++ b/src/template/transaction/setvarcommands.ts
@@ -6,7 +6,10 @@
  */
 
 import { z } from 'zod';
-import { ITxTemplateInterpreter } from './types';
+
+import { IUserSignedData } from '../../nano_contracts/fields/signedData';
+import { getOracleBuffer, getOracleSignedDataFromUser } from '../../nano_contracts/utils';
+
 import { TxTemplateContext } from './context';
 import {
   SetVarGetOracleScriptOpts,
@@ -15,13 +18,12 @@ import {
   SetVarGetWalletBalanceOpts,
   getVariable,
 } from './instructions';
-import { getOracleBuffer, getOracleSignedDataFromUser } from '../../nano_contracts/utils';
-import { IUserSignedData } from '../../nano_contracts/fields/signedData';
+import { ITxTemplateInterpreter } from './types';
 
 export async function getWalletAddress(
   interpreter: ITxTemplateInterpreter,
   _ctx: TxTemplateContext,
-  options: z.infer<typeof SetVarGetWalletAddressOpts>
+  options: z.infer<typeof SetVarGetWalletAddressOpts>,
 ): Promise<string> {
   if (options.index != null) {
     return interpreter.getAddressAtIndex(options.index);
@@ -32,7 +34,7 @@ export async function getWalletAddress(
 export async function getWalletBalance(
   interpreter: ITxTemplateInterpreter,
   _ctx: TxTemplateContext,
-  options: z.infer<typeof SetVarGetWalletBalanceOpts>
+  options: z.infer<typeof SetVarGetWalletBalanceOpts>,
 ): Promise<number | bigint> {
   const data = await interpreter.getBalance(options.token);
   switch (options.authority) {
@@ -48,7 +50,7 @@ export async function getWalletBalance(
 export async function getOracleScript(
   interpreter: ITxTemplateInterpreter,
   _ctx: TxTemplateContext,
-  options: z.infer<typeof SetVarGetOracleScriptOpts>
+  options: z.infer<typeof SetVarGetOracleScriptOpts>,
 ): Promise<string> {
   const address = await interpreter.getAddressAtIndex(options.index);
   const oracle = getOracleBuffer(address, interpreter.getNetwork());
@@ -58,7 +60,7 @@ export async function getOracleScript(
 export async function getOracleSignedData(
   interpreter: ITxTemplateInterpreter,
   _ctx: TxTemplateContext,
-  options: z.infer<typeof SetVarGetOracleSignedDataOpts>
+  options: z.infer<typeof SetVarGetOracleSignedDataOpts>,
 ): Promise<IUserSignedData> {
   const address = await interpreter.getAddressAtIndex(options.index);
   const oracle = getOracleBuffer(address, interpreter.getNetwork());
@@ -66,12 +68,12 @@ export async function getOracleSignedData(
   const data = getVariable<unknown>(
     options.data,
     _ctx.vars,
-    SetVarGetOracleSignedDataOpts.shape.data
+    SetVarGetOracleSignedDataOpts.shape.data,
   );
   const ncId = getVariable<string>(
     options.ncId,
     _ctx.vars,
-    SetVarGetOracleSignedDataOpts.shape.ncId
+    SetVarGetOracleSignedDataOpts.shape.ncId,
   );
 
   return getOracleSignedDataFromUser(oracle, ncId, options.type, data, interpreter.getWallet());

--- a/src/template/transaction/types.ts
+++ b/src/template/transaction/types.ts
@@ -6,13 +6,15 @@
  */
 
 import { z } from 'zod';
-import { TransactionTemplate } from './instructions';
-import { TxTemplateContext } from './context';
-import { IHistoryTx, ITokenBalance, ITokenData, OutputValueType, TokenVersion } from '../../types';
-import Transaction from '../../models/transaction';
-import Network from '../../models/network';
-import { IHathorWallet, Utxo } from '../../wallet/types';
+
 import CreateTokenTransaction from '../../models/create_token_transaction';
+import Network from '../../models/network';
+import Transaction from '../../models/transaction';
+import { IHistoryTx, ITokenBalance, ITokenData, OutputValueType, TokenVersion } from '../../types';
+import { IHathorWallet, Utxo } from '../../wallet/types';
+
+import { TxTemplateContext } from './context';
+import { TransactionTemplate } from './instructions';
 
 export type TxInstance = Transaction | CreateTokenTransaction;
 

--- a/src/template/transaction/utils.ts
+++ b/src/template/transaction/utils.ts
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { OutputValueType } from '../../types';
 import { NATIVE_TOKEN_UID } from '../../constants';
-import { TxTemplateContext } from './context';
-import { ITxTemplateInterpreter, IGetUtxosOptions } from './types';
-import { createOutputScriptFromAddress } from '../../utils/address';
 import Input from '../../models/input';
 import Output from '../../models/output';
+import { OutputValueType } from '../../types';
+import { createOutputScriptFromAddress } from '../../utils/address';
+
+import { TxTemplateContext } from './context';
+import { ITxTemplateInterpreter, IGetUtxosOptions } from './types';
 
 /**
  * Select tokens from interpreter and modify context as required by the tokens found.
@@ -23,7 +24,7 @@ export async function selectTokens(
   options: IGetUtxosOptions,
   autoChange: boolean,
   changeAddress: string,
-  position: number = -1
+  position: number = -1,
 ) {
   const token = options.token ?? NATIVE_TOKEN_UID;
   await ctx.cacheTokenDetails(interpreter, token);
@@ -64,7 +65,7 @@ export async function selectAuthorities(
   ctx: TxTemplateContext,
   options: IGetUtxosOptions,
   count: number = 1,
-  position: number = -1
+  position: number = -1,
 ) {
   const token = options.token ?? NATIVE_TOKEN_UID;
   // Only cache the token version (no outputs created here)

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,10 +6,10 @@
  */
 
 import { Config } from './config';
-import Transaction from './models/transaction';
-import Input from './models/input';
-import FullNodeConnection from './new/connection';
 import Header from './headers/base';
+import Input from './models/input';
+import Transaction from './models/transaction';
+import FullNodeConnection from './new/connection';
 
 /**
  * Token version used to identify the type of token during the token creation process.
@@ -85,7 +85,7 @@ export enum WalletState {
 export type EcdsaTxSign = (
   tx: Transaction,
   storage: IStorage,
-  pinCode: string
+  pinCode: string,
 ) => Promise<ITxSignatureData>;
 
 export type HistorySyncFunction = (
@@ -93,7 +93,7 @@ export type HistorySyncFunction = (
   count: number,
   storage: IStorage,
   connection: FullNodeConnection,
-  shouldProcessHistory?: boolean
+  shouldProcessHistory?: boolean,
 ) => Promise<void>;
 
 export interface IAddressInfo {
@@ -421,19 +421,19 @@ export type AddressScanPolicyData =
   | ISingleAddressAddressScanPolicy;
 
 export function isGapLimitScanPolicy(
-  scanPolicyData: AddressScanPolicyData
+  scanPolicyData: AddressScanPolicyData,
 ): scanPolicyData is IGapLimitAddressScanPolicy {
   return scanPolicyData.policy === SCANNING_POLICY.GAP_LIMIT;
 }
 
 export function isIndexLimitScanPolicy(
-  scanPolicyData: AddressScanPolicyData
+  scanPolicyData: AddressScanPolicyData,
 ): scanPolicyData is IIndexLimitAddressScanPolicy {
   return scanPolicyData.policy === SCANNING_POLICY.INDEX_LIMIT;
 }
 
 export function isSingleAddressScanPolicy(
-  scanPolicyData: AddressScanPolicyData
+  scanPolicyData: AddressScanPolicyData,
 ): scanPolicyData is ISingleAddressAddressScanPolicy {
   return scanPolicyData.policy === SCANNING_POLICY.SINGLE_ADDRESS;
 }
@@ -480,7 +480,7 @@ export interface IUtxoFilterOptions {
 export type UtxoSelectionAlgorithm = (
   storage: IStorage,
   token: string,
-  amount: OutputValueType
+  amount: OutputValueType,
 ) => Promise<{ utxos: IUtxo[]; amount: OutputValueType; available?: OutputValueType }>;
 
 export interface IUtxoSelectionOptions {
@@ -586,7 +586,7 @@ export interface IStore {
   cleanStorage(
     cleanHistory?: boolean,
     cleanAddresses?: boolean,
-    cleanTokens?: boolean
+    cleanTokens?: boolean,
   ): Promise<void>;
   cleanMetadata(): Promise<void>;
 }
@@ -642,7 +642,7 @@ export interface IStorage {
   fillTx(
     token: string,
     tx: IDataTx,
-    options: IFillTxOptions
+    options: IFillTxOptions,
   ): Promise<{ inputs: IDataInput[]; outputs: IDataOutput[] }>;
   utxoSelectAsInput(utxo: IUtxoId, markAs: boolean, ttl?: number): Promise<void>;
   isUtxoSelectedAsInput(utxo: IUtxoId): Promise<boolean>;
@@ -669,7 +669,7 @@ export interface IStorage {
   cleanStorage(
     cleanHistory?: boolean,
     cleanAddresses?: boolean,
-    cleanTokens?: boolean
+    cleanTokens?: boolean,
   ): Promise<void>;
   handleStop(options: {
     connection?: FullNodeConnection;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -11,12 +11,14 @@ import {
   Script,
   HDPublicKey,
 } from 'bitcore-lib';
+
 import Address from '../models/address';
+import Network from '../models/network';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
-import Network from '../models/network';
-import { hexToBuffer } from './buffer';
 import { IMultisigData, IStorage, IAddressInfo } from '../types';
+
+import { hexToBuffer } from './buffer';
 import { createP2SHRedeemScript } from './scripts';
 
 /**
@@ -35,7 +37,7 @@ export function getAddressType(address: string, network: Network): 'p2pkh' | 'p2
 export function deriveAddressFromXPubP2PKH(
   xpubkey: string,
   index: number,
-  networkName: string
+  networkName: string,
 ): IAddressInfo {
   const network = new Network(networkName);
   const hdpubkey = new HDPublicKey(xpubkey);
@@ -58,18 +60,18 @@ export async function deriveAddressP2PKH(index: number, storage: IStorage): Prom
 export function deriveAddressFromDataP2SH(
   multisigData: IMultisigData,
   index: number,
-  networkName: string
+  networkName: string,
 ): IAddressInfo {
   const network = new Network(networkName);
   const redeemScript = createP2SHRedeemScript(
     multisigData.pubkeys,
     multisigData.numSignatures,
-    index
+    index,
   );
   // eslint-disable-next-line new-cap -- Cannot change the dependency method name
   const address = new BitcoreAddress.payingTo(
     Script.fromBuffer(redeemScript),
-    network.bitcoreNetwork
+    network.bitcoreNetwork,
   );
   return {
     base58: address.toString(),
@@ -135,7 +137,7 @@ export function getAddressFromPubkey(pubkey: string, network: Network): Address 
   const pubkeyBuffer = hexToBuffer(pubkey);
   const base58 = new BitcoreAddress(
     bitcorePublicKey(pubkeyBuffer),
-    network.bitcoreNetwork
+    network.bitcoreNetwork,
   ).toString();
   return new Address(base58, { network });
 }

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from 'zod';
+
 import { getDefaultLogger } from '../types';
 
 /**

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,7 +1,9 @@
 import buffer from 'buffer';
+
+import { MAX_OUTPUT_VALUE, MAX_OUTPUT_VALUE_32 } from '../constants';
 import { OutputValueError, ParseError } from '../errors';
 import { OutputValueType } from '../types';
-import { MAX_OUTPUT_VALUE, MAX_OUTPUT_VALUE_32 } from '../constants';
+
 import { prettyValue } from './numbers';
 
 const isHexa = (value: string): boolean => {
@@ -123,7 +125,7 @@ export const hexToBuffer = (value: string): Buffer => {
 const validateLenToUnpack = (n: number, buff: Buffer) => {
   if (buff.length < n) {
     throw new ParseError(
-      `Don't have enough bytes to unpack. Requested ${n} and buffer has ${buff.length}`
+      `Don't have enough bytes to unpack. Requested ${n} and buffer has ${buff.length}`,
     );
   }
 };

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import CryptoJS from 'crypto-js';
 import bitcore from 'bitcore-lib';
-import { DecryptionError, InvalidPasswdError, UnsupportedHasherError } from '../errors';
+import CryptoJS from 'crypto-js';
+
 import { HATHOR_MAGIC_BYTES, HASH_ITERATIONS, HASH_KEY_SIZE } from '../constants';
+import { DecryptionError, InvalidPasswdError, UnsupportedHasherError } from '../errors';
 import { IEncryptedData } from '../types';
 
 // Monkey-patch MAGIC_BYTES to use Hathor's
@@ -32,7 +33,7 @@ export function hashData(
     salt,
     iterations = HASH_ITERATIONS,
     pbkdf2Hasher = 'sha1',
-  }: { salt?: string; iterations?: number; pbkdf2Hasher?: string } = {}
+  }: { salt?: string; iterations?: number; pbkdf2Hasher?: string } = {},
 ): { hash: string; salt: string; iterations: number; pbkdf2Hasher: string } {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- HasherStatic type is not exported by its lib
   const hashers = new Map<string, any>([
@@ -81,7 +82,7 @@ export function encryptData(
     salt,
     iterations = HASH_ITERATIONS,
     pbkdf2Hasher = 'sha1',
-  }: { salt?: string; iterations?: number; pbkdf2Hasher?: string } = {}
+  }: { salt?: string; iterations?: number; pbkdf2Hasher?: string } = {},
 ): IEncryptedData {
   const encrypted = CryptoJS.AES.encrypt(data, password);
   const hash = hashData(password, { salt, iterations, pbkdf2Hasher });
@@ -148,7 +149,7 @@ export function validateHash(
     salt,
     iterations = HASH_ITERATIONS,
     pbkdf2Hasher = 'sha1',
-  }: { salt?: string; iterations?: number; pbkdf2Hasher?: string } = {}
+  }: { salt?: string; iterations?: number; pbkdf2Hasher?: string } = {},
 ): boolean {
   const hash = hashData(dataToValidate, { salt, iterations, pbkdf2Hasher });
   return hash.hash === hashedData;

--- a/src/utils/fee.ts
+++ b/src/utils/fee.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IHathorWallet, TokenInfo, Utxo } from '../wallet/types';
 import { FEE_PER_OUTPUT, NATIVE_TOKEN_UID } from '../constants';
-import { IDataInput, IDataOutputWithToken, ITokenData, IUtxo, TokenVersion } from '../types';
 import Output from '../models/output';
-import HathorWallet from '../new/wallet';
 import { NanoContractAction, NanoContractActionType } from '../nano_contracts/types';
+import HathorWallet from '../new/wallet';
+import { IDataInput, IDataOutputWithToken, ITokenData, IUtxo, TokenVersion } from '../types';
+import { IHathorWallet, TokenInfo, Utxo } from '../wallet/types';
 
 type TokenElement = IDataInput | Utxo | IUtxo | IDataInput | IDataOutputWithToken | Output;
 
@@ -38,7 +38,7 @@ export class Fee {
     inputs: (IDataInput | Utxo | IUtxo)[],
     outputs: (IDataOutputWithToken | Output)[],
     tokens: Map<string, ITokenData | TokenInfo>,
-    actions?: NanoContractAction[]
+    actions?: NanoContractAction[],
   ): Promise<bigint> {
     const nonAuthorityInputs = Fee.groupTokenElementsByTokenUid(inputs);
     const nonAuthorityOutputs = Fee.groupTokenElementsByTokenUid(outputs);
@@ -106,7 +106,7 @@ export class Fee {
     inputs: (IDataInput | Utxo | IUtxo)[],
     outputs: (IDataOutputWithToken | Output)[],
     tokens: string[],
-    actions?: NanoContractAction[]
+    actions?: NanoContractAction[],
   ): Promise<{ fee: bigint; tokensMap: Map<string, ITokenData> }> {
     const tokensMap = new Map<string, ITokenData>();
 
@@ -150,7 +150,7 @@ export class Fee {
    * @static
    */
   static getNonAuthorityTokenElement(
-    outputs: (TokenElement | Omit<TokenElement, 'token'>)[]
+    outputs: (TokenElement | Omit<TokenElement, 'token'>)[],
   ): (TokenElement | Omit<TokenElement, 'token'>)[] {
     return outputs.filter(output => !Fee.isAuthorityTokenElement(output as never)); // casting to never since we don't need the token property here.
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,24 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
 import buffer from 'buffer';
+import path from 'path';
+
+import { AxiosInstance, AxiosRequestConfig } from 'axios';
 import { crypto, encoding, Address as bitcoreAddress } from 'bitcore-lib';
 import { clone } from 'lodash';
-import { AxiosInstance, AxiosRequestConfig } from 'axios';
-import { OP_PUSHDATA1 } from '../opcodes';
+
+import config from '../config';
 import { DEFAULT_TX_VERSION, CREATE_TOKEN_TX_VERSION } from '../constants';
-import Transaction from '../models/transaction';
-import { HistoryTransaction, HistoryTransactionOutput } from '../models/types';
-import P2PKH from '../models/p2pkh';
-import P2SH from '../models/p2sh';
-import ScriptData from '../models/script_data';
-import CreateTokenTransaction from '../models/create_token_transaction';
-import Input from '../models/input';
-import Output from '../models/output';
-import Network from '../models/network';
-import Address from '../models/address';
-import { hexToBuffer, unpackToInt, intToBytes } from './buffer';
+import { ErrorMessages } from '../errorMessages';
 import {
   AddressError,
   OutputValueError,
@@ -32,11 +24,21 @@ import {
   MaximumNumberOutputsError,
   ParseError,
 } from '../errors';
-
-import { ErrorMessages } from '../errorMessages';
-import config from '../config';
+import Address from '../models/address';
+import CreateTokenTransaction from '../models/create_token_transaction';
+import Input from '../models/input';
+import Network from '../models/network';
+import Output from '../models/output';
+import P2PKH from '../models/p2pkh';
+import P2SH from '../models/p2sh';
+import ScriptData from '../models/script_data';
+import Transaction from '../models/transaction';
+import { HistoryTransaction, HistoryTransactionOutput } from '../models/types';
+import { OP_PUSHDATA1 } from '../opcodes';
 import { IDataInput, IUtxo } from '../types';
 import { Utxo } from '../wallet/types';
+
+import { hexToBuffer, unpackToInt, intToBytes } from './buffer';
 
 /**
  * Helper methods
@@ -199,7 +201,7 @@ const helpers = {
     const calcChecksum = decoded.subarray(21);
     if (!calcChecksum.equals(recvChecksum)) {
       throw new Error(
-        `Generated checksum(${calcChecksum.toString('hex')}) does not match received checksum(${recvChecksum.toString('hex')})`
+        `Generated checksum(${calcChecksum.toString('hex')}) does not match received checksum(${recvChecksum.toString('hex')})`,
       );
     }
 
@@ -290,7 +292,7 @@ const helpers = {
       return CreateTokenTransaction.createFromBytes(cloneBuffer, network);
     }
     throw new ParseError(
-      'We currently support only the Transaction and CreateTokenTransaction types. Other types will be supported in the future.'
+      'We currently support only the Transaction and CreateTokenTransaction types. Other types will be supported in the future.',
     );
   },
 
@@ -400,7 +402,7 @@ const helpers = {
         data.symbol,
         inputs,
         outputs,
-        createTokenOptions
+        createTokenOptions,
       );
     }
     if (data.version === DEFAULT_TX_VERSION) {
@@ -439,7 +441,7 @@ const helpers = {
         historyTx.token_symbol!,
         inputs,
         outputs,
-        { ...historyTx }
+        { ...historyTx },
       );
     }
     return new Transaction(inputs, outputs, { ...historyTx });

--- a/src/utils/leb128.ts
+++ b/src/utils/leb128.ts
@@ -20,7 +20,7 @@ export interface Leb128DecodeResult {
 export function encodeLeb128(
   value: bigint | number,
   signed: boolean = true,
-  maxBytes: number | null = null
+  maxBytes: number | null = null,
 ) {
   let val = BigInt(value);
   if (!signed && val < 0n) {
@@ -67,7 +67,7 @@ export function encodeLeb128(
 export function decodeLeb128(
   buf: Buffer,
   signed: boolean = true,
-  maxBytes: number | null = null
+  maxBytes: number | null = null,
 ): Leb128DecodeResult {
   const byte_list = Array.from(buf.values()).map(v => BigInt(v));
   let result = 0n;

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -42,7 +42,7 @@ function getLocaleString(value: bigint | number): string {
  */
 export function prettyValue(
   inputValue: bigint | number | string,
-  decimalPlaces: number = DECIMAL_PLACES
+  decimalPlaces: number = DECIMAL_PLACES,
 ): string {
   const value = BigInt(inputValue);
 

--- a/src/utils/scripts.ts
+++ b/src/utils/scripts.ts
@@ -1,13 +1,15 @@
-import _ from 'lodash';
 import { Script, HDPublicKey } from 'bitcore-lib';
+import _ from 'lodash';
+
+import { ParseError, ParseScriptError, XPubError } from '../errors';
+import Network from '../models/network';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
 import ScriptData from '../models/script_data';
-import Network from '../models/network';
-import helpers from './helpers';
-import { unpackLen, unpackToInt } from './buffer';
-import { ParseError, ParseScriptError, XPubError } from '../errors';
 import { OP_PUSHDATA1, OP_CHECKSIG } from '../opcodes';
+
+import { unpackLen, unpackToInt } from './buffer';
+import helpers from './helpers';
 
 /**
  * Parse P2PKH output script
@@ -107,7 +109,7 @@ export const parseScriptData = (buff: Buffer): ScriptData => {
   if (expectedLen !== scriptBuf.length) {
     // The script has different qty of bytes than expected
     throw new ParseScriptError(
-      `Invalid output script. Expected len ${expectedLen} and received len ${scriptBuf.length}.`
+      `Invalid output script. Expected len ${expectedLen} and received len ${scriptBuf.length}.`,
     );
   }
 
@@ -174,7 +176,7 @@ export const getPushData = (buff: Buffer): Buffer => {
 export function createP2SHRedeemScript(
   xpubs: string[],
   numSignatures: number,
-  index: number
+  index: number,
 ): Buffer {
   let sortedXpubs: HDPublicKey[];
   try {
@@ -182,7 +184,7 @@ export function createP2SHRedeemScript(
       xpubs.map(xp => new HDPublicKey(xp)),
       (xpub: HDPublicKey) => {
         return xpub.publicKey.toString('hex');
-      }
+      },
     );
   } catch (e) {
     throw new XPubError('Invalid xpub');

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -5,10 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { chunk } from 'lodash';
 import axios, { AxiosError, AxiosResponse } from 'axios';
+import { chunk } from 'lodash';
 
+import { AddressHistorySchema, GeneralTokenInfoSchema } from '../api/schemas/wallet';
+import walletApi from '../api/wallet';
+import {
+  NATIVE_TOKEN_UID,
+  MAX_ADDRESSES_GET,
+  LOAD_WALLET_MAX_RETRY,
+  LOAD_WALLET_RETRY_SLEEP,
+  CREATE_TOKEN_TX_VERSION,
+  ON_CHAIN_BLUEPRINTS_VERSION,
+} from '../constants';
+import CreateTokenTransaction from '../models/create_token_transaction';
 import FullnodeConnection from '../new/connection';
+import { DEFAULT_ADDRESS_META } from '../storage/storage';
+import { xpubStreamSyncHistory, manualStreamSyncHistory } from '../sync/stream';
 import {
   IStorage,
   IAddressInfo,
@@ -26,22 +39,10 @@ import {
   ITokenData,
   TokenVersion,
 } from '../types';
-import walletApi from '../api/wallet';
+
+import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from './address';
 import helpers from './helpers';
 import transactionUtils from './transaction';
-import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from './address';
-import { xpubStreamSyncHistory, manualStreamSyncHistory } from '../sync/stream';
-import {
-  NATIVE_TOKEN_UID,
-  MAX_ADDRESSES_GET,
-  LOAD_WALLET_MAX_RETRY,
-  LOAD_WALLET_RETRY_SLEEP,
-  CREATE_TOKEN_TX_VERSION,
-  ON_CHAIN_BLUEPRINTS_VERSION,
-} from '../constants';
-import { AddressHistorySchema, GeneralTokenInfoSchema } from '../api/schemas/wallet';
-import CreateTokenTransaction from '../models/create_token_transaction';
-import { DEFAULT_ADDRESS_META } from '../storage/storage';
 
 /**
  * Get history sync method for a given mode
@@ -85,7 +86,7 @@ export async function getSupportedSyncMode(storage: IStorage): Promise<HistorySy
 export async function loadAddresses(
   startIndex: number,
   count: number,
-  storage: IStorage
+  storage: IStorage,
 ): Promise<string[]> {
   const addresses: string[] = [];
   const stopIndex = startIndex + count;
@@ -125,7 +126,7 @@ export async function apiSyncHistory(
   count: number,
   storage: IStorage,
   connection: FullnodeConnection,
-  shouldProcessHistory: boolean = false
+  shouldProcessHistory: boolean = false,
 ) {
   let itStartIndex = startIndex;
   let itCount = count;
@@ -173,7 +174,7 @@ export async function apiSyncHistory(
 export async function* loadAddressHistory(
   addresses: string[],
   storage: IStorage,
-  saveTxs: boolean = true
+  saveTxs: boolean = true,
 ): AsyncGenerator<boolean> {
   let foundAnyTx = false;
   // chunkify addresses
@@ -257,7 +258,7 @@ export async function* loadAddressHistory(
  * @returns {Promise<IScanPolicyLoadAddresses>}
  */
 export async function scanPolicyStartAddresses(
-  storage: IStorage
+  storage: IStorage,
 ): Promise<IScanPolicyLoadAddresses> {
   const scanPolicy = await storage.getScanningPolicy();
   let limits;
@@ -293,7 +294,7 @@ export async function scanPolicyStartAddresses(
  * @returns {Promise<IScanPolicyLoadAddresses|null>}
  */
 export async function checkScanningPolicy(
-  storage: IStorage
+  storage: IStorage,
 ): Promise<IScanPolicyLoadAddresses | null> {
   const scanPolicy = await storage.getScanningPolicy();
   switch (scanPolicy) {
@@ -322,7 +323,7 @@ export async function checkIndexLimit(storage: IStorage): Promise<IScanPolicyLoa
   if (!isIndexLimitScanPolicy(scanPolicyData)) {
     // This error should never happen, but this enforces scanPolicyData typing
     throw new Error(
-      'Wallet is configured to use index-limit but the scan policy data is not configured as index-limit'
+      'Wallet is configured to use index-limit but the scan policy data is not configured as index-limit',
     );
   }
 
@@ -360,7 +361,7 @@ export async function checkGapLimit(storage: IStorage): Promise<IScanPolicyLoadA
   if (!isGapLimitScanPolicy(scanPolicyData)) {
     // This error should never happen, but this enforces scanPolicyData typing
     throw new Error(
-      'Wallet is configured to use gap-limit but the scan policy data is not configured as gap-limit'
+      'Wallet is configured to use gap-limit but the scan policy data is not configured as gap-limit',
     );
   }
   const { gapLimit } = scanPolicyData;
@@ -387,7 +388,7 @@ export async function checkGapLimit(storage: IStorage): Promise<IScanPolicyLoadA
  */
 export async function processHistory(
   storage: IStorage,
-  { rewardLock }: { rewardLock?: number } = {}
+  { rewardLock }: { rewardLock?: number } = {},
 ): Promise<void> {
   const { store } = storage;
   // We have an additive method to update metadata so we need to clean the current metadata before processing.
@@ -414,7 +415,7 @@ export async function processHistory(
 export async function processSingleTx(
   storage: IStorage,
   tx: IHistoryTx,
-  { rewardLock }: { rewardLock?: number } = {}
+  { rewardLock }: { rewardLock?: number } = {},
 ): Promise<void> {
   const { store } = storage;
   const nowTs = Math.floor(Date.now() / 1000);
@@ -518,7 +519,7 @@ export async function processMetadataChanged(storage: IStorage, tx: IHistoryTx):
  */
 export async function _updateTokensData(storage: IStorage, tokens: Set<string>): Promise<void> {
   async function fetchTokenData(
-    uid: string
+    uid: string,
   ): Promise<
     GeneralTokenInfoSchema | { success: true; name: string; symbol: string; version?: TokenVersion }
   > {
@@ -587,7 +588,7 @@ export async function _updateTokensData(storage: IStorage, tokens: Set<string>):
  */
 async function updateWalletMetadataFromProcessedTxData(
   storage: IStorage,
-  { maxIndexUsed, tokens }: { maxIndexUsed: number; tokens: Set<string> }
+  { maxIndexUsed, tokens }: { maxIndexUsed: number; tokens: Set<string> },
 ): Promise<void> {
   const { store } = storage;
   // Update wallet data
@@ -597,7 +598,7 @@ async function updateWalletMetadataFromProcessedTxData(
     if (walletData.lastUsedAddressIndex <= maxIndexUsed) {
       if (walletData.currentAddressIndex <= maxIndexUsed) {
         await store.setCurrentAddressIndex(
-          Math.min(maxIndexUsed + 1, walletData.lastLoadedAddressIndex)
+          Math.min(maxIndexUsed + 1, walletData.lastLoadedAddressIndex),
         );
       }
       await store.setLastUsedAddressIndex(maxIndexUsed);
@@ -630,7 +631,7 @@ export async function processNewTx(
     rewardLock,
     nowTs,
     currentHeight,
-  }: { rewardLock?: number; nowTs?: number; currentHeight?: number } = {}
+  }: { rewardLock?: number; nowTs?: number; currentHeight?: number } = {},
 ): Promise<{
   maxAddressIndex: number;
   tokens: Set<string>;
@@ -912,7 +913,7 @@ export async function processUtxoUnlock(
     rewardLock,
     nowTs,
     currentHeight,
-  }: { rewardLock?: number; nowTs?: number; currentHeight?: number } = {}
+  }: { rewardLock?: number; nowTs?: number; currentHeight?: number } = {},
 ): Promise<void> {
   function getEmptyBalance(): IBalance {
     return {
@@ -1003,7 +1004,7 @@ export async function processUtxoUnlock(
  */
 export async function addCreatedTokenFromTx(
   tx: CreateTokenTransaction,
-  storage: IStorage
+  storage: IStorage,
 ): Promise<void> {
   if (tx.version !== CREATE_TOKEN_TX_VERSION) {
     return;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -6,8 +6,8 @@
  */
 
 import buffer from 'buffer';
-import FeeHeader from '../headers/fee';
-import Header from '../headers/base';
+
+import walletApi from '../api/wallet';
 import {
   CREATE_TOKEN_TX_VERSION,
   NATIVE_TOKEN_UID,
@@ -16,7 +16,14 @@ import {
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
 } from '../constants';
-import helpers from './helpers';
+import {
+  InsufficientFundsError,
+  SendTxError,
+  TokenNotFoundError,
+  TokenValidationError,
+} from '../errors';
+import Header from '../headers/base';
+import FeeHeader from '../headers/fee';
 import {
   AuthorityType,
   IDataInput,
@@ -29,16 +36,11 @@ import {
   TokenVersion,
   UtxoSelectionAlgorithm,
 } from '../types';
+
 import { getAddressType } from './address';
-import {
-  InsufficientFundsError,
-  SendTxError,
-  TokenNotFoundError,
-  TokenValidationError,
-} from '../errors';
-import { bestUtxoSelection } from './utxo';
-import walletApi from '../api/wallet';
 import { Fee } from './fee';
+import helpers from './helpers';
+import { bestUtxoSelection } from './utxo';
 
 const tokens = {
   /**
@@ -52,7 +54,7 @@ const tokens = {
   async validateTokenToAddByConfigurationString(
     config: string,
     storage?: IStorage,
-    uid?: string
+    uid?: string,
   ): Promise<ITokenData> {
     const tokenData = this.getTokenFromConfigurationString(config);
     if (!tokenData) {
@@ -60,7 +62,7 @@ const tokens = {
     }
     if (uid && tokenData.uid !== uid) {
       throw new TokenValidationError(
-        `Configuration string uid does not match: ${uid} != ${tokenData.uid}`
+        `Configuration string uid does not match: ${uid} != ${tokenData.uid}`,
       );
     }
 
@@ -83,14 +85,14 @@ const tokens = {
     if (storage) {
       if (await storage.isTokenRegistered(tokenData.uid)) {
         throw new TokenValidationError(
-          `You already have this token: ${tokenData.uid} (${tokenData.name})`
+          `You already have this token: ${tokenData.uid} (${tokenData.name})`,
         );
       }
 
       const isDuplicate = await this.checkDuplicateTokenInfo(tokenData, storage);
       if (isDuplicate) {
         throw new TokenValidationError(
-          `You already have a token with this ${isDuplicate.key}: ${isDuplicate.token.uid} - ${isDuplicate.token.name} (${isDuplicate.token.symbol})`
+          `You already have a token with this ${isDuplicate.key}: ${isDuplicate.token.uid} - ${isDuplicate.token.name} (${isDuplicate.token.symbol})`,
         );
       }
     }
@@ -111,12 +113,12 @@ const tokens = {
 
     if (response.name !== tokenData.name) {
       throw new TokenValidationError(
-        `Token name does not match with the real one. Added: ${tokenData.name}. Real: ${response.name}`
+        `Token name does not match with the real one. Added: ${tokenData.name}. Real: ${response.name}`,
       );
     }
     if (response.symbol !== tokenData.symbol) {
       throw new TokenValidationError(
-        `Token symbol does not match with the real one. Added: ${tokenData.symbol}. Real: ${response.symbol}`
+        `Token symbol does not match with the real one. Added: ${tokenData.symbol}. Real: ${response.symbol}`,
       );
     }
   },
@@ -130,7 +132,7 @@ const tokens = {
    */
   async checkDuplicateTokenInfo(
     tokenData: ITokenData,
-    storage: IStorage
+    storage: IStorage,
   ): Promise<null | { token: ITokenData; key: string }> {
     const cleanName = helpers.cleanupString(tokenData.name);
     const cleanSymbol = helpers.cleanupString(tokenData.symbol);
@@ -311,7 +313,7 @@ const tokens = {
    */
   getDepositAmount(
     mintAmount: OutputValueType,
-    depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE
+    depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE,
   ): OutputValueType {
     // This conversion from mintAmount to Number may cause loss of precision for large amounts,
     // but this is fully equivalent to the reference Python implementation, which does the same.
@@ -341,7 +343,7 @@ const tokens = {
    */
   getWithdrawAmount(
     meltAmount: OutputValueType,
-    depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE
+    depositPercent: number = TOKEN_DEPOSIT_PERCENTAGE,
   ): OutputValueType {
     return BigInt(Math.floor(depositPercent * Number(meltAmount)));
   },
@@ -394,7 +396,7 @@ const tokens = {
       skipDepositFee?: boolean;
       skipFeeCalculation?: boolean;
       tokenVersion?: TokenVersion;
-    }
+    },
   ): Promise<IDataTx> {
     const inputs: IDataInput[] = [];
     const outputs: IDataOutput[] = [];
@@ -486,7 +488,7 @@ const tokens = {
       if (foundAmount < requiredAmount) {
         const availableAmount = selectedUtxos.available ?? 0;
         throw new InsufficientFundsError(
-          `Not enough HTR tokens for deposit or fee: ${requiredAmount} required, ${availableAmount} available`
+          `Not enough HTR tokens for deposit or fee: ${requiredAmount} required, ${availableAmount} available`,
         );
       }
 
@@ -583,7 +585,7 @@ const tokens = {
       unshiftData?: boolean | null;
       data?: string[] | null;
       utxoSelection?: UtxoSelectionAlgorithm;
-    } = {}
+    } = {},
   ): Promise<IDataTx> {
     if (authorityMeltInput.token !== token || authorityMeltInput.authorities !== 2n) {
       throw new Error('Melt authority input is not valid');
@@ -635,7 +637,7 @@ const tokens = {
     if (foundAmount < amount) {
       const availableAmount = selectedUtxos.available ?? 0;
       throw new InsufficientFundsError(
-        `Not enough tokens to melt: ${amount} requested, ${availableAmount} available`
+        `Not enough tokens to melt: ${amount} requested, ${availableAmount} available`,
       );
     }
 
@@ -696,7 +698,7 @@ const tokens = {
 
       if (htrFoundAmount < requiredAmount) {
         throw new InsufficientFundsError(
-          `Not enough HTR tokens for deposit or fee: ${requiredAmount} required, ${htrFoundAmount} available`
+          `Not enough HTR tokens for deposit or fee: ${requiredAmount} required, ${htrFoundAmount} available`,
         );
       }
 
@@ -789,7 +791,7 @@ const tokens = {
       skipDepositFee?: boolean;
       skipFeeCalculation?: boolean;
       tokenVersion?: TokenVersion;
-    } = {}
+    } = {},
   ): Promise<IDataTx> {
     const mintOptions = {
       createAnotherMint: createMint,
@@ -849,7 +851,7 @@ const tokens = {
     authorityInput: IDataInput, // Authority input
     address: string,
     storage: IStorage,
-    createAnother: boolean = true
+    createAnother: boolean = true,
   ): Promise<IDataTx> {
     const outputs: IDataOutput[] = [
       {
@@ -888,7 +890,7 @@ const tokens = {
    * @returns {IDataTx} Transaction data
    */
   prepareDestroyAuthorityTxData(
-    authorityInputs: IDataInput[] // Authority inputs
+    authorityInputs: IDataInput[], // Authority inputs
   ): IDataTx {
     return {
       inputs: authorityInputs,
@@ -904,7 +906,7 @@ const tokens = {
   getTransactionHTRDeposit(
     mintAmount: OutputValueType,
     dataLen: number,
-    storage: IStorage
+    storage: IStorage,
   ): OutputValueType {
     let mintDeposit = this.getMintDeposit(mintAmount, storage);
     mintDeposit += this.getDataFee(dataLen);
@@ -981,14 +983,14 @@ const tokens = {
         ({
           ...output,
           token: mintingTokenUid,
-        }) satisfies IDataOutputWithToken
+        }) satisfies IDataOutputWithToken,
     );
     // since we control the inputs, we can assume we don't have any melt operation that should be charged at this point.
     // so we can pass an empty array for inputs
     feeAmount = await Fee.calculate(
       [],
       mappedOutputs,
-      await tokens.getTokensByManyIds(storage, new Set(tokensArray))
+      await tokens.getTokensByManyIds(storage, new Set(tokensArray)),
     );
 
     return { feeAmount, depositAmount };

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { z } from 'zod';
 import { crypto as cryptoBL, PrivateKey, HDPrivateKey } from 'bitcore-lib';
 import { cloneDeep } from 'lodash';
-import { Utxo } from '../wallet/types';
-import { UtxoError, ParseError } from '../errors';
-import { HistoryTransactionOutput } from '../models/types';
+import { z } from 'zod';
+
+import { FullNodeTxApiResponse, transactionApiSchema } from '../api/schemas/txApi';
+import txApi from '../api/txApi';
 import {
   TOKEN_AUTHORITY_MASK,
   TOKEN_MINT_MASK,
@@ -24,11 +24,18 @@ import {
   POA_BLOCK_VERSION,
   ON_CHAIN_BLUEPRINTS_VERSION,
 } from '../constants';
-import Transaction from '../models/transaction';
+import { UtxoError, ParseError } from '../errors';
+import Address from '../models/address';
 import CreateTokenTransaction from '../models/create_token_transaction';
 import Input from '../models/input';
-import Output from '../models/output';
 import Network from '../models/network';
+import Output from '../models/output';
+import P2PKH from '../models/p2pkh';
+import P2SH from '../models/p2sh';
+import ScriptData from '../models/script_data';
+import Transaction from '../models/transaction';
+import { HistoryTransactionOutput } from '../models/types';
+import OnChainBlueprint from '../nano_contracts/on_chain_blueprint';
 import {
   IBalance,
   IStorage,
@@ -44,16 +51,11 @@ import {
   IHistoryInput,
   AuthorityType,
 } from '../types';
-import Address from '../models/address';
-import P2PKH from '../models/p2pkh';
-import P2SH from '../models/p2sh';
-import ScriptData from '../models/script_data';
-import helpers from './helpers';
+import { Utxo } from '../wallet/types';
+
 import { getAddressType, getAddressFromPubkey } from './address';
-import txApi from '../api/txApi';
-import { FullNodeTxApiResponse, transactionApiSchema } from '../api/schemas/txApi';
+import helpers from './helpers';
 import tokenUtils from './tokens';
-import OnChainBlueprint from '../nano_contracts/on_chain_blueprint';
 
 const transaction = {
   /**
@@ -109,7 +111,7 @@ const transaction = {
    */
   isOutputLocked(
     output: Pick<HistoryTransactionOutput, 'decoded'>,
-    options: { refTs?: number } = {}
+    options: { refTs?: number } = {},
   ): boolean {
     // XXX: check reward lock: requires blockHeight, bestBlockHeight and reward_spend_min_blocks
     const refTs = options.refTs || Math.floor(Date.now() / 1000);
@@ -132,7 +134,7 @@ const transaction = {
   isHeightLocked(
     blockHeight: number | undefined | null,
     currentHeight: number | undefined | null,
-    rewardLock: number | undefined | null
+    rewardLock: number | undefined | null,
   ): boolean {
     if (!(blockHeight && currentHeight && rewardLock)) {
       // We do not have the details needed to consider this as locked
@@ -170,7 +172,7 @@ const transaction = {
   async getSignatureForTx(
     tx: Transaction,
     storage: IStorage,
-    pinCode: string
+    pinCode: string,
   ): Promise<ITxSignatureData> {
     const xprivstr = await storage.getMainXPrivKey(pinCode);
     const xprivkey = HDPrivateKey.fromString(xprivstr);
@@ -303,7 +305,7 @@ const transaction = {
    */
   selectUtxos(
     utxos: Utxo[],
-    totalAmount: OutputValueType
+    totalAmount: OutputValueType,
   ): { utxos: Utxo[]; changeAmount: OutputValueType } {
     if (totalAmount <= 0) {
       throw new UtxoError('Total amount must be a positive integer.');
@@ -356,7 +358,7 @@ const transaction = {
     txId: string,
     index: number,
     txout: HistoryTransactionOutput,
-    { addressPath = '' }: { addressPath?: string }
+    { addressPath = '' }: { addressPath?: string },
   ): Utxo {
     const isAuthority = this.isAuthorityOutput(txout);
 
@@ -471,7 +473,7 @@ const transaction = {
    */
   async calculateTxBalanceToFillTx(
     token: string,
-    tx: IDataTx
+    tx: IDataTx,
   ): Promise<Record<'funds' | AuthorityType, OutputValueType>> {
     const balance = { funds: 0n, mint: 0n, melt: 0n };
     for (const output of tx.outputs) {
@@ -591,7 +593,7 @@ const transaction = {
    */
   createTransactionFromData(
     txData: IDataTx,
-    network: Network
+    network: Network,
   ): Transaction | CreateTokenTransaction {
     const inputs: Input[] = txData.inputs.map(input => {
       const inputObj = new Input(input.txId, input.index);
@@ -625,7 +627,7 @@ const transaction = {
         txData.symbol!,
         inputs,
         outputs,
-        createTokenOptions
+        createTokenOptions,
       );
     }
     if (options.version === DEFAULT_TX_VERSION) {
@@ -641,7 +643,7 @@ const transaction = {
    */
   async convertTransactionToHistoryTx(
     tx: Transaction | CreateTokenTransaction | OnChainBlueprint,
-    storage: IStorage
+    storage: IStorage,
   ): Promise<IHistoryTx> {
     if (!tx.hash) {
       throw new Error('To be a history tx a calculated hash is required');
@@ -686,7 +688,7 @@ const transaction = {
 
       if (input.index >= spentTx.outputs.length) {
         throw new Error(
-          `Index (${input.index}) outside of transaction output array bounds (${spentTx.outputs.length})`
+          `Index (${input.index}) outside of transaction output array bounds (${spentTx.outputs.length})`,
         );
       }
 
@@ -773,7 +775,7 @@ const transaction = {
     txData: IDataTx,
     pinCode: string,
     storage: IStorage,
-    options?: { signTx?: boolean }
+    options?: { signTx?: boolean },
   ): Promise<Transaction | CreateTokenTransaction> {
     const newOptions = {
       signTx: true,
@@ -889,7 +891,7 @@ const transaction = {
    */
   hydrateIOWithToken<IO extends { token_data: number }, T extends { uid: string }>(
     io: IO,
-    tokens: T[]
+    tokens: T[],
   ): IO & { token: string } {
     const { token_data } = io;
     if (token_data === 0) {

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -48,7 +48,7 @@ export function getAlgorithmFromEnum(algorithm: UtxoSelection): UtxoSelectionAlg
 export async function fastUtxoSelection(
   storage: IStorage,
   token: string,
-  amount: OutputValueType
+  amount: OutputValueType,
 ): Promise<{ utxos: IUtxo[]; amount: OutputValueType; available?: OutputValueType }> {
   const utxos: IUtxo[] = [];
   let utxosAmount = 0n;
@@ -93,7 +93,7 @@ export async function fastUtxoSelection(
 export async function bestUtxoSelection(
   storage: IStorage,
   token: string,
-  amount: OutputValueType
+  amount: OutputValueType,
 ): Promise<{ utxos: IUtxo[]; amount: OutputValueType; available?: OutputValueType }> {
   const utxos: IUtxo[] = [];
   let utxosAmount = 0n;

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -8,6 +8,7 @@
 import { crypto, util, HDPublicKey, HDPrivateKey, Script, PublicKey } from 'bitcore-lib';
 import Mnemonic from 'bitcore-mnemonic';
 import _ from 'lodash';
+
 import {
   HD_WALLET_ENTROPY,
   HATHOR_BIP44_CODE,
@@ -15,11 +16,9 @@ import {
   P2PKH_ACCT_PATH,
   WALLET_SERVICE_AUTH_DERIVATION_PATH,
 } from '../constants';
-import { OP_0 } from '../opcodes';
 import { XPubError, InvalidWords, UncompressedPubKeyError } from '../errors';
 import Network from '../models/network';
-import helpers from './helpers';
-
+import { OP_0 } from '../opcodes';
 import {
   IEncryptedData,
   IMultisigData,
@@ -27,7 +26,9 @@ import {
   WalletType,
   WALLET_FLAGS,
 } from '../types';
+
 import { encryptData, decryptData } from './crypto';
+import helpers from './helpers';
 
 const wallet = {
   /**
@@ -136,7 +137,7 @@ const wallet = {
     pubkey: Buffer,
     chainCode: Buffer,
     fingerprint: Buffer,
-    networkName: string = 'mainnet'
+    networkName: string = 'mainnet',
   ): string {
     const network = new Network(networkName);
     const hdpubkey = new HDPublicKey({
@@ -172,7 +173,7 @@ const wallet = {
     fingerprint: number,
     depth: number,
     childIndex: number,
-    networkName: string
+    networkName: string,
   ): string {
     const network = new Network(networkName);
     const hdprivkey = new HDPrivateKey({
@@ -267,7 +268,7 @@ const wallet = {
    */
   getXPubKeyFromSeed(
     seed: string,
-    options: { passphrase?: string; networkName?: string; accountDerivationIndex?: string } = {}
+    options: { passphrase?: string; networkName?: string; accountDerivationIndex?: string } = {},
   ): string {
     const methodOptions = {
       passphrase: '',
@@ -298,7 +299,7 @@ const wallet = {
    */
   getXPrivKeyFromSeed(
     seed: string,
-    options: { passphrase?: string; networkName?: string } = {}
+    options: { passphrase?: string; networkName?: string } = {},
   ): HDPrivateKey {
     const methodOptions = { passphrase: '', networkName: 'mainnet', ...options };
     const { passphrase, networkName } = methodOptions;
@@ -381,13 +382,13 @@ const wallet = {
       xpubs.map(xp => new HDPublicKey(xp)),
       (xpub: HDPublicKey) => {
         return xpub.publicKey.toString('hex');
-      }
+      },
     );
 
     // xpub comes derived to m/45'/280'/0'
     // Derive to m/45'/280'/0'/0/index
     const pubkeys = sortedXpubs.map(
-      (xpub: HDPublicKey) => xpub.deriveChild(0).deriveChild(index).publicKey
+      (xpub: HDPublicKey) => xpub.deriveChild(0).deriveChild(index).publicKey,
     );
 
     // bitcore-lib sorts the public keys by default before building the script
@@ -446,7 +447,7 @@ const wallet = {
    */
   getMultiSigXPubFromWords(
     seed: string,
-    options: { passphrase?: string; networkName?: string } = {}
+    options: { passphrase?: string; networkName?: string } = {},
   ): string {
     const methodOptions = { passphrase: '', networkName: 'mainnet', ...options };
     const xpriv = this.getXPrivKeyFromSeed(seed, methodOptions);
@@ -473,7 +474,7 @@ const wallet = {
    */
   generateAccessDataFromXpub(
     xpubkey: string,
-    { multisig, hardware = false }: { multisig?: IMultisigData; hardware?: boolean } = {}
+    { multisig, hardware = false }: { multisig?: IMultisigData; hardware?: boolean } = {},
   ): IWalletAccessData {
     let walletFlags = 0 | WALLET_FLAGS.READONLY;
     if (hardware) {
@@ -562,7 +563,7 @@ const wallet = {
       seed?: string;
       password?: string;
       authXpriv?: string;
-    }
+    },
   ): IWalletAccessData {
     let walletType: WalletType;
     if (multisig === undefined) {
@@ -651,7 +652,7 @@ const wallet = {
       password: string;
       passphrase?: string;
       networkName: string;
-    }
+    },
   ): IWalletAccessData {
     let walletType: WalletType;
     if (multisig === undefined) {
@@ -714,7 +715,7 @@ const wallet = {
   changeEncryptionPin(
     accessData: IWalletAccessData,
     oldPin: string,
-    newPin: string
+    newPin: string,
   ): IWalletAccessData {
     const data = _.cloneDeep(accessData);
     if (!(data.mainKey || data.authKey || data.acctPathKey)) {
@@ -754,7 +755,7 @@ const wallet = {
   changeEncryptionPassword(
     accessData: IWalletAccessData,
     oldPassword: string,
-    newPassword: string
+    newPassword: string,
   ): IWalletAccessData {
     const data = _.cloneDeep(accessData);
     if (!data.words) {

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -6,10 +6,11 @@
  */
 
 import { z } from 'zod';
+
 import { NATIVE_TOKEN_UID } from '../../../constants';
 import { txIdSchema } from '../../../schemas';
-import { bigIntCoercibleSchema } from '../../../utils/bigint';
 import { TokenVersion } from '../../../types';
+import { bigIntCoercibleSchema } from '../../../utils/bigint';
 
 /**
  * Schema for validating Hathor addresses.
@@ -428,7 +429,7 @@ export const historyResponseSchema = baseResponseSchema.extend({
       timestamp: z.number(),
       voided: z.number().transform(val => val === 1),
       version: z.number(),
-    })
+    }),
   ),
 });
 
@@ -449,7 +450,7 @@ export const txOutputResponseSchema = baseResponseSchema.extend({
       heightlock: z.number().nullable(),
       locked: z.boolean(),
       addressPath: AddressPathSchema,
-    })
+    }),
   ),
 });
 
@@ -480,7 +481,7 @@ export const txByIdResponseSchema = baseResponseSchema.extend({
       tokenId: z.string(),
       tokenName: z.string(),
       tokenSymbol: z.string(),
-    })
+    }),
   ),
 });
 

--- a/src/wallet/api/swapService.ts
+++ b/src/wallet/api/swapService.ts
@@ -6,14 +6,15 @@
  */
 
 import axios, { AxiosRequestConfig } from 'axios';
-import sha256 from 'crypto-js/sha256';
-import AES from 'crypto-js/aes';
 import CryptoJS from 'crypto-js';
+import AES from 'crypto-js/aes';
+import sha256 from 'crypto-js/sha256';
 import { isNumber } from 'lodash';
-import { AtomicSwapProposal } from '../../models/types';
-import { PartialTxPrefix } from '../../models/partial_tx';
-import { TIMEOUT } from '../../constants';
+
 import config from '../../config';
+import { TIMEOUT } from '../../constants';
+import { PartialTxPrefix } from '../../models/partial_tx';
+import { AtomicSwapProposal } from '../../models/types';
 
 /**
  * This interface represents the type returned on the HTTP response, with its untreated and encrypted data.

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -6,7 +6,9 @@
  */
 
 import { get, isNumber } from 'lodash';
-import { axiosInstance } from './walletServiceAxios';
+
+import { WalletRequestError, TxNotFoundError } from '../../errors';
+import { parseSchema } from '../../utils/bigint';
 import {
   CheckAddressesMineResponseData,
   WalletStatusResponseData,
@@ -30,8 +32,7 @@ import {
   HasTxOutsideFirstAddressResponseData,
 } from '../types';
 import HathorWalletServiceWallet from '../wallet';
-import { WalletRequestError, TxNotFoundError } from '../../errors';
-import { parseSchema } from '../../utils/bigint';
+
 import {
   addressesResponseSchema,
   checkAddressesMineResponseSchema,
@@ -53,6 +54,7 @@ import {
   txProposalDeleteResponseSchema,
   hasTxOutsideFirstAddressResponseSchema,
 } from './schemas/walletApi';
+import { axiosInstance } from './walletServiceAxios';
 
 /**
  * Api calls for wallet
@@ -89,7 +91,7 @@ const walletApi = {
     authXpubkey: string,
     authXpubkeySignature: string,
     timestamp: number,
-    firstAddress: string | null = null
+    firstAddress: string | null = null,
   ): Promise<WalletStatusResponseData> {
     const data: {
       authXpubkeySignature: string;
@@ -123,7 +125,7 @@ const walletApi = {
 
   async getAddresses(
     wallet: HathorWalletServiceWallet,
-    index?: number
+    index?: number,
   ): Promise<AddressesResponseData> {
     const axios = await axiosInstance(wallet, true);
     const path = isNumber(index) ? `?index=${index}` : '';
@@ -139,7 +141,7 @@ const walletApi = {
 
   async getAddressDetails(
     wallet: HathorWalletServiceWallet,
-    address: string
+    address: string,
   ): Promise<AddressDetailsResponseData> {
     const axios = await axiosInstance(wallet, true);
     const query = `?address=${address}`;
@@ -155,7 +157,7 @@ const walletApi = {
 
   async checkAddressesMine(
     wallet: HathorWalletServiceWallet,
-    addresses: string[]
+    addresses: string[],
   ): Promise<CheckAddressesMineResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.post('wallet/addresses/check_mine', { addresses });
@@ -177,7 +179,7 @@ const walletApi = {
 
   async getTokenDetails(
     wallet: HathorWalletServiceWallet,
-    tokenId: string
+    tokenId: string,
   ): Promise<TokenDetailsResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get(`wallet/tokens/${tokenId}/details`);
@@ -190,7 +192,7 @@ const walletApi = {
 
   async getBalances(
     wallet: HathorWalletServiceWallet,
-    token: string | null = null
+    token: string | null = null,
   ): Promise<BalanceResponseData> {
     const data: { params: { token_id?: string } } = { params: {} };
     if (token) {
@@ -225,7 +227,7 @@ const walletApi = {
 
   async getTxOutputs(
     wallet: HathorWalletServiceWallet,
-    options: GetTxOutputsOptions = {}
+    options: GetTxOutputsOptions = {},
   ): Promise<TxOutputResponseData> {
     const data = { params: options };
     const axios = await axiosInstance(wallet, true);
@@ -238,7 +240,7 @@ const walletApi = {
 
   async createTxProposal(
     wallet: HathorWalletServiceWallet,
-    txHex: string
+    txHex: string,
   ): Promise<TxProposalCreateResponseData> {
     const data = { txHex };
     const axios = await axiosInstance(wallet, true);
@@ -252,7 +254,7 @@ const walletApi = {
   async updateTxProposal(
     wallet: HathorWalletServiceWallet,
     id: string,
-    txHex: string
+    txHex: string,
   ): Promise<TxProposalUpdateResponseData> {
     const data = { txHex };
     const axios = await axiosInstance(wallet, true);
@@ -265,7 +267,7 @@ const walletApi = {
 
   async deleteTxProposal(
     wallet: HathorWalletServiceWallet,
-    id: string
+    id: string,
   ): Promise<TxProposalDeleteResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.delete(`tx/proposal/${id}`);
@@ -279,7 +281,7 @@ const walletApi = {
     wallet: HathorWalletServiceWallet,
     timestamp: number,
     xpub: string,
-    sign: string
+    sign: string,
   ): Promise<AuthTokenResponseData> {
     const data = {
       ts: timestamp,
@@ -298,7 +300,7 @@ const walletApi = {
 
   async createReadOnlyAuthToken(
     wallet: HathorWalletServiceWallet,
-    xpubkey: string
+    xpubkey: string,
   ): Promise<AuthTokenResponseData> {
     const data = {
       xpubkey,
@@ -314,7 +316,7 @@ const walletApi = {
 
   async getTxById(
     wallet: HathorWalletServiceWallet,
-    txId: string
+    txId: string,
   ): Promise<TxByIdTokensResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get(`wallet/transactions/${txId}`);
@@ -355,7 +357,7 @@ const walletApi = {
 
   async getFullTxById(
     wallet: HathorWalletServiceWallet,
-    txId: string
+    txId: string,
   ): Promise<FullNodeTxResponse> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get(`wallet/proxy/transactions/${txId}`);
@@ -372,7 +374,7 @@ const walletApi = {
 
   async getTxConfirmationData(
     wallet: HathorWalletServiceWallet,
-    txId: string
+    txId: string,
   ): Promise<FullNodeTxConfirmationDataResponse> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get(`wallet/proxy/transactions/${txId}/confirmation_data`);
@@ -386,7 +388,7 @@ const walletApi = {
       'Error getting transaction confirmation data by its id from the proxied fullnode.',
       {
         cause: response.data,
-      }
+      },
     );
   },
 
@@ -394,11 +396,11 @@ const walletApi = {
     wallet: HathorWalletServiceWallet,
     txId: string,
     graphType: string,
-    maxLevel: number
+    maxLevel: number,
   ): Promise<string> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get(
-      `wallet/proxy/graphviz/neighbours?txId=${txId}&graphType=${graphType}&maxLevel=${maxLevel}`
+      `wallet/proxy/graphviz/neighbours?txId=${txId}&graphType=${graphType}&maxLevel=${maxLevel}`,
     );
     if (response.status === 200) {
       // The service might answer a status code 200 but output an error message like
@@ -413,7 +415,7 @@ const walletApi = {
           `Error getting neighbors data for ${txId} from the proxied fullnode.`,
           {
             cause: response.data.message,
-          }
+          },
         );
       }
 
@@ -424,12 +426,12 @@ const walletApi = {
       `Error getting neighbors data for ${txId} from the proxied fullnode.`,
       {
         cause: response.data,
-      }
+      },
     );
   },
 
   async getHasTxOutsideFirstAddress(
-    wallet: HathorWalletServiceWallet
+    wallet: HathorWalletServiceWallet,
   ): Promise<HasTxOutsideFirstAddressResponseData> {
     const axios = await axiosInstance(wallet, true);
     const response = await axios.get('wallet/addresses/has-transactions-outside-first-address');
@@ -437,7 +439,7 @@ const walletApi = {
       return parseSchema(response.data, hasTxOutsideFirstAddressResponseSchema);
     }
     throw new WalletRequestError(
-      'Error checking if wallet has transactions outside first address.'
+      'Error checking if wallet has transactions outside first address.',
     );
   },
 };

--- a/src/wallet/api/walletServiceAxios.ts
+++ b/src/wallet/api/walletServiceAxios.ts
@@ -6,9 +6,10 @@
  */
 
 import axios from 'axios';
+
+import config from '../../config';
 import { TIMEOUT } from '../../constants';
 import HathorWalletServiceWallet from '../wallet';
-import config from '../../config';
 
 /**
  * Method that creates an axios instance
@@ -26,7 +27,7 @@ import config from '../../config';
 export const axiosInstance = async (
   wallet: HathorWalletServiceWallet,
   needsAuth: boolean,
-  timeout: number = TIMEOUT
+  timeout: number = TIMEOUT,
 ) => {
   // TODO How to allow 'Retry' request?
   const defaultOptions: {

--- a/src/wallet/connection.ts
+++ b/src/wallet/connection.ts
@@ -5,13 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { getDefaultLogger } from '../types';
-import WalletServiceWebSocket from './websocket';
 import config from '../config';
 import BaseConnection, { DEFAULT_PARAMS, ConnectionParams } from '../connection';
-import { WsTransaction, ConnectionState } from './types';
+import { getDefaultLogger } from '../types';
 import { parseSchema } from '../utils/bigint';
+
 import { wsTransactionSchema } from './api/schemas/walletApi';
+import { WsTransaction, ConnectionState } from './types';
+import WalletServiceWebSocket from './websocket';
 
 export interface WalletServiceConnectionParams extends ConnectionParams {
   walletId: string;

--- a/src/wallet/mineTransaction.ts
+++ b/src/wallet/mineTransaction.ts
@@ -6,10 +6,12 @@
  */
 
 import { EventEmitter } from 'events';
+
+import txMiningApi from '../api/txMining';
 import { MIN_POLLING_INTERVAL } from '../constants';
 import { MineTxError } from '../errors';
 import Transaction from '../models/transaction';
-import txMiningApi from '../api/txMining';
+
 import { MineTxSuccessData } from './types';
 
 // Error to be shown in case of no miners connected

--- a/src/wallet/partialTxProposal.ts
+++ b/src/wallet/partialTxProposal.ts
@@ -5,21 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { PartialTx, PartialTxInputData } from '../models/partial_tx';
+import { NATIVE_TOKEN_UID, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../constants';
+import { AddressError, InvalidPartialTxError } from '../errors';
 import Address from '../models/address';
-import P2SH from '../models/p2sh';
 import P2PKH from '../models/p2pkh';
+import P2SH from '../models/p2sh';
+import { PartialTx, PartialTxInputData } from '../models/partial_tx';
 import ScriptData from '../models/script_data';
 import Transaction from '../models/transaction';
-import { AddressError, InvalidPartialTxError } from '../errors';
-import { NATIVE_TOKEN_UID, TOKEN_MELT_MASK, TOKEN_MINT_MASK } from '../constants';
-
-import transactionUtils from '../utils/transaction';
-import dateFormatter from '../utils/date';
-
-import { OutputType, Utxo } from './types';
 import { Balance } from '../models/types';
 import { IStorage, OutputValueType } from '../types';
+import dateFormatter from '../utils/date';
+import transactionUtils from '../utils/transaction';
+
+import { OutputType, Utxo } from './types';
 
 class PartialTxProposal {
   public partialTx: PartialTx;
@@ -76,7 +75,7 @@ class PartialTxProposal {
       utxos = [],
       changeAddress = null,
       markAsSelected = true,
-    }: { utxos?: Utxo[] | null; changeAddress?: string | null; markAsSelected?: boolean } = {}
+    }: { utxos?: Utxo[] | null; changeAddress?: string | null; markAsSelected?: boolean } = {},
   ) {
     this.resetSignatures();
 
@@ -105,7 +104,7 @@ class PartialTxProposal {
     // Filter pool of utxos for only utxos from the token and not already in the partial tx
     const currentUtxos = this.partialTx.inputs.map(input => `${input.hash}-${input.index}`);
     const utxosToUse = allUtxos.filter(
-      utxo => utxo.tokenId === token && !currentUtxos.includes(`${utxo.txId}-${utxo.index}`)
+      utxo => utxo.tokenId === token && !currentUtxos.includes(`${utxo.txId}-${utxo.index}`),
     );
 
     const utxosDetails = transactionUtils.selectUtxos(utxosToUse, value);
@@ -138,7 +137,7 @@ class PartialTxProposal {
   async addReceive(
     token: string,
     value: OutputValueType,
-    { timelock = null, address = null }: { timelock?: number | null; address?: string | null } = {}
+    { timelock = null, address = null }: { timelock?: number | null; address?: string | null } = {},
   ) {
     this.resetSignatures();
 
@@ -172,7 +171,7 @@ class PartialTxProposal {
       token?: string;
       authorities?: OutputValueType;
       markAsSelected?: boolean;
-    } = {}
+    } = {},
   ) {
     this.resetSignatures();
 
@@ -204,7 +203,7 @@ class PartialTxProposal {
       timelock = null,
       isChange = false,
       authorities = 0n,
-    }: { timelock?: number | null; isChange?: boolean; authorities?: OutputValueType } = {}
+    }: { timelock?: number | null; isChange?: boolean; authorities?: OutputValueType } = {},
   ) {
     this.resetSignatures();
 

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -7,20 +7,24 @@
 
 /* eslint-disable max-classes-per-file -- AddressPathMap is a private helper tightly coupled to SendTransactionWalletService */
 import { EventEmitter } from 'events';
+
 import { shuffle } from 'lodash';
-import tokensUtils from '../utils/tokens';
-import walletApi from './api/walletApi';
-import MineTransaction from './mineTransaction';
-import HathorWalletServiceWallet from './wallet';
-import helpers from '../utils/helpers';
+
+import { DEFAULT_NATIVE_TOKEN_CONFIG, FEE_PER_OUTPUT, NATIVE_TOKEN_UID } from '../constants';
+import { SendTxError, UtxoError, WalletError, WalletRequestError } from '../errors';
+import { FeeHeader, Header } from '../headers';
+import Address from '../models/address';
+import Input from '../models/input';
+import Output from '../models/output';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
 import Transaction from '../models/transaction';
-import Output from '../models/output';
-import Input from '../models/input';
-import Address from '../models/address';
-import { DEFAULT_NATIVE_TOKEN_CONFIG, FEE_PER_OUTPUT, NATIVE_TOKEN_UID } from '../constants';
-import { SendTxError, UtxoError, WalletError, WalletRequestError } from '../errors';
+import { IDataInput, IDataOutputWithToken, IDataTx, TokenVersion } from '../types';
+import helpers from '../utils/helpers';
+import tokensUtils from '../utils/tokens';
+
+import walletApi from './api/walletApi';
+import MineTransaction from './mineTransaction';
 import {
   OutputSendTransaction,
   InputRequestObj,
@@ -30,8 +34,7 @@ import {
   OutputType,
   Utxo,
 } from './types';
-import { IDataInput, IDataOutputWithToken, IDataTx, TokenVersion } from '../types';
-import { FeeHeader, Header } from '../headers';
+import HathorWalletServiceWallet from './wallet';
 
 type optionsType = {
   outputs?: OutputSendTransaction[];
@@ -206,13 +209,13 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         const utxo = await this.wallet.getUtxoFromId(input.txId, input.index);
         if (utxo === null) {
           throw new UtxoError(
-            `Invalid input selection. Input ${input.txId} at index ${input.index}.`
+            `Invalid input selection. Input ${input.txId} at index ${input.index}.`,
           );
         }
 
         if (!(utxo.tokenId in tokenAmountMap)) {
           throw new SendTxError(
-            `Invalid input selection. Input ${input.txId} at index ${input.index} has token ${utxo.tokenId} that is not on the outputs.`
+            `Invalid input selection. Input ${input.txId} at index ${input.index} has token ${utxo.tokenId} that is not on the outputs.`,
           );
         }
 
@@ -252,7 +255,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         userInputData.amount,
         tokenAmountMap[token].amount,
         tokenAmountMap[token].version,
-        finalOutputs
+        finalOutputs,
       );
     }
 
@@ -262,7 +265,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     // - Each fee-based token change output increments _feeAmount
     // - We need the final _feeAmount to know how much NATIVE TOKEN is needed
     const customTokens = Array.from(tokenNeedsInputs.keys()).filter(
-      token => token !== NATIVE_TOKEN_UID
+      token => token !== NATIVE_TOKEN_UID,
     );
     await this.selectUtxosForTokens(
       customTokens,
@@ -271,7 +274,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       finalInputs,
       utxosAddressPath,
       utxoDataMap,
-      finalOutputs
+      finalOutputs,
     );
 
     // 3.5. Add the calculated fee to HTR requirements
@@ -300,7 +303,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         userHtrData.amount,
         requiredHtr,
         TokenVersion.NATIVE,
-        finalOutputs
+        finalOutputs,
       );
     } else {
       // No HTR inputs provided - auto-select UTXOs if needed
@@ -311,7 +314,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         finalInputs,
         utxosAddressPath,
         utxoDataMap,
-        finalOutputs
+        finalOutputs,
       );
     }
 
@@ -332,7 +335,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       if (!utxo) {
         // Should not happen as we cached them before
         throw new UtxoError(
-          `Could not retrieve utxo details for input ${input.txId}:${input.index}`
+          `Could not retrieve utxo details for input ${input.txId}:${input.index}`,
         );
       }
       dataInputs.push({
@@ -501,7 +504,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
           throw new SendTxError(
             `Input ${input.txId}:${input.index} was not processed by any validation pass. ` +
               'This usually means an HTR input was provided but no HTR is required ' +
-              '(no HTR outputs and no fee-token fees).'
+              '(no HTR outputs and no fee-token fees).',
           );
         }
         return path;
@@ -596,7 +599,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     options: {
       ignoreNative?: boolean;
       onlyNative?: boolean;
-    } = {}
+    } = {},
   ): Promise<void> {
     const { ignoreNative = false, onlyNative = false } = options;
     const amountInputMap = {};
@@ -604,7 +607,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
       const utxo = await this.wallet.getUtxoFromId(input.txId, input.index);
       if (utxo === null) {
         throw new UtxoError(
-          `Invalid input selection. Input ${input.txId} at index ${input.index}.`
+          `Invalid input selection. Input ${input.txId} at index ${input.index}.`,
         );
       }
 
@@ -622,7 +625,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
 
       if (!(utxo.tokenId in tokenAmountMap)) {
         throw new SendTxError(
-          `Invalid input selection. Input ${input.txId} at index ${input.index} has token ${utxo.tokenId} that is not on the outputs.`
+          `Invalid input selection. Input ${input.txId} at index ${input.index} has token ${utxo.tokenId} that is not on the outputs.`,
         );
       }
 
@@ -638,13 +641,13 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     for (const t in tokenAmountMap) {
       if (!(t in amountInputMap)) {
         throw new SendTxError(
-          `Invalid input selection. Token ${t} is in the outputs but there are no inputs for it.`
+          `Invalid input selection. Token ${t} is in the outputs but there are no inputs for it.`,
         );
       }
 
       if (amountInputMap[t] < tokenAmountMap[t].amount) {
         throw new SendTxError(
-          `Invalid input selection. Sum of inputs for token ${t} is smaller than the sum of outputs.`
+          `Invalid input selection. Sum of inputs for token ${t} is smaller than the sum of outputs.`,
         );
       }
 
@@ -689,7 +692,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     finalInputs: InputRequestObj[],
     utxosAddressPath: string[],
     utxoDataMap: Map<string, Utxo>,
-    finalOutputs: OutputSendTransaction[]
+    finalOutputs: OutputSendTransaction[],
   ): Promise<void> {
     for (const token of tokensToProcess) {
       const needsInputs = tokenNeedsInputs.get(token);
@@ -699,12 +702,12 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
 
       const { utxos, changeAmount } = await this.wallet.getUtxosForAmount(
         tokenAmountMap[token].amount,
-        { token }
+        { token },
       );
 
       if (utxos.length === 0) {
         throw new UtxoError(
-          `No utxos available to fill the request. Token: ${token} - Amount: ${tokenAmountMap[token].amount}.`
+          `No utxos available to fill the request. Token: ${token} - Amount: ${tokenAmountMap[token].amount}.`,
         );
       }
 
@@ -753,11 +756,11 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     userInputAmount: bigint,
     requiredAmount: bigint,
     tokenVersion: TokenVersion,
-    finalOutputs: OutputSendTransaction[]
+    finalOutputs: OutputSendTransaction[],
   ): void {
     if (userInputAmount < requiredAmount) {
       throw new SendTxError(
-        `Invalid input selection. Sum of inputs for token ${token} is smaller than the sum of outputs.`
+        `Invalid input selection. Sum of inputs for token ${token} is smaller than the sum of outputs.`,
       );
     }
 
@@ -794,11 +797,11 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         tokenAmountMap[token].amount,
         {
           token,
-        }
+        },
       );
       if (utxos.length === 0) {
         throw new UtxoError(
-          `No utxos available to fill the request. Token: ${token} - Amount: ${tokenAmountMap[token].amount}.`
+          `No utxos available to fill the request. Token: ${token} - Amount: ${tokenAmountMap[token].amount}.`,
         );
       }
 
@@ -844,7 +847,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
     }
     if (this.utxosAddressPath.length !== this.transaction.inputs.length) {
       throw new SendTxError(
-        'utxosAddressPath length does not match transaction inputs. Call prepareTx() first.'
+        'utxosAddressPath length does not match transaction inputs. Call prepareTx() first.',
       );
     }
     this.emit('sign-tx-start');
@@ -856,7 +859,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
         xprivkey,
         dataToSignHash,
         // the wallet service returns the full BIP44 path, but we only need the address path:
-        HathorWalletServiceWallet.getAddressIndexFromFullPath(this.utxosAddressPath[idx])
+        HathorWalletServiceWallet.getAddressIndexFromFullPath(this.utxosAddressPath[idx]),
       );
       inputObj.setData(inputData);
     }
@@ -1020,7 +1023,7 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
    */
   async run(
     until: 'prepare-tx' | 'sign-tx' | 'mine-tx' | null = null,
-    pin: string | null = null
+    pin: string | null = null,
   ): Promise<Transaction> {
     try {
       if (this._currentStep === 'idle') {

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -6,6 +6,13 @@
  */
 
 import bitcore from 'bitcore-lib';
+
+import CreateTokenTransaction from '../models/create_token_transaction';
+import Input from '../models/input';
+import Output from '../models/output';
+import Transaction from '../models/transaction';
+import NanoContractHeader from '../nano_contracts/header';
+import { CreateNanoTxData, CreateNanoTxOptions } from '../nano_contracts/types';
 import {
   TokenVersion,
   IStorage,
@@ -14,13 +21,8 @@ import {
   IDataTx,
   WalletAddressMode,
 } from '../types';
-import Transaction from '../models/transaction';
-import CreateTokenTransaction from '../models/create_token_transaction';
+
 import SendTransactionWalletService from './sendTransactionWalletService';
-import Input from '../models/input';
-import Output from '../models/output';
-import { CreateNanoTxData, CreateNanoTxOptions } from '../nano_contracts/types';
-import NanoContractHeader from '../nano_contracts/header';
 
 // Type used in create token methods so we can have defaults for required params
 export type CreateTokenOptionsInput = {
@@ -351,12 +353,12 @@ export interface IHathorWallet {
   }): Promise<GetHistoryObject[]>;
   sendManyOutputsTransaction(
     outputs: OutputRequestObj[],
-    options: { inputs?: InputRequestObj[]; changeAddress?: string }
+    options: { inputs?: InputRequestObj[]; changeAddress?: string },
   ): Promise<Transaction>;
   sendTransaction(
     address: string,
     value: OutputValueType,
-    options: { token?: string; changeAddress?: string }
+    options: { token?: string; changeAddress?: string },
   ): Promise<Transaction>;
   stop(params?: IStopWalletParams): void;
   getAddressAtIndex(index: number): Promise<string>;
@@ -371,20 +373,20 @@ export interface IHathorWallet {
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options
+    options,
   ): Promise<CreateTokenTransaction>;
   createNewToken(
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options
+    options,
   ): Promise<Transaction>;
   createNFT(
     name: string,
     symbol: string,
     amount: OutputValueType,
     data: string,
-    options
+    options,
   ): Promise<Transaction>;
   prepareMintTokensData(token: string, amount: OutputValueType, options): Promise<Transaction>;
   mintTokens(token: string, amount: OutputValueType, options): Promise<Transaction>;
@@ -394,25 +396,25 @@ export interface IHathorWallet {
     token: string,
     type: string,
     address: string,
-    options: WalletServiceDelegateAuthorityOptions
+    options: WalletServiceDelegateAuthorityOptions,
   ): Promise<Transaction>;
   delegateAuthority(
     token: string,
     type: string,
     address: string,
-    options: WalletServiceDelegateAuthorityOptions
+    options: WalletServiceDelegateAuthorityOptions,
   ): Promise<Transaction>;
   prepareDestroyAuthorityData(
     token: string,
     type: string,
     count: number,
-    options: WalletServiceDestroyAuthorityOptions
+    options: WalletServiceDestroyAuthorityOptions,
   ): Promise<Transaction>;
   destroyAuthority(
     token: string,
     type: string,
     count: number,
-    options: WalletServiceDestroyAuthorityOptions
+    options: WalletServiceDestroyAuthorityOptions,
   ): Promise<Transaction>;
   getFullHistory(): TransactionFullObject[] | Promise<unknown>; // FIXME: Should have a single return type;
   getTxBalance(tx: IHistoryTx, optionsParams): Promise<{ [tokenId: string]: OutputValueType }>;
@@ -432,33 +434,33 @@ export interface IHathorWallet {
   getAddressPathForIndex(index: number): Promise<string>;
   sendManyOutputsSendTransaction(
     outputs: Array<OutputRequestObj | DataScriptOutputRequestObj>,
-    options?: { inputs?: InputRequestObj[]; changeAddress?: string; pinCode?: string }
+    options?: { inputs?: InputRequestObj[]; changeAddress?: string; pinCode?: string },
   ): Promise<SendTransactionWalletService>;
   createNanoContractTransaction(
     method: string,
     address: string,
     data: CreateNanoTxData,
-    options?: CreateNanoTxOptions
+    options?: CreateNanoTxOptions,
   ): Promise<SendTransactionWalletService>;
   createAndSendNanoContractTransaction(
     method: string,
     address: string,
     data: CreateNanoTxData,
-    options?: CreateNanoTxOptions
+    options?: CreateNanoTxOptions,
   ): Promise<Transaction>;
   createNanoContractCreateTokenTransaction(
     method: string,
     address: string,
     data: CreateNanoTxData,
     createTokenOptions: CreateTokenOptionsInput,
-    options?: CreateNanoTxOptions
+    options?: CreateNanoTxOptions,
   ): Promise<SendTransactionWalletService>;
   createAndSendNanoContractCreateTokenTransaction(
     method: string,
     address: string,
     data: CreateNanoTxData,
     createTokenOptions: CreateTokenOptionsInput,
-    options?: CreateNanoTxOptions
+    options?: CreateNanoTxOptions,
   ): Promise<Transaction>;
   getNanoHeaderSeqnum(address: string): Promise<number>;
   isAddressMine(address: string): Promise<boolean>;
@@ -467,7 +469,7 @@ export interface IHathorWallet {
     options?: {
       token?: string;
       filter_address?: string;
-    }
+    },
   ): Promise<{ utxos: Utxo[]; changeAmount: OutputValueType }>;
   getUtxos(options?: {
     token?: string;
@@ -506,7 +508,7 @@ export interface IHathorWallet {
 export interface ISendTransaction {
   run(
     until?: 'prepare-tx' | 'sign-tx' | 'mine-tx' | null,
-    pin?: string | null
+    pin?: string | null,
   ): Promise<Transaction>;
   runFromMining(until?: 'mine-tx' | null): Promise<Transaction>;
   prepareTx(): Promise<Transaction>;

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -5,11 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { EventEmitter } from 'events';
-import bitcore, { util } from 'bitcore-lib';
 import assert from 'assert';
-import Header from '../headers/base';
-import FeeHeader from '../headers/fee';
+import { EventEmitter } from 'events';
+
+import bitcore, { util } from 'bitcore-lib';
+
+import config from '../config';
 import {
   NATIVE_TOKEN_UID,
   TOKEN_MINT_MASK,
@@ -20,23 +21,60 @@ import {
   P2PKH_ACCT_PATH,
   GAP_LIMIT,
 } from '../constants';
-import { decryptData, signMessage } from '../utils/crypto';
-import walletApi from './api/walletApi';
-import { deriveAddressFromXPubP2PKH } from '../utils/address';
-import walletUtils from '../utils/wallet';
-import helpers from '../utils/helpers';
-import transaction from '../utils/transaction';
-import tokens from '../utils/tokens';
-import config from '../config';
+import { ErrorMessages } from '../errorMessages';
+import {
+  SendTxError,
+  UtxoError,
+  WalletRequestError,
+  WalletError,
+  UninitializedWalletError,
+  WalletFromXPubGuard,
+  PinRequiredError,
+  TokenNotFoundError,
+  HasTxOutsideFirstAddressError,
+} from '../errors';
+import Header from '../headers/base';
+import FeeHeader from '../headers/fee';
+import Address from '../models/address';
+import CreateTokenTransaction from '../models/create_token_transaction';
+import Input from '../models/input';
+import Network from '../models/network';
+import Output from '../models/output';
 import P2PKH from '../models/p2pkh';
 import Transaction from '../models/transaction';
-import CreateTokenTransaction from '../models/create_token_transaction';
-import Output from '../models/output';
-import Input from '../models/input';
-import Address from '../models/address';
-import Network from '../models/network';
+import NanoContractTransactionBuilder from '../nano_contracts/builder';
+import NanoContractHeader from '../nano_contracts/header';
+import {
+  NanoContractVertexType,
+  NanoContractBuilderCreateTokenOptions,
+  CreateNanoTxData,
+  CreateNanoTxOptions,
+} from '../nano_contracts/types';
+import { setNanoHeaderCallerFromWallet } from '../nano_contracts/utils';
 import networkInstance from '../network';
+import HathorWallet from '../new/wallet';
 import { MemoryStore, Storage } from '../storage';
+import {
+  IStorage,
+  IWalletAccessData,
+  OutputValueType,
+  IHistoryTx,
+  IDataOutputWithToken,
+  WalletType,
+  ITokenData,
+  TokenVersion,
+  SCANNING_POLICY,
+  WalletAddressMode,
+} from '../types';
+import { deriveAddressFromXPubP2PKH } from '../utils/address';
+import { decryptData, signMessage } from '../utils/crypto';
+import { Fee } from '../utils/fee';
+import helpers from '../utils/helpers';
+import tokens from '../utils/tokens';
+import transaction from '../utils/transaction';
+import walletUtils from '../utils/wallet';
+
+import walletApi from './api/walletApi';
 import WalletServiceConnection from './connection';
 import SendTransactionWalletService from './sendTransactionWalletService';
 import {
@@ -70,42 +108,7 @@ import {
   GetAddressDetailsObject,
   CreateTokenOptionsInput,
 } from './types';
-import {
-  SendTxError,
-  UtxoError,
-  WalletRequestError,
-  WalletError,
-  UninitializedWalletError,
-  WalletFromXPubGuard,
-  PinRequiredError,
-  TokenNotFoundError,
-  HasTxOutsideFirstAddressError,
-} from '../errors';
-import NanoContractTransactionBuilder from '../nano_contracts/builder';
-import NanoContractHeader from '../nano_contracts/header';
-import {
-  NanoContractVertexType,
-  NanoContractBuilderCreateTokenOptions,
-  CreateNanoTxData,
-  CreateNanoTxOptions,
-} from '../nano_contracts/types';
-import { setNanoHeaderCallerFromWallet } from '../nano_contracts/utils';
 import { WalletServiceStorageProxy } from './walletServiceStorageProxy';
-import HathorWallet from '../new/wallet';
-import { ErrorMessages } from '../errorMessages';
-import {
-  IStorage,
-  IWalletAccessData,
-  OutputValueType,
-  IHistoryTx,
-  IDataOutputWithToken,
-  WalletType,
-  ITokenData,
-  TokenVersion,
-  SCANNING_POLICY,
-  WalletAddressMode,
-} from '../types';
-import { Fee } from '../utils/fee';
 
 // Time in milliseconds berween each polling to check wallet status
 // if it ended loading and became ready
@@ -293,10 +296,10 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async getServerUrlsFromStorage(): Promise<WalletServiceServerUrls> {
     const walletServiceBaseUrl = (await this.storage.store.getItem(
-      'wallet:wallet_service:base_server'
+      'wallet:wallet_service:base_server',
     )) as string;
     const walletServiceWsUrl = (await this.storage.store.getItem(
-      'wallet:wallet_service:ws_server'
+      'wallet:wallet_service:ws_server',
     )) as string;
 
     return {
@@ -340,7 +343,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   static getAuthXPubKeyFromSeed(
     seed: string,
-    options: { passphrase?: string; networkName?: string } = {}
+    options: { passphrase?: string; networkName?: string } = {},
   ): string {
     const methodOptions = {
       passphrase: '',
@@ -518,7 +521,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       authXpub,
       authXpubkeySignature,
       timestampNow,
-      firstAddress
+      firstAddress,
     );
 
     // Set walletId immediately after wallet creation
@@ -574,7 +577,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async generateCreateWalletAuthData(
     accessData: IWalletAccessData,
-    pinCode: string
+    pinCode: string,
   ): Promise<CreateWalletAuthData> {
     let privKey: bitcore.HDPrivateKey;
     let privKeyAccountPath: bitcore.HDPrivateKey;
@@ -616,7 +619,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     } else {
       try {
         authDerivedPrivKey = bitcore.HDPrivateKey.fromString(
-          await this.storage.getAuthPrivKey(pinCode)
+          await this.storage.getAuthPrivKey(pinCode),
         );
       } catch (err) {
         throw new Error('Cannot fetch or derive auth path key');
@@ -635,7 +638,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const { base58: firstAddress } = deriveAddressFromXPubP2PKH(
       xpubChangeDerivation,
       0,
-      this.network.name
+      this.network.name,
     );
 
     return {
@@ -713,7 +716,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * */
   async getTxBalance(
     tx: IHistoryTx,
-    optionsParam = {}
+    optionsParam = {},
   ): Promise<{ [tokenId: string]: OutputValueType }> {
     const options = { includeAuthorities: false, ...optionsParam };
 
@@ -938,7 +941,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * @inner
    */
   async getTxHistory(
-    options: { token_id?: string; count?: number; skip?: number } = {}
+    options: { token_id?: string; count?: number; skip?: number } = {},
   ): Promise<GetHistoryObject[]> {
     this.failIfWalletNotReady();
     const data = await walletApi.getHistory(this, options);
@@ -964,7 +967,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     }
     if (utxos.length > 1) {
       throw new UtxoError(
-        `Expected to receive only one utxo for txId ${txId} and index ${index} but received ${utxos.length}.`
+        `Expected to receive only one utxo for txId ${txId} and index ${index} but received ${utxos.length}.`,
       );
     }
 
@@ -999,7 +1002,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       amount_bigger_than?: number;
       max_amount?: number;
       only_available_utxos?: boolean;
-    } = {}
+    } = {},
   ): Promise<{
     total_amount_available: bigint;
     total_utxos_available: bigint;
@@ -1089,7 +1092,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     options: {
       token?: string;
       filter_address?: string;
-    } = {}
+    } = {},
   ): Promise<{ utxos: Utxo[]; changeAmount: OutputValueType }> {
     if (amount <= 0) {
       throw new UtxoError('Total amount must be a positive integer.');
@@ -1184,7 +1187,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       // without blocking this method's promise
 
       const privKey = bitcore.HDPrivateKey.fromString(
-        await this.storage.getAuthPrivKey(usePassword)
+        await this.storage.getAuthPrivKey(usePassword),
       );
 
       this.renewAuthToken(privKey, timestampNow);
@@ -1293,7 +1296,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         // Wallet is in error state or other invalid state
         throw new WalletRequestError(
           'Wallet must be initialized and ready before starting in read-only mode.',
-          { cause: walletStatus.status }
+          { cause: walletStatus.status },
         );
       }
     }
@@ -1309,7 +1312,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async sendManyOutputsSendTransaction(
     outputs: Array<OutputRequestObj | DataScriptOutputRequestObj>,
-    options: { inputs?: InputRequestObj[]; changeAddress?: string; pinCode?: string } = {}
+    options: { inputs?: InputRequestObj[]; changeAddress?: string; pinCode?: string } = {},
   ): Promise<SendTransactionWalletService> {
     this.failIfWalletNotReady();
     if (await this.storage.isReadonly()) {
@@ -1358,7 +1361,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async sendManyOutputsTransaction(
     outputs: Array<OutputRequestObj | DataScriptOutputRequestObj>,
-    options: { inputs?: InputRequestObj[]; changeAddress?: string; pinCode?: string } = {}
+    options: { inputs?: InputRequestObj[]; changeAddress?: string; pinCode?: string } = {},
   ): Promise<Transaction> {
     const sendTransaction = await this.sendManyOutputsSendTransaction(outputs, options);
     return sendTransaction.run();
@@ -1373,7 +1376,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async sendTransaction(
     address: string,
     value: OutputValueType,
-    options: { token?: string; changeAddress?: string; pinCode?: string } = {}
+    options: { token?: string; changeAddress?: string; pinCode?: string } = {},
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     const newOptions = {
@@ -1596,7 +1599,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async enableSingleAddressMode(ignoreWalletReady: boolean = false): Promise<void> {
     if (await this.hasTxOutsideFirstAddress(ignoreWalletReady)) {
       throw new HasTxOutsideFirstAddressError(
-        'Cannot enable single-address policy: wallet has transactions on addresses other than the first'
+        'Cannot enable single-address policy: wallet has transactions on addresses other than the first',
       );
     }
 
@@ -1674,7 +1677,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   async getPrivateKeyFromAddress(
     address: string,
-    options: { pinCode?: string } = {}
+    options: { pinCode?: string } = {},
   ): Promise<bitcore.PrivateKey> {
     if (await this.storage.isReadonly()) {
       throw new WalletFromXPubGuard('getPrivateKeyFromAddress');
@@ -1704,7 +1707,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const addressDetails = await this.getAddressDetails(address);
     if (addressDetails?.index === undefined) {
       throw new Error(
-        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`,
       );
     }
     return addressDetails.index;
@@ -1718,7 +1721,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const addressPrivKey = await this.getAddressPrivKey(pin, addressIndex);
     const callerAddress = new Address(
       addressPrivKey.publicKey.toAddress(this.network.getNetwork()).toString(),
-      { network: this.network }
+      { network: this.network },
     );
     return callerAddress;
   }
@@ -1818,7 +1821,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options = {}
+    options = {},
   ): Promise<CreateTokenTransaction> {
     this.failIfWalletNotReady();
     type optionsType = {
@@ -1907,7 +1910,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       const mintAuthorityAddressObj = this.validateAddress(newOptions.mintAuthorityAddress);
       const p2pkhMintAuthorityScript = mintAuthorityAddressObj.getScript();
       outputsObj.push(
-        new Output(TOKEN_MINT_MASK, p2pkhMintAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA })
+        new Output(TOKEN_MINT_MASK, p2pkhMintAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA }),
       );
     }
 
@@ -1930,7 +1933,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     });
     if (utxos.length === 0) {
       throw new UtxoError(
-        `No utxos available to fill the request. Token: HTR - Amount: ${totalAmount}.`
+        `No utxos available to fill the request. Token: HTR - Amount: ${totalAmount}.`,
       );
     }
 
@@ -1945,7 +1948,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
       const p2pkhMeltAuthorityScript = meltAuthorityAddressObj.getScript();
       outputsObj.push(
-        new Output(TOKEN_MELT_MASK, p2pkhMeltAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA })
+        new Output(TOKEN_MELT_MASK, p2pkhMeltAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA }),
       );
     }
 
@@ -1981,7 +1984,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         const inputData = this.getInputData(
           xprivkey,
           dataToSignHash,
-          HathorWalletServiceWallet.getAddressIndexFromFullPath(utxosAddressPath[idx])
+          HathorWalletServiceWallet.getAddressIndexFromFullPath(utxosAddressPath[idx]),
         );
         inputObj.setData(inputData);
       }
@@ -2055,7 +2058,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * */
   async getMintAuthority(
     tokenId: string,
-    options: { many?: boolean; skipSpent?: boolean } = {}
+    options: { many?: boolean; skipSpent?: boolean } = {},
   ): Promise<AuthorityTxOutput[]> {
     const newOptions = { many: false, skipSpent: true, ...options };
 
@@ -2083,7 +2086,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    * */
   async getMeltAuthority(
     tokenId: string,
-    options: { many?: boolean; skipSpent?: boolean } = {}
+    options: { many?: boolean; skipSpent?: boolean } = {},
   ): Promise<AuthorityTxOutput[]> {
     const newOptions = { many: false, skipSpent: true, ...options };
 
@@ -2117,7 +2120,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       many?: boolean;
       only_available_utxos?: boolean;
       filter_address?: string | null;
-    } = {}
+    } = {},
   ): Promise<AuthorityTxOutput[]> {
     let authorityValue: OutputValueType;
     if (authority === 'mint') {
@@ -2154,7 +2157,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     name: string,
     symbol: string,
     amount: OutputValueType,
-    options = {}
+    options = {},
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareCreateNewToken(name, symbol, amount, options);
@@ -2170,7 +2173,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async prepareMintTokensData(
     token: string,
     amount: OutputValueType,
-    options = {}
+    options = {},
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     type optionsType = {
@@ -2233,7 +2236,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       const authorityAddressObj = this.validateAddress(newOptions.mintAuthorityAddress);
       const p2pkhAuthorityScript = authorityAddressObj.getScript();
       outputsObj.push(
-        new Output(TOKEN_MINT_MASK, p2pkhAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA })
+        new Output(TOKEN_MINT_MASK, p2pkhAuthorityScript, { tokenData: AUTHORITY_TOKEN_DATA }),
       );
     }
 
@@ -2256,7 +2259,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     });
     if (utxos.length === 0) {
       throw new UtxoError(
-        `No utxos available to fill the request. Token: HTR - Amount: ${totalAmount}.`
+        `No utxos available to fill the request. Token: HTR - Amount: ${totalAmount}.`,
       );
     }
 
@@ -2343,7 +2346,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
   async prepareMeltTokensData(
     token: string,
     amount: OutputValueType,
-    options = {}
+    options = {},
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     type optionsType = {
@@ -2436,7 +2439,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       outputsObj.push(
         new Output(TOKEN_MELT_MASK, p2pkhAuthorityScript, {
           tokenData: AUTHORITY_TOKEN_DATA,
-        })
+        }),
       );
     }
 
@@ -2458,7 +2461,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       const fee = await Fee.calculate(
         tokenUtxos, // we are using the token utxos instead of the inputs we need to check if this utxo is an authority utxo
         mappedOutputs,
-        new Map([[tokenData.uid, tokenData]])
+        new Map([[tokenData.uid, tokenData]]),
       );
 
       if (fee > 0) {
@@ -2557,7 +2560,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
    */
   private validateAddress(
     address: string | null,
-    { markAsUsed }: { markAsUsed: boolean } = { markAsUsed: true }
+    { markAsUsed }: { markAsUsed: boolean } = { markAsUsed: true },
   ): Address {
     const _address = address || this.getCurrentAddress({ markAsUsed }).address;
     const addressInstance = new Address(_address, { network: this.network });
@@ -2593,7 +2596,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       anotherAuthorityAddress = null,
       createAnother = true,
       pinCode = null,
-    }: WalletServiceDelegateAuthorityOptions
+    }: WalletServiceDelegateAuthorityOptions,
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
 
@@ -2613,7 +2616,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         : await this.getMeltAuthority(token, { many: false, skipSpent: true });
     if (authorityUtxos.length === 0) {
       throw new UtxoError(
-        `No authority utxo available for delegating authority. Token: ${token} - Type ${type}.`
+        `No authority utxo available for delegating authority. Token: ${token} - Type ${type}.`,
       );
     }
     // it's safe to assume that we have an utxo in the array
@@ -2646,7 +2649,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       outputsObj.push(
         new Output(mask, p2pkhAnotherAddressScript, {
           tokenData: AUTHORITY_TOKEN_DATA,
-        })
+        }),
       );
     }
 
@@ -2683,7 +2686,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     token: string,
     type: string,
     address: string,
-    options: WalletServiceDelegateAuthorityOptions
+    options: WalletServiceDelegateAuthorityOptions,
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareDelegateAuthorityData(token, type, address, options);
@@ -2700,7 +2703,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     token: string,
     type: string,
     count: number,
-    { pinCode = null }: WalletServiceDestroyAuthorityOptions
+    { pinCode = null }: WalletServiceDestroyAuthorityOptions,
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
 
@@ -2715,7 +2718,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         : await this.getMeltAuthority(token, { many: true, skipSpent: true });
     if (authorityUtxos.length < count) {
       throw new UtxoError(
-        `Not enough authority utxos available for destroying. Token: ${token} - Type ${type}. Requested quantity ${count} - Available quantity ${authorityUtxos.length}`
+        `Not enough authority utxos available for destroying. Token: ${token} - Type ${type}. Requested quantity ${count} - Available quantity ${authorityUtxos.length}`,
       );
     }
     const ret = { utxos: authorityUtxos.slice(0, count) };
@@ -2763,7 +2766,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     token: string,
     type: string,
     count: number,
-    options: WalletServiceDestroyAuthorityOptions
+    options: WalletServiceDestroyAuthorityOptions,
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     const tx = await this.prepareDestroyAuthorityData(token, type, count, options);
@@ -2781,7 +2784,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     symbol: string,
     amount: OutputValueType,
     data: string,
-    options = {}
+    options = {},
   ): Promise<Transaction> {
     this.failIfWalletNotReady();
     type optionsType = {
@@ -2925,7 +2928,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     method: string,
     address: string,
     data: CreateNanoTxData,
-    options: CreateNanoTxOptions = {}
+    options: CreateNanoTxOptions = {},
   ): Promise<SendTransactionWalletService> {
     this.failIfWalletNotReady();
 
@@ -2992,7 +2995,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     method: string,
     address: string,
     data: CreateNanoTxData,
-    options: Omit<CreateNanoTxOptions, 'signTx'> = {}
+    options: Omit<CreateNanoTxOptions, 'signTx'> = {},
   ): Promise<Transaction> {
     const sendTransaction = await this.createNanoContractTransaction(method, address, data, {
       ...options,
@@ -3022,14 +3025,14 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     address: string,
     data: CreateNanoTxData,
     createTokenOptions: CreateTokenOptionsInput,
-    options: CreateNanoTxOptions = {}
+    options: CreateNanoTxOptions = {},
   ): Promise<Transaction> {
     const sendTransaction = await this.createNanoContractCreateTokenTransaction(
       method,
       address,
       data,
       createTokenOptions,
-      options
+      options,
     );
     const result = await sendTransaction.runFromMining();
     if (!result) {
@@ -3051,7 +3054,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     tx: Transaction,
     address: string,
     pinCode: string | null,
-    options: { signTx?: boolean } = { signTx: true }
+    options: { signTx?: boolean } = { signTx: true },
   ): Promise<SendTransactionWalletService> {
     // Get the index for the address
     const addressDetails = await this.getAddressDetails(address);
@@ -3059,7 +3062,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     if (addressIndex === undefined) {
       throw new Error(
-        `Address used to sign the transaction (${address}) does not belong to the wallet.`
+        `Address used to sign the transaction (${address}) does not belong to the wallet.`,
       );
     }
 
@@ -3090,7 +3093,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     address: string,
     data: CreateNanoTxData,
     createTokenOptions: CreateTokenOptionsInput,
-    options: CreateNanoTxOptions = {}
+    options: CreateNanoTxOptions = {},
   ): Promise<SendTransactionWalletService> {
     this.failIfWalletNotReady();
     if (await this.storage.isReadonly()) {
@@ -3196,7 +3199,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const signedTx = await transaction.signTransaction(
       tx,
       storageProxy.createProxy(),
-      options.pinCode
+      options.pinCode,
     );
     signedTx.prepareToSend();
     return signedTx;

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { IStorage, IHistoryTx, IAddressInfo, IAddressMetadata } from '../types';
-import Transaction from '../models/transaction';
 import Input from '../models/input';
-import HathorWalletServiceWallet from './wallet';
-import { FullNodeTxResponse } from './types';
+import Transaction from '../models/transaction';
+import { IStorage, IHistoryTx, IAddressInfo, IAddressMetadata } from '../types';
 import transactionUtils from '../utils/transaction';
+
+import { FullNodeTxResponse } from './types';
+import HathorWalletServiceWallet from './wallet';
 
 /**
  * Storage proxy that implements missing storage methods for wallet service
@@ -85,7 +86,7 @@ export class WalletServiceStorageProxy {
    * Get address information including BIP32 index
    */
   private async getAddressInfo(
-    address: string
+    address: string,
   ): Promise<(IAddressInfo & IAddressMetadata & { seqnum: number }) | null> {
     const addressDetails = await this.wallet.getAddressDetails(address);
 

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -6,7 +6,9 @@
  */
 
 import { EventEmitter } from 'events';
+
 import _WebSocket from 'isomorphic-ws';
+
 import { ILogger, getDefaultLogger } from '../types';
 
 export const DEFAULT_WS_OPTIONS = {

--- a/src/websocket/index.ts
+++ b/src/websocket/index.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import BaseWebSocket, { WsOptions } from './base';
 import { JSONBigInt } from '../utils/bigint';
+
+import BaseWebSocket, { WsOptions } from './base';
 
 /**
  * Handles websocket connections and message transmission


### PR DESCRIPTION
## Summary

- Enables `import/order` (alphabetized, grouped, blank line between groups) plus `import/first`, `import/newline-after-import`, `import/no-duplicates` from the already-installed `eslint-plugin-import`.
- Bumps Prettier `trailingComma` from `"es5"` to `"all"` so trailing-comma immunity now extends to function parameters and call arguments.
- Adds `husky` + `lint-staged` for an automatic pre-commit hook (`eslint --fix` and `prettier --write` on staged JS/TS files). Setup is automatic — fresh clones get the hook via the `prepare` script.
- One-shot bulk reformat of 201 files (auto-fix output) plus 4 manual barrel sorts (`lib.ts`, `storage/index.ts`, `template/transaction/index.ts`, `nano_contracts/fields/encoding/index.ts`) and 2 localized `// eslint-disable-next-line import/order` annotations in `wallet.test.ts` and `pushNotification.test.ts` for module-load-order pins (mock-helper `jest.mock()` side effects + a circular import).
- Adds `.git-blame-ignore-revs` and a contributing note in the README so `git blame` skips the bulk-reformat commit (GitHub's web blame honors this automatically).

## ⚠️ Please do NOT squash-merge

A squash-merge would discard the bulk-reformat commit's SHA and break `.git-blame-ignore-revs`, so post-merge `git blame` would attribute every reformatted line to the squash commit instead of the real authors.

Use **"Create a merge commit"** or **"Rebase and merge"** instead. Open to discussion if the team prefers an alternative — see the third option below.

(Alternative if a squash is required: land this as-is, then open a one-line follow-up PR replacing the SHA in `.git-blame-ignore-revs` with the squash-commit SHA.)

## Why

The dominant import-area conflict pattern is "everyone appends a new import to the bottom of the list", which guarantees collisions when two unrelated PRs each add an import. Alphabetic ordering + trailing commas neutralize this for the imports block, named-specifier braces, and multiline call/parameter lists. The husky hook ensures the rules are enforced before code leaves a developer's machine.

## Acceptance Criteria

- [ ] No squash-merge — reviewer confirms merge type preserves the bulk-reformat SHA, **or** a follow-up updates `.git-blame-ignore-revs` post-squash.
- [ ] CI green (lint, format, build, unit tests).

## Test plan

- [x] `npm run lint` — 0 errors (1 pre-existing warning on `lib.ts` re `transactionUtils`, unrelated).
- [x] `npm run format:check` — clean.
- [x] `npm run build` — succeeds (`126` files via Babel + tsc).
- [x] `npm run test` — `828/828` passing.
- [x] `git -c blame.ignoreRevsFile=.git-blame-ignore-revs blame src/wallet/wallet.ts` — attributes lines to original authors, not the reformat commit.
- [ ] Reviewer pulls the branch and verifies the husky hook fires on a test commit (`echo " " >> some-file.ts && git add . && git commit -m "test"` should rewrite imports if any are out of order).
- [ ] `npm run test_integration` — not run; not expected to be affected by import-only changes, but recommended before merge given the blast radius.

## Breaking changes

None. Public API surface unchanged — exports were reordered, never added or removed. No behavioral changes outside import position and trailing-comma placement.