### PR TITLE
test: cover HathorWalletServiceWallet.populateStorageVersion

### DIFF
--- a/__tests__/integration/shared/calculate-weight.test.ts
+++ b/__tests__/integration/shared/calculate-weight.test.ts
@@ -6,27 +6,23 @@
  */
 
 /**
- * Verifies that the wallet threads the network-reported
- * `min_tx_weight*` values (via
- * `transactionUtils.getWeightConstantsFromStorage`) into every
- * `Transaction.prepareToSend` invocation, instead of letting it fall
- * back to the hardcoded {@link TX_WEIGHT_CONSTANTS} mainnet defaults.
+ * Verifies that, after a real wallet `start()`, the storage's version
+ * data is populated AND `transactionUtils.getWeightConstantsFromStorage`
+ * resolves to the privnet's reported `(min_tx_weight,
+ * min_tx_weight_coefficient, min_tx_weight_k)` rather than the
+ * hardcoded {@link TX_WEIGHT_CONSTANTS} mainnet defaults.
  *
- * The privnet used by the integration suite reports
- * `min_tx_weight=1, min_tx_weight_coefficient=0, min_tx_weight_k=0`
- * (see `__tests__/integration/configuration/privnet.yml`), which
- * diverges from the defaults (14 / 1.6 / 100) — so checking that
- * `getWeightConstantsFromStorage(storage)` resolves to the privnet
- * triple proves the override is well-formed.
+ * This is the only weight-constants assertion that genuinely exercises
+ * the wallet/fullnode integration: without `start()` actually fetching
+ * /version and writing it to storage, the helper would return
+ * undefined and the wallet would silently fall back to the hardcoded
+ * defaults — the behaviour we're protecting against. Both facades go
+ * through this path: `HathorWallet.start()` (src/new/wallet.ts:1712)
+ * and `HathorWalletServiceWallet.start()` (src/wallet/wallet.ts).
  *
- * The post-send `tx.weight` cannot be inspected directly: the
- * miner's response weight overwrites whatever the wallet computed
- * (see `runFromMining` in `src/new/sendTransaction.ts`). We instead
- * spy on `Transaction.prototype.prepareToSend` to capture the
- * arguments it actually received during a real send.
- *
- * Both wallet facades (fullnode + wallet-service) consume the same
- * `prepareToSend` path, so this is a shared test.
+ * Pure-unit assertions about `getWeightConstantsFromStorage` and
+ * `prepareToSend` argument threading live in
+ * __tests__/utils/transaction.test.ts.
  */
 
 import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
@@ -35,7 +31,6 @@ import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
 import { TX_WEIGHT_CONSTANTS } from '../../../src/constants';
 import transactionUtils from '../../../src/utils/transaction';
-import Transaction from '../../../src/models/transaction';
 
 const adapters: IWalletTestAdapter[] = [
   new FullnodeWalletTestAdapter(),
@@ -45,18 +40,12 @@ const adapters: IWalletTestAdapter[] = [
 describe.each(adapters)('[Shared] tx weight constants — $name', adapter => {
   let wallet: FuzzyWalletType;
   let storage: IStorage;
-  let externalWallet: FuzzyWalletType;
 
   beforeAll(async () => {
     await adapter.suiteSetup();
-
     const created = await adapter.createWallet();
     wallet = created.wallet;
     storage = created.storage;
-    const addr = await wallet.getAddressAtIndex(0);
-    await adapter.injectFunds(wallet, addr!, 20n);
-
-    externalWallet = (await adapter.createWallet()).wallet;
   });
 
   afterAll(async () => {
@@ -78,46 +67,5 @@ describe.each(adapters)('[Shared] tx weight constants — $name', adapter => {
       txWeightCoefficient: versionData.minTxWeightCoefficient,
       txMinWeightK: versionData.minTxWeightK,
     });
-  });
-
-  it('returns undefined when the storage version data is not yet populated', () => {
-    // The helper must tolerate a fresh storage where the fullnode's
-    // /version response hasn't landed yet — callers fall back to
-    // TX_WEIGHT_CONSTANTS in that case.
-    const emptyStorage = { version: null } as unknown as IStorage;
-    expect(transactionUtils.getWeightConstantsFromStorage(emptyStorage)).toBeUndefined();
-  });
-
-  it('threads the network constants through prepareToSend when sending', async () => {
-    // We cannot read `tx.weight` after sending: the SendTransaction
-    // pipeline (`runFromMining` in src/new/sendTransaction.ts) writes
-    // the miner's returned weight onto the tx, overwriting what
-    // `prepareToSend` computed locally. On the privnet's test-mode
-    // miner, that always lands at 1, so the post-send field tells us
-    // nothing about which constants the wallet used.
-    //
-    // Instead, spy on Transaction.prototype.prepareToSend and check
-    // what each invocation receives — that's the exact API surface
-    // the override is meant to be threaded through.
-    const prepareSpy = jest.spyOn(Transaction.prototype, 'prepareToSend');
-    prepareSpy.mockClear();
-    try {
-      const externalAddr = await externalWallet.getAddressAtIndex(0);
-      await adapter.sendTransaction(wallet, externalAddr!, 1n);
-
-      expect(prepareSpy).toHaveBeenCalled();
-
-      // Every prepareToSend call on this code path must have received
-      // the network constants from storage — *not* `undefined` (which
-      // would silently fall back to TX_WEIGHT_CONSTANTS).
-      const networkConstants = transactionUtils.getWeightConstantsFromStorage(storage);
-      expect(networkConstants).toBeDefined();
-
-      for (const call of prepareSpy.mock.calls) {
-        expect(call[0]).toEqual(networkConstants);
-      }
-    } finally {
-      prepareSpy.mockRestore();
-    }
   });
 });

--- a/__tests__/integration/shared/calculate-weight.test.ts
+++ b/__tests__/integration/shared/calculate-weight.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Verifies that the wallet threads the network-reported
+ * `min_tx_weight*` values (via
+ * `transactionUtils.getWeightConstantsFromStorage`) into every
+ * `Transaction.prepareToSend` invocation, instead of letting it fall
+ * back to the hardcoded {@link TX_WEIGHT_CONSTANTS} mainnet defaults.
+ *
+ * The privnet used by the integration suite reports
+ * `min_tx_weight=1, min_tx_weight_coefficient=0, min_tx_weight_k=0`
+ * (see `__tests__/integration/configuration/privnet.yml`), which
+ * diverges from the defaults (14 / 1.6 / 100) — so checking that
+ * `getWeightConstantsFromStorage(storage)` resolves to the privnet
+ * triple proves the override is well-formed.
+ *
+ * The post-send `tx.weight` cannot be inspected directly: the
+ * miner's response weight overwrites whatever the wallet computed
+ * (see `runFromMining` in `src/new/sendTransaction.ts`). We instead
+ * spy on `Transaction.prototype.prepareToSend` to capture the
+ * arguments it actually received during a real send.
+ *
+ * Both wallet facades (fullnode + wallet-service) consume the same
+ * `prepareToSend` path, so this is a shared test.
+ */
+
+import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
+import type { IStorage } from '../../../src/types';
+import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
+import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
+import { TX_WEIGHT_CONSTANTS } from '../../../src/constants';
+import transactionUtils from '../../../src/utils/transaction';
+import Transaction from '../../../src/models/transaction';
+
+const adapters: IWalletTestAdapter[] = [
+  new FullnodeWalletTestAdapter(),
+  new ServiceWalletTestAdapter(),
+];
+
+describe.each(adapters)('[Shared] tx weight constants — $name', adapter => {
+  let wallet: FuzzyWalletType;
+  let storage: IStorage;
+  let externalWallet: FuzzyWalletType;
+
+  beforeAll(async () => {
+    await adapter.suiteSetup();
+
+    const created = await adapter.createWallet();
+    wallet = created.wallet;
+    storage = created.storage;
+    const addr = await wallet.getAddressAtIndex(0);
+    await adapter.injectFunds(wallet, addr!, 20n);
+
+    externalWallet = (await adapter.createWallet()).wallet;
+  });
+
+  afterAll(async () => {
+    await adapter.suiteTeardown();
+  });
+
+  it('exposes the network constants via getWeightConstantsFromStorage', async () => {
+    const versionData = await wallet.getVersionData();
+
+    // Sanity: this test is only meaningful if the privnet's reported
+    // values actually diverge from the hardcoded defaults.
+    expect(versionData.minTxWeight).not.toBe(TX_WEIGHT_CONSTANTS.txMinWeight);
+    expect(versionData.minTxWeightCoefficient).not.toBe(TX_WEIGHT_CONSTANTS.txWeightCoefficient);
+    expect(versionData.minTxWeightK).not.toBe(TX_WEIGHT_CONSTANTS.txMinWeightK);
+
+    const networkConstants = transactionUtils.getWeightConstantsFromStorage(storage);
+    expect(networkConstants).toEqual({
+      txMinWeight: versionData.minTxWeight,
+      txWeightCoefficient: versionData.minTxWeightCoefficient,
+      txMinWeightK: versionData.minTxWeightK,
+    });
+  });
+
+  it('returns undefined when the storage version data is not yet populated', () => {
+    // The helper must tolerate a fresh storage where the fullnode's
+    // /version response hasn't landed yet — callers fall back to
+    // TX_WEIGHT_CONSTANTS in that case.
+    const emptyStorage = { version: null } as unknown as IStorage;
+    expect(transactionUtils.getWeightConstantsFromStorage(emptyStorage)).toBeUndefined();
+  });
+
+  it('threads the network constants through prepareToSend when sending', async () => {
+    // We cannot read `tx.weight` after sending: the SendTransaction
+    // pipeline (`runFromMining` in src/new/sendTransaction.ts) writes
+    // the miner's returned weight onto the tx, overwriting what
+    // `prepareToSend` computed locally. On the privnet's test-mode
+    // miner, that always lands at 1, so the post-send field tells us
+    // nothing about which constants the wallet used.
+    //
+    // Instead, spy on Transaction.prototype.prepareToSend and check
+    // what each invocation receives — that's the exact API surface
+    // the override is meant to be threaded through.
+    const prepareSpy = jest.spyOn(Transaction.prototype, 'prepareToSend');
+    prepareSpy.mockClear();
+    try {
+      const externalAddr = await externalWallet.getAddressAtIndex(0);
+      await adapter.sendTransaction(wallet, externalAddr!, 1n);
+
+      expect(prepareSpy).toHaveBeenCalled();
+
+      // Every prepareToSend call on this code path must have received
+      // the network constants from storage — *not* `undefined` (which
+      // would silently fall back to TX_WEIGHT_CONSTANTS).
+      const networkConstants = transactionUtils.getWeightConstantsFromStorage(storage);
+      expect(networkConstants).toBeDefined();
+
+      for (const call of prepareSpy.mock.calls) {
+        expect(call[0]).toEqual(networkConstants);
+      }
+    } finally {
+      prepareSpy.mockRestore();
+    }
+  });
+});

--- a/__tests__/integration/shared/calculate-weight.test.ts
+++ b/__tests__/integration/shared/calculate-weight.test.ts
@@ -8,17 +8,23 @@
 /**
  * Verifies that, after a real wallet `start()`, the storage's version
  * data is populated AND `transactionUtils.getWeightConstantsFromStorage`
- * resolves to the privnet's reported `(min_tx_weight,
- * min_tx_weight_coefficient, min_tx_weight_k)` rather than the
- * hardcoded {@link TX_WEIGHT_CONSTANTS} mainnet defaults.
+ * resolves to whatever the connected network reports for
+ * `(min_tx_weight, min_tx_weight_coefficient, min_tx_weight_k)`.
  *
  * This is the only weight-constants assertion that genuinely exercises
  * the wallet/fullnode integration: without `start()` actually fetching
  * /version and writing it to storage, the helper would return
- * undefined and the wallet would silently fall back to the hardcoded
- * defaults — the behaviour we're protecting against. Both facades go
- * through this path: `HathorWallet.start()` (src/new/wallet.ts:1712)
- * and `HathorWalletServiceWallet.start()` (src/wallet/wallet.ts).
+ * `undefined` and the wallet would silently fall back to the hardcoded
+ * `TX_WEIGHT_CONSTANTS` — the behaviour we're protecting against. Both
+ * facades go through this path: `HathorWallet.start()`
+ * (src/new/wallet.ts) and `HathorWalletServiceWallet.start()`
+ * (src/wallet/wallet.ts).
+ *
+ * The assertion deliberately does NOT require the network's reported
+ * constants to differ from `TX_WEIGHT_CONSTANTS`. The unit under test
+ * is the storage→version mapping, not the value of the privnet's
+ * configuration; if the integration network ever adopts the mainnet
+ * defaults, this test should still pass.
  *
  * Pure-unit assertions about `getWeightConstantsFromStorage` and
  * `prepareToSend` argument threading live in
@@ -29,7 +35,6 @@ import type { FuzzyWalletType, IWalletTestAdapter } from '../adapters/types';
 import type { IStorage } from '../../../src/types';
 import { FullnodeWalletTestAdapter } from '../adapters/fullnode.adapter';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
-import { TX_WEIGHT_CONSTANTS } from '../../../src/constants';
 import transactionUtils from '../../../src/utils/transaction';
 
 const adapters: IWalletTestAdapter[] = [
@@ -54,12 +59,6 @@ describe.each(adapters)('[Shared] tx weight constants — $name', adapter => {
 
   it('exposes the network constants via getWeightConstantsFromStorage', async () => {
     const versionData = await wallet.getVersionData();
-
-    // Sanity: this test is only meaningful if the privnet's reported
-    // values actually diverge from the hardcoded defaults.
-    expect(versionData.minTxWeight).not.toBe(TX_WEIGHT_CONSTANTS.txMinWeight);
-    expect(versionData.minTxWeightCoefficient).not.toBe(TX_WEIGHT_CONSTANTS.txWeightCoefficient);
-    expect(versionData.minTxWeightK).not.toBe(TX_WEIGHT_CONSTANTS.txMinWeightK);
 
     const networkConstants = transactionUtils.getWeightConstantsFromStorage(storage);
     expect(networkConstants).toEqual({

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -736,6 +736,30 @@ test('convertTransactionToHistoryTx', async () => {
   }
 });
 
+/**
+ * Reusable `ApiVersion` literal for tests that need a populated
+ * `storage.version`. Defaults match a privnet-shaped configuration so
+ * the values diverge from `TX_WEIGHT_CONSTANTS` and any "did the
+ * override get threaded through?" assertions land at observable
+ * differences. Pass `overrides` to tweak individual fields (e.g.
+ * `decimal_places` for tests that exercise that path).
+ */
+const sampleApiVersion = (overrides: Partial<ApiVersion> = {}): ApiVersion => ({
+  version: '0.0.0-test',
+  network: 'unittest',
+  min_weight: 1,
+  min_tx_weight: 1,
+  min_tx_weight_coefficient: 0,
+  min_tx_weight_k: 0,
+  token_deposit_percentage: 0.01,
+  reward_spend_min_blocks: 1,
+  max_number_inputs: 255,
+  max_number_outputs: 255,
+  decimal_places: 2,
+  native_token: null,
+  ...overrides,
+});
+
 describe('getWeightConstantsFromStorage', () => {
   it('returns undefined when the storage version data is not yet populated', () => {
     // Until the wallet's `start()` finishes its /version round-trip,
@@ -749,25 +773,12 @@ describe('getWeightConstantsFromStorage', () => {
 
   it('mirrors storage.version into the calculateWeight constants shape', () => {
     // When version data is populated the helper exposes a shape that
-    // calculateWeight can consume directly. Use values that diverge
-    // from TX_WEIGHT_CONSTANTS so the mapping is observable.
+    // calculateWeight can consume directly. The sample's (1, 0, 0)
+    // weight constants diverge from TX_WEIGHT_CONSTANTS so the mapping
+    // is observable.
     const store = new MemoryStore();
     const storage = new Storage(store);
-    const version: ApiVersion = {
-      version: '0.0.0-test',
-      network: 'unittest',
-      min_weight: 1,
-      min_tx_weight: 1,
-      min_tx_weight_coefficient: 0,
-      min_tx_weight_k: 0,
-      token_deposit_percentage: 0.01,
-      reward_spend_min_blocks: 1,
-      max_number_inputs: 255,
-      max_number_outputs: 255,
-      decimal_places: 2,
-      native_token: null,
-    };
-    storage.setApiVersion(version);
+    storage.setApiVersion(sampleApiVersion());
     expect(transaction.getWeightConstantsFromStorage(storage)).toEqual({
       txMinWeight: 1,
       txWeightCoefficient: 0,
@@ -820,22 +831,7 @@ describe('prepareTransaction threads weight constants from storage', () => {
   const buildStorageWithVersion = (overrides?: Partial<ApiVersion>): IStorage => {
     const store = new MemoryStore();
     const storage = new Storage(store);
-    const version: ApiVersion = {
-      version: '0.0.0-test',
-      network: 'unittest',
-      min_weight: 1,
-      min_tx_weight: 1,
-      min_tx_weight_coefficient: 0,
-      min_tx_weight_k: 0,
-      token_deposit_percentage: 0.01,
-      reward_spend_min_blocks: 1,
-      max_number_inputs: 255,
-      max_number_outputs: 255,
-      decimal_places: 2,
-      native_token: null,
-      ...overrides,
-    };
-    storage.setApiVersion(version);
+    storage.setApiVersion(sampleApiVersion(overrides));
     return storage;
   };
 

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -18,6 +18,7 @@ import {
   TOKEN_AUTHORITY_MASK,
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
+  TX_WEIGHT_CONSTANTS,
 } from '../../src/constants';
 import txApi from '../../src/api/txApi';
 import { MemoryStore, Storage } from '../../src/storage';
@@ -28,6 +29,7 @@ import P2PKH from '../../src/models/p2pkh';
 import Address from '../../src/models/address';
 import NanoContractHeader from '../../src/nano_contracts/header';
 import { TokenVersion } from '../../src/types';
+import type { ApiVersion, IStorage } from '../../src/types';
 
 test('isAuthorityOutput', () => {
   expect(transaction.isAuthorityOutput({ token_data: TOKEN_AUTHORITY_MASK })).toBe(true);
@@ -732,4 +734,129 @@ test('convertTransactionToHistoryTx', async () => {
   } finally {
     getTxSpy.mockRestore();
   }
+});
+
+describe('getWeightConstantsFromStorage', () => {
+  it('returns undefined when the storage version data is not yet populated', () => {
+    // Until the wallet's `start()` finishes its /version round-trip,
+    // `storage.version` is null. The helper must return undefined so
+    // callers fall back to TX_WEIGHT_CONSTANTS instead of throwing.
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    expect(storage.version).toBeNull();
+    expect(transaction.getWeightConstantsFromStorage(storage)).toBeUndefined();
+  });
+
+  it('mirrors storage.version into the calculateWeight constants shape', () => {
+    // When version data is populated the helper exposes a shape that
+    // calculateWeight can consume directly. Use values that diverge
+    // from TX_WEIGHT_CONSTANTS so the mapping is observable.
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const version: ApiVersion = {
+      version: '0.0.0-test',
+      network: 'unittest',
+      min_weight: 1,
+      min_tx_weight: 1,
+      min_tx_weight_coefficient: 0,
+      min_tx_weight_k: 0,
+      token_deposit_percentage: 0.01,
+      reward_spend_min_blocks: 1,
+      max_number_inputs: 255,
+      max_number_outputs: 255,
+      decimal_places: 2,
+      native_token: null,
+    };
+    storage.setApiVersion(version);
+    expect(transaction.getWeightConstantsFromStorage(storage)).toEqual({
+      txMinWeight: 1,
+      txWeightCoefficient: 0,
+      txMinWeightK: 0,
+    });
+  });
+});
+
+describe('Transaction.calculateWeight override threading', () => {
+  // Build a deterministic small transparent tx via a Transaction model
+  // so we can call calculateWeight without spinning up a wallet.
+  const sampleTx = (): Transaction => {
+    const inputs = [new Input('aa'.repeat(32), 0)];
+    const script = new P2PKH(new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo')).createScript();
+    const outputs = [new Output(1n, script, { tokenData: 0 })];
+    const tx = new Transaction(inputs, outputs);
+    tx.parents = ['bb'.repeat(32), 'cc'.repeat(32)];
+    return tx;
+  };
+
+  it('uses TX_WEIGHT_CONSTANTS when no override is passed', () => {
+    const tx = sampleTx();
+    const w = tx.calculateWeight();
+    // Floor at TX_WEIGHT_CONSTANTS.txMinWeight = 14.
+    expect(w).toBeGreaterThanOrEqual(TX_WEIGHT_CONSTANTS.txMinWeight);
+  });
+
+  it('uses the override constants when one is passed', () => {
+    const tx = sampleTx();
+    const override = { txMinWeight: 1, txWeightCoefficient: 0, txMinWeightK: 0 };
+    const wOverride = tx.calculateWeight(override);
+    const wDefault = tx.calculateWeight();
+
+    // With the privnet-shaped (1, 0, 0) constants the formula collapses
+    // to `0*log2(size) + 4/(1+0/amount) + 4 = 8`, well below the
+    // hardcoded 14-floor that the default constants enforce.
+    expect(wOverride).toBeCloseTo(8, 5);
+    // And the default branch must remain unaffected — i.e. the default
+    // call still returns the hardcoded-constant result, not the override.
+    expect(wDefault).toBeGreaterThan(wOverride);
+  });
+});
+
+describe('prepareTransaction threads weight constants from storage', () => {
+  // High-level integration of the helper + Transaction model: build a
+  // tx via prepareTransaction with a Storage whose version is populated,
+  // and assert the resulting tx.weight matches the override-derived
+  // calculation. This exercises the same path HathorWallet's send flow
+  // takes, but without any wallet, network, or mining service.
+  const buildStorageWithVersion = (overrides?: Partial<ApiVersion>): IStorage => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const version: ApiVersion = {
+      version: '0.0.0-test',
+      network: 'unittest',
+      min_weight: 1,
+      min_tx_weight: 1,
+      min_tx_weight_coefficient: 0,
+      min_tx_weight_k: 0,
+      token_deposit_percentage: 0.01,
+      reward_spend_min_blocks: 1,
+      max_number_inputs: 255,
+      max_number_outputs: 255,
+      decimal_places: 2,
+      native_token: null,
+      ...overrides,
+    };
+    storage.setApiVersion(version);
+    return storage;
+  };
+
+  it('Transaction.prepareToSend honours the override end-to-end', () => {
+    const storage = buildStorageWithVersion();
+    const constants = transaction.getWeightConstantsFromStorage(storage)!;
+
+    const inputs = [new Input('aa'.repeat(32), 0)];
+    const script = new P2PKH(new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo')).createScript();
+    const outputs = [new Output(1n, script, { tokenData: 0 })];
+    const tx = new Transaction(inputs, outputs);
+    tx.parents = ['bb'.repeat(32), 'cc'.repeat(32)];
+
+    tx.prepareToSend(constants);
+    // Same instance must reflect a weight matching calculateWeight when
+    // run with the same override constants — proves prepareToSend
+    // forwarded the override into calculateWeight rather than silently
+    // falling back to TX_WEIGHT_CONSTANTS.
+    expect(tx.weight).toBeCloseTo(tx.calculateWeight(constants), 5);
+    // And the value must differ from the no-override calculation,
+    // otherwise the test couldn't distinguish the two paths.
+    expect(tx.weight).not.toBeCloseTo(tx.calculateWeight(), 1);
+  });
 });

--- a/__tests__/wallet/wallet.test.ts
+++ b/__tests__/wallet/wallet.test.ts
@@ -32,6 +32,7 @@ import {
 import SendTransactionWalletService from '../../src/wallet/sendTransactionWalletService';
 import transaction from '../../src/utils/transaction';
 import {
+  DECIMAL_PLACES,
   TOKEN_MELT_MASK,
   TOKEN_MINT_MASK,
   WALLET_SERVICE_AUTH_DERIVATION_PATH,
@@ -2928,6 +2929,144 @@ test('start', async () => {
   }).toThrow('authxpriv parameter is an invalid hd privatekey');
 
   expect(wallet.getServerUrl()).toBe(config.getServerUrl());
+});
+
+describe('start populates storage.version', () => {
+  /**
+   * Pins the behavior of `HathorWalletServiceWallet.populateStorageVersion()`
+   * (added in PR #1082). Without it, `prepareToSend` falls back to the
+   * hardcoded mainnet `TX_WEIGHT_CONSTANTS` instead of the network's
+   * reported `min_tx_weight*` values.
+   */
+
+  // Distinct, non-default values so a transposition bug surfaces as a
+  // failed assertion rather than a coincidental match.
+  const mockVersionData = {
+    timestamp: 1700000000000,
+    version: '0.99.0',
+    network: 'privnet',
+    minWeight: 7,
+    minTxWeight: 1,
+    minTxWeightCoefficient: 0,
+    minTxWeightK: 0,
+    tokenDepositPercentage: 0.01,
+    rewardSpendMinBlocks: 5,
+    maxNumberInputs: 200,
+    maxNumberOutputs: 300,
+  };
+
+  function setupStartMocks() {
+    jest
+      .spyOn(HathorWalletServiceWallet.prototype, 'pollForWalletStatus')
+      .mockImplementation(() => Promise.resolve());
+    jest
+      .spyOn(HathorWalletServiceWallet.prototype, 'setupConnection')
+      .mockImplementation(jest.fn());
+    jest
+      .spyOn(HathorWalletServiceWallet.prototype, 'renewAuthToken')
+      .mockImplementation(async function mockRenew(this: HathorWalletServiceWallet) {
+        this.authToken = 'mocked-token';
+      });
+    jest
+      .spyOn(walletApi, 'getNewAddresses')
+      .mockImplementation(() => Promise.resolve({ success: true, addresses: [] }));
+    jest.spyOn(walletApi, 'createWallet').mockImplementation(() =>
+      Promise.resolve({
+        success: true,
+        status: {
+          walletId: 'id',
+          xpubkey: 'xpub',
+          status: 'creating',
+          maxGap: 20,
+          createdAt: 0,
+          readyAt: 0,
+        },
+      })
+    );
+  }
+
+  function buildWallet(): HathorWalletServiceWallet {
+    return new HathorWalletServiceWallet({
+      requestPassword: jest.fn(),
+      seed: defaultWalletSeed,
+      network: new Network('testnet'),
+      storage: new Storage(new MemoryStore()),
+    });
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('populates storage.version with the network constants on default startup', async () => {
+    setupStartMocks();
+    jest.spyOn(walletApi, 'getVersionData').mockResolvedValue(mockVersionData);
+
+    const wallet = buildWallet();
+    await wallet.start({ pinCode: '1234', password: '1234' });
+
+    expect(wallet.storage.version).not.toBeNull();
+    expect(wallet.storage.version).toMatchObject({
+      version: mockVersionData.version,
+      network: mockVersionData.network,
+      min_weight: mockVersionData.minWeight,
+      min_tx_weight: mockVersionData.minTxWeight,
+      min_tx_weight_coefficient: mockVersionData.minTxWeightCoefficient,
+      min_tx_weight_k: mockVersionData.minTxWeightK,
+      token_deposit_percentage: mockVersionData.tokenDepositPercentage,
+      reward_spend_min_blocks: mockVersionData.rewardSpendMinBlocks,
+      max_number_inputs: mockVersionData.maxNumberInputs,
+      max_number_outputs: mockVersionData.maxNumberOutputs,
+      // FullNodeVersionData has no `decimal_places`/`native_token`; the impl
+      // backfills with safe defaults so storage.getDecimalPlaces /
+      // getNativeTokenData keep working.
+      decimal_places: DECIMAL_PLACES,
+      native_token: null,
+    });
+
+    await wallet.stop();
+  });
+
+  it('also populates storage.version when waitReady is false', async () => {
+    // Regression test for the inline ordering comment in
+    // src/wallet/wallet.ts (`Run this BEFORE the waitReady === false early
+    // return`). If a future change moves populateStorageVersion() after the
+    // early return, non-blocking-startup callers silently fall back to
+    // TX_WEIGHT_CONSTANTS — this assertion catches that.
+    setupStartMocks();
+    jest.spyOn(walletApi, 'getVersionData').mockResolvedValue(mockVersionData);
+
+    const wallet = buildWallet();
+    await wallet.start({ pinCode: '1234', password: '1234', waitReady: false });
+
+    expect(wallet.storage.version).not.toBeNull();
+    expect(wallet.storage.version?.min_tx_weight).toBe(mockVersionData.minTxWeight);
+    expect(wallet.storage.version?.min_tx_weight_coefficient).toBe(
+      mockVersionData.minTxWeightCoefficient
+    );
+    expect(wallet.storage.version?.min_tx_weight_k).toBe(mockVersionData.minTxWeightK);
+
+    await wallet.stop();
+  });
+
+  it('does not throw and leaves storage.version null when getVersionData rejects', async () => {
+    // The try/catch in populateStorageVersion is load-bearing: a transient
+    // /version failure must not break wallet startup. The wallet keeps
+    // working — prepareToSend just falls back to TX_WEIGHT_CONSTANTS.
+    setupStartMocks();
+    jest.spyOn(walletApi, 'getVersionData').mockRejectedValue(new Error('boom'));
+
+    const wallet = buildWallet();
+    const warnSpy = jest.spyOn(wallet.storage.logger, 'warn').mockImplementation(jest.fn());
+
+    await expect(wallet.start({ pinCode: '1234', password: '1234' })).resolves.not.toThrow();
+
+    expect(wallet.storage.version).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/wallet-service \/version fetch failed/);
+
+    await wallet.stop();
+  });
 });
 
 test('getAddressPrivKey', async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -199,9 +199,23 @@ export const STRATUM_TIMEOUT_RETURN_CODE = 'stratum_timeout';
 export const MIN_POLLING_INTERVAL: number = 0.5;
 
 /**
+ * Shape of the per-network weight constants consumed by
+ * {@link Transaction.calculateWeight}. Network values arrive via the
+ * fullnode's /version response and are normalised by
+ * `transactionUtils.getWeightConstantsFromStorage`; the hardcoded
+ * {@link TX_WEIGHT_CONSTANTS} below is the fallback used when the
+ * version data hasn't been fetched yet.
+ */
+export interface TxWeightConstants {
+  txMinWeight: number;
+  txWeightCoefficient: number;
+  txMinWeightK: number;
+}
+
+/**
  * Constants to calculate weight
  */
-export const TX_WEIGHT_CONSTANTS = {
+export const TX_WEIGHT_CONSTANTS: TxWeightConstants = {
   txMinWeight: 14,
   txWeightCoefficient: 1.6,
   txMinWeightK: 100,

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -305,15 +305,25 @@ class Transaction {
   }
 
   /**
-   * Calculate the minimum tx weight
+   * Calculate the minimum tx weight.
    *
-   * @throws {ConstantNotSet} If the weight constants are not set yet
+   * Defaults to the hardcoded {@link TX_WEIGHT_CONSTANTS}, but accepts an
+   * override so callers with access to the network's actual values (from
+   * `storage.version.min_tx_weight*`) can pass them in. Networks like the
+   * shielded testnet report much lower constants, which significantly
+   * reduces mining work.
    *
+   * @param weightConstants Optional override of the weight constants.
    * @return {number} Minimum weight calculated (float)
    * @memberof Transaction
    * @inner
    */
-  calculateWeight(): number {
+  calculateWeight(weightConstants?: {
+    txMinWeight: number;
+    txWeightCoefficient: number;
+    txMinWeightK: number;
+  }): number {
+    const constants = weightConstants ?? TX_WEIGHT_CONSTANTS;
     let txSize = this.toBytes().length;
 
     // If parents are not in txData, we need to consider them here
@@ -333,13 +343,14 @@ class Transaction {
     // For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     const amount = sumOutputs / 10 ** DECIMAL_PLACES;
 
-    let weight =
-      TX_WEIGHT_CONSTANTS.txWeightCoefficient * Math.log2(txSize) +
-      4 / (1 + TX_WEIGHT_CONSTANTS.txMinWeightK / amount) +
-      4;
+    // When txMinWeightK is 0, avoid the division-by-zero in `k/amount` —
+    // the term `4 / (1 + 0)` collapses to 4.
+    const kTerm = constants.txMinWeightK === 0 ? 4 : 4 / (1 + constants.txMinWeightK / amount);
+
+    let weight = constants.txWeightCoefficient * Math.log2(txSize) + kTerm + 4;
 
     // Make sure the calculated weight is at least the minimum
-    weight = Math.max(weight, TX_WEIGHT_CONSTANTS.txMinWeight);
+    weight = Math.max(weight, constants.txMinWeight);
     // FIXME precision difference between backend and frontend (weight (17.76246721531992) is smaller than the minimum weight (17.762467215319923))
     // Even though it must be fixed, there is no practical effect when mining the transaction
     return weight + 1e-6;
@@ -471,9 +482,13 @@ class Transaction {
    * @memberof Transaction
    * @inner
    */
-  prepareToSend() {
+  prepareToSend(weightConstants?: {
+    txMinWeight: number;
+    txWeightCoefficient: number;
+    txMinWeightK: number;
+  }) {
     this.updateTimestamp();
-    this.weight = this.calculateWeight();
+    this.weight = this.calculateWeight(weightConstants);
   }
 
   /**

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -20,6 +20,7 @@ import {
   MERGED_MINED_BLOCK_VERSION,
   TX_HASH_SIZE_BYTES,
   TX_WEIGHT_CONSTANTS,
+  TxWeightConstants,
 } from '../constants';
 import {
   bufferToHex,
@@ -318,11 +319,7 @@ class Transaction {
    * @memberof Transaction
    * @inner
    */
-  calculateWeight(weightConstants?: {
-    txMinWeight: number;
-    txWeightCoefficient: number;
-    txMinWeightK: number;
-  }): number {
+  calculateWeight(weightConstants?: TxWeightConstants): number {
     const constants = weightConstants ?? TX_WEIGHT_CONSTANTS;
     let txSize = this.toBytes().length;
 
@@ -481,11 +478,7 @@ class Transaction {
    * @memberof Transaction
    * @inner
    */
-  prepareToSend(weightConstants?: {
-    txMinWeight: number;
-    txWeightCoefficient: number;
-    txMinWeightK: number;
-  }) {
+  prepareToSend(weightConstants?: TxWeightConstants) {
     this.updateTimestamp();
     this.weight = this.calculateWeight(weightConstants);
   }

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -343,11 +343,10 @@ class Transaction {
     // For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     const amount = sumOutputs / 10 ** DECIMAL_PLACES;
 
-    // When txMinWeightK is 0, avoid the division-by-zero in `k/amount` —
-    // the term `4 / (1 + 0)` collapses to 4.
-    const kTerm = constants.txMinWeightK === 0 ? 4 : 4 / (1 + constants.txMinWeightK / amount);
-
-    let weight = constants.txWeightCoefficient * Math.log2(txSize) + kTerm + 4;
+    let weight =
+      constants.txWeightCoefficient * Math.log2(txSize) +
+      4 / (1 + constants.txMinWeightK / amount) +
+      4;
 
     // Make sure the calculated weight is at least the minimum
     weight = Math.max(weight, constants.txMinWeight);

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -73,7 +73,7 @@ export const prepareNanoSendTransaction = async (
   storage: IStorage
 ): Promise<SendTransaction> => {
   await transactionUtils.signTransaction(tx, storage, pin);
-  tx.prepareToSend();
+  tx.prepareToSend(transactionUtils.getWeightConstantsFromStorage(storage));
 
   // Create and return a send transaction object
   return new SendTransaction({

--- a/src/new/sendTransaction.ts
+++ b/src/new/sendTransaction.ts
@@ -378,7 +378,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
       }
 
       await transactionUtils.signTransaction(this.transaction, this.storage, pinToUse);
-      this.transaction.prepareToSend();
+      this.transaction.prepareToSend(transactionUtils.getWeightConstantsFromStorage(this.storage));
       this._currentStep = 'signed';
       return this.transaction;
     } catch (e) {
@@ -435,7 +435,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
         this.fullTxData,
         this.storage.config.getNetwork()
       );
-      this.transaction.prepareToSend();
+      this.transaction.prepareToSend(transactionUtils.getWeightConstantsFromStorage(this.storage));
       return this.transaction;
     } catch (e) {
       const message = helpers.handlePrepareDataError(e);

--- a/src/new/wallet.ts
+++ b/src/new/wallet.ts
@@ -2775,7 +2775,7 @@ class HathorWallet extends EventEmitter {
     }
 
     const signedTx = await transactionUtils.signTransaction(tx, this.storage, pinCode);
-    signedTx.prepareToSend();
+    signedTx.prepareToSend(transactionUtils.getWeightConstantsFromStorage(this.storage));
     return signedTx;
   }
 
@@ -3388,7 +3388,7 @@ class HathorWallet extends EventEmitter {
         throw new Error(ERROR_MESSAGE_PIN_REQUIRED);
       }
       await transactionUtils.signTransaction(tx, this.storage, pin);
-      tx.prepareToSend();
+      tx.prepareToSend(transactionUtils.getWeightConstantsFromStorage(this.storage));
     }
     return tx;
   }

--- a/src/template/transaction/interpreter.ts
+++ b/src/template/transaction/interpreter.ts
@@ -220,7 +220,7 @@ export class WalletTxTemplateInterpreter implements ITxTemplateInterpreter {
   ): Promise<TxInstance> {
     let tx = await this.build(instructions, debug);
     tx = await transactionUtils.signTransaction(tx, this.wallet.storage, pinCode);
-    tx.prepareToSend();
+    tx.prepareToSend(transactionUtils.getWeightConstantsFromStorage(this.wallet.storage));
     return tx;
   }
 

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -783,10 +783,28 @@ const transaction = {
     const tx = this.createTransactionFromData(txData, network);
     if (newOptions.signTx) {
       await this.signTransaction(tx, storage, pinCode);
-      tx.prepareToSend();
+      tx.prepareToSend(this.getWeightConstantsFromStorage(storage));
     }
 
     return tx;
+  },
+
+  /**
+   * Build a weight-constants object from the network's reported values
+   * (`storage.version.min_tx_weight*`). Falls back to undefined when the
+   * version data hasn't been fetched yet, in which case callers will use
+   * the hardcoded {@link TX_WEIGHT_CONSTANTS}.
+   */
+  getWeightConstantsFromStorage(
+    storage: IStorage
+  ): { txMinWeight: number; txWeightCoefficient: number; txMinWeightK: number } | undefined {
+    const { version } = storage;
+    if (!version) return undefined;
+    return {
+      txMinWeight: version.min_tx_weight,
+      txWeightCoefficient: version.min_tx_weight_coefficient,
+      txMinWeightK: version.min_tx_weight_k,
+    };
   },
 
   /**

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -23,6 +23,7 @@ import {
   MERGED_MINED_BLOCK_VERSION,
   POA_BLOCK_VERSION,
   ON_CHAIN_BLUEPRINTS_VERSION,
+  TxWeightConstants,
 } from '../constants';
 import Transaction from '../models/transaction';
 import CreateTokenTransaction from '../models/create_token_transaction';
@@ -795,9 +796,7 @@ const transaction = {
    * version data hasn't been fetched yet, in which case callers will use
    * the hardcoded {@link TX_WEIGHT_CONSTANTS}.
    */
-  getWeightConstantsFromStorage(
-    storage: IStorage
-  ): { txMinWeight: number; txWeightCoefficient: number; txMinWeightK: number } | undefined {
+  getWeightConstantsFromStorage(storage: IStorage): TxWeightConstants | undefined {
     const { version } = storage;
     if (!version) return undefined;
     return {

--- a/src/wallet/partialTxProposal.ts
+++ b/src/wallet/partialTxProposal.ts
@@ -419,7 +419,7 @@ class PartialTxProposal {
       this.partialTx.inputs[index].setData(inputData);
     }
     this.transaction = this.partialTx.getTx();
-    this.transaction.prepareToSend();
+    this.transaction.prepareToSend(transactionUtils.getWeightConstantsFromStorage(this.storage));
     return this.transaction;
   }
 }

--- a/src/wallet/sendTransactionWalletService.ts
+++ b/src/wallet/sendTransactionWalletService.ts
@@ -9,6 +9,7 @@
 import { EventEmitter } from 'events';
 import { shuffle } from 'lodash';
 import tokensUtils from '../utils/tokens';
+import transactionUtils from '../utils/transaction';
 import walletApi from './api/walletApi';
 import MineTransaction from './mineTransaction';
 import HathorWalletServiceWallet from './wallet';
@@ -863,7 +864,9 @@ class SendTransactionWalletService extends EventEmitter implements ISendTransact
 
     // Now that the tx is completed with the data of the input
     // we can add the timestamp and calculate the weight
-    this.transaction.prepareToSend();
+    this.transaction.prepareToSend(
+      transactionUtils.getWeightConstantsFromStorage(this.wallet.storage)
+    );
 
     this._currentStep = 'signed';
     this.emit('sign-tx-end', this.transaction);

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -11,6 +11,7 @@ import assert from 'assert';
 import Header from '../headers/base';
 import FeeHeader from '../headers/fee';
 import {
+  DECIMAL_PLACES,
   NATIVE_TOKEN_UID,
   TOKEN_MINT_MASK,
   AUTHORITY_TOKEN_DATA,
@@ -94,6 +95,7 @@ import { WalletServiceStorageProxy } from './walletServiceStorageProxy';
 import HathorWallet from '../new/wallet';
 import { ErrorMessages } from '../errorMessages';
 import {
+  ApiVersion,
   IStorage,
   IWalletAccessData,
   OutputValueType,
@@ -500,6 +502,41 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       throw new WalletRequestError(ErrorMessages.WALLET_STATUS_ERROR, {
         cause: data.status,
       });
+    }
+
+    // Populate `storage.version` with the fullnode network constants.
+    // Without this `prepareToSend` would always fall back to the hardcoded
+    // mainnet TX_WEIGHT_CONSTANTS, ignoring the connected network's
+    // reported `min_tx_weight*` values — see HathorWallet.start in
+    // src/new/wallet.ts where the equivalent setApiVersion call lives.
+    //
+    // walletApi.getVersionData returns FullNodeVersionData (camelCase,
+    // and without `decimal_places` / `native_token`). Map back to the
+    // snake_case ApiVersion shape that storage expects, defaulting the
+    // missing fields — `decimal_places` to the constant default and
+    // `native_token` to null (storage's getDecimalPlaces /
+    // getNativeTokenData paths already fall back to constants when
+    // those fields are missing).
+    try {
+      const v = await walletApi.getVersionData(this);
+      const apiVersion: ApiVersion = {
+        version: v.version,
+        network: v.network,
+        min_weight: v.minWeight,
+        min_tx_weight: v.minTxWeight,
+        min_tx_weight_coefficient: v.minTxWeightCoefficient,
+        min_tx_weight_k: v.minTxWeightK,
+        token_deposit_percentage: v.tokenDepositPercentage,
+        reward_spend_min_blocks: v.rewardSpendMinBlocks,
+        max_number_inputs: v.maxNumberInputs,
+        max_number_outputs: v.maxNumberOutputs,
+        decimal_places: DECIMAL_PLACES,
+        native_token: null,
+      };
+      this.storage.setApiVersion(apiVersion);
+    } catch (_e) {
+      // Non-fatal: if /version fails the wallet still works, prepareToSend
+      // just falls back to TX_WEIGHT_CONSTANTS as it did before this change.
     }
 
     // Auth token renewal is NOT called explicitly here. The axios interceptor

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1963,7 +1963,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       }
     }
 
-    tx.prepareToSend();
+    tx.prepareToSend(transaction.getWeightConstantsFromStorage(this.storage));
     return tx;
   }
 
@@ -2279,7 +2279,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       }
     }
 
-    tx.prepareToSend();
+    tx.prepareToSend(transaction.getWeightConstantsFromStorage(this.storage));
     return tx;
   }
 
@@ -2483,7 +2483,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       }
     }
 
-    tx.prepareToSend();
+    tx.prepareToSend(transaction.getWeightConstantsFromStorage(this.storage));
     return tx;
   }
 
@@ -2644,7 +2644,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     const inputData = this.getInputData(xprivkey, dataToSignHash, addressIndex);
     inputsObj[0].setData(inputData);
 
-    tx.prepareToSend();
+    tx.prepareToSend(transaction.getWeightConstantsFromStorage(this.storage));
 
     return tx;
   }
@@ -2725,7 +2725,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       inputObj.setData(inputData);
     }
 
-    tx.prepareToSend();
+    tx.prepareToSend(transaction.getWeightConstantsFromStorage(this.storage));
     return tx;
   }
 
@@ -3174,7 +3174,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       storageProxy.createProxy(),
       options.pinCode
     );
-    signedTx.prepareToSend();
+    signedTx.prepareToSend(transaction.getWeightConstantsFromStorage(this.storage));
     return signedTx;
   }
 }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -486,6 +486,19 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
 
     this.walletId = data.status.walletId;
 
+    // Populate `storage.version` with the fullnode network constants.
+    // Without this, `prepareToSend` would always fall back to the hardcoded
+    // mainnet TX_WEIGHT_CONSTANTS, ignoring the connected network's reported
+    // `min_tx_weight*` values — see HathorWallet.start in src/new/wallet.ts
+    // where the equivalent setApiVersion call lives.
+    //
+    // Run this BEFORE the `waitReady === false` early return so both
+    // public startup paths (waitReady=true and waitReady=false) populate
+    // the field. Otherwise non-blocking-startup callers would silently
+    // fall back to TX_WEIGHT_CONSTANTS forever, defeating the purpose of
+    // this feature.
+    await this.populateStorageVersion();
+
     // If waitReady is false, return immediately after wallet creation
     if (!waitReady) {
       this.clearSensitiveData();
@@ -504,21 +517,38 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
       });
     }
 
-    // Populate `storage.version` with the fullnode network constants.
-    // Without this `prepareToSend` would always fall back to the hardcoded
-    // mainnet TX_WEIGHT_CONSTANTS, ignoring the connected network's
-    // reported `min_tx_weight*` values — see HathorWallet.start in
-    // src/new/wallet.ts where the equivalent setApiVersion call lives.
-    //
-    // walletApi.getVersionData returns FullNodeVersionData (camelCase,
-    // and without `decimal_places` / `native_token`). Map back to the
-    // snake_case ApiVersion shape that storage expects, defaulting the
-    // missing fields — `decimal_places` to the constant default and
-    // `native_token` to null (storage's getDecimalPlaces /
-    // getNativeTokenData paths already fall back to constants when
-    // those fields are missing).
+    // Auth token renewal is NOT called explicitly here. The axios interceptor
+    // in walletServiceAxios.ts handles it on-demand: any authenticated API
+    // call (including getWalletStatus during polling) triggers
+    // validateAndRenewAuthToken() automatically when the token is missing or
+    // expired. By this point, authPrivKey and walletId are both set, so the
+    // interceptor can obtain a token without needing the PIN.
+    await this.onWalletReady();
+    this.clearSensitiveData();
+  }
+
+  /**
+   * Fetch the connected wallet-service's /version response and write it to
+   * `storage.version` so internal callers (notably `prepareToSend` via
+   * `transactionUtils.getWeightConstantsFromStorage`) consume the network's
+   * actual weight constants instead of the hardcoded mainnet defaults.
+   *
+   * `walletApi.getVersionData` returns `FullNodeVersionData` (camelCase, and
+   * without `decimal_places` / `native_token`). We map to the snake_case
+   * `ApiVersion` shape that storage expects, defaulting the missing fields:
+   * `decimal_places` to the constant default and `native_token` to null
+   * (storage.getDecimalPlaces / getNativeTokenData already fall back to
+   * constants when those fields are missing).
+   *
+   * Non-fatal: any failure is logged via the storage logger and swallowed.
+   * The wallet still works — `prepareToSend` simply falls back to
+   * `TX_WEIGHT_CONSTANTS` as it did before this method existed. We emit a
+   * warning rather than silently dropping the error so a regression here is
+   * visible in logs instead of producing surprisingly-mined transactions.
+   */
+  private async populateStorageVersion(): Promise<void> {
     try {
-      const v = await walletApi.getVersionData(this);
+      const v = await this.getVersionData();
       const apiVersion: ApiVersion = {
         version: v.version,
         network: v.network,
@@ -534,19 +564,11 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         native_token: null,
       };
       this.storage.setApiVersion(apiVersion);
-    } catch (_e) {
-      // Non-fatal: if /version fails the wallet still works, prepareToSend
-      // just falls back to TX_WEIGHT_CONSTANTS as it did before this change.
+    } catch (e) {
+      this.storage.logger.warn(
+        `wallet-service /version fetch failed during start(): ${e instanceof Error ? e.message : String(e)}`
+      );
     }
-
-    // Auth token renewal is NOT called explicitly here. The axios interceptor
-    // in walletServiceAxios.ts handles it on-demand: any authenticated API
-    // call (including getWalletStatus during polling) triggers
-    // validateAndRenewAuthToken() automatically when the token is missing or
-    // expired. By this point, authPrivKey and walletId are both set, so the
-    // interceptor can obtain a token without needing the PIN.
-    await this.onWalletReady();
-    this.clearSensitiveData();
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds unit tests for `HathorWalletServiceWallet.populateStorageVersion()` introduced in #1082. Targets `feat/calculate-weight-constants` so it lands together with that feature.

Three tests, all in `__tests__/wallet/wallet.test.ts` under a new `describe('start populates storage.version', ...)` block:

1. **Default startup (`waitReady: true`)** — asserts `storage.version` is populated with every network field (mapped camelCase → snake_case) plus the `decimal_places` / `native_token` backfills.
2. **Non-blocking startup (`waitReady: false`)** — regression test for the inline ordering comment in `src/wallet/wallet.ts`. If a future change moves `populateStorageVersion()` after the `waitReady === false` early return, this test fails. Without it, headless / non-blocking startup callers would silently fall back to `TX_WEIGHT_CONSTANTS` and the feature would regress unnoticed.
3. **Graceful failure** — when `walletApi.getVersionData` rejects, `start()` still resolves, `storage.version` stays `null`, and a warning is logged via `storage.logger.warn`. Pins the load-bearing `try/catch` in `populateStorageVersion`.

The mocks reuse the same seams (`walletApi.createWallet`, `pollForWalletStatus`, `setupConnection`, `renewAuthToken`, `getNewAddresses`) the existing `start` test already mocks at line 2826 — no new harness is needed.

## Test plan

- [x] `npx jest __tests__/wallet/wallet.test.ts` — 120/120 pass
- [x] `npx eslint __tests__/wallet/wallet.test.ts` — clean

## Security Checklist

- [x] No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)