### PR TITLE
feat(shielded): types, constants, and ShieldedOutput model

### DIFF
--- a/__tests__/models/shielded_output.test.ts
+++ b/__tests__/models/shielded_output.test.ts
@@ -127,15 +127,24 @@ describe('ShieldedOutput', () => {
       expect(serialized.subarray(acOffset + 35, acOffset + 37)).toEqual(surjectionProof);
     });
 
-    it('should throw when FullShielded fields are missing', () => {
+    it('should throw when FullShielded asset_commitment is missing', () => {
       const out = makeOutput({
         mode: ShieldedOutputMode.FULLY_SHIELDED,
       });
 
-      expect(() => out.serialize()).toThrow(
-        'FullShielded output requires assetCommitment and surjectionProof'
-      );
+      expect(() => out.serialize()).toThrow('FullShielded output requires assetCommitment');
       expect(() => out.serializeSighash()).toThrow('FullShielded output requires assetCommitment');
+    });
+
+    it('should throw when FullShielded surjection_proof is missing on serialize but not on sighash', () => {
+      const out = makeOutput({
+        mode: ShieldedOutputMode.FULLY_SHIELDED,
+        assetCommitment: Buffer.alloc(33, 0xdd),
+      });
+
+      // serialize requires the proof — sighash deliberately omits it.
+      expect(() => out.serialize()).toThrow('FullShielded output requires surjectionProof');
+      expect(() => out.serializeSighash()).not.toThrow();
     });
   });
 
@@ -203,6 +212,41 @@ describe('ShieldedOutput', () => {
     it('should throw when ephemeral pubkey has wrong size', () => {
       const out = makeOutput({ ephemeralPubkey: Buffer.alloc(32) });
       expect(() => out.serializeSighash()).toThrow(/expected 33 bytes/);
+    });
+  });
+
+  describe('AmountShielded tokenData', () => {
+    it('serialize should throw when tokenData is undefined', () => {
+      const out = new ShieldedOutput(
+        ShieldedOutputMode.AMOUNT_SHIELDED,
+        Buffer.alloc(33, 0xaa),
+        Buffer.alloc(10, 0xbb),
+        undefined,
+        Buffer.from([0x76, 0xa9, 0x14]),
+        Buffer.alloc(33, 0xcc),
+        100n
+      );
+      expect(() => out.serialize()).toThrow('AmountShielded output requires tokenData');
+      expect(() => out.serializeSighash()).toThrow('AmountShielded output requires tokenData');
+    });
+
+    it('FullShielded does not require tokenData', () => {
+      // Mirrors how PR 2+ deserializers build FullShielded outputs without
+      // ever populating tokenData — the wire format has no slot for it in
+      // FullShielded mode, so requiring callers to pass a placeholder would
+      // be misleading.
+      const out = new ShieldedOutput(
+        ShieldedOutputMode.FULLY_SHIELDED,
+        Buffer.alloc(33, 0xaa),
+        Buffer.alloc(10, 0xbb),
+        undefined,
+        Buffer.from([0x76, 0xa9, 0x14]),
+        Buffer.alloc(33, 0xcc),
+        100n,
+        { assetCommitment: Buffer.alloc(33, 0xdd), surjectionProof: Buffer.from([0xee]) }
+      );
+      expect(() => out.serialize()).not.toThrow();
+      expect(() => out.serializeSighash()).not.toThrow();
     });
   });
 

--- a/__tests__/models/shielded_output.test.ts
+++ b/__tests__/models/shielded_output.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ShieldedOutput from '../../src/models/shielded_output';
+import { ShieldedOutputMode } from '../../src/shielded/types';
+
+function makeOutput(
+  overrides: Partial<{
+    mode: ShieldedOutputMode;
+    commitment: Buffer;
+    rangeProof: Buffer;
+    tokenData: number;
+    script: Buffer;
+    ephemeralPubkey: Buffer;
+    assetCommitment: Buffer;
+    surjectionProof: Buffer;
+    value: bigint;
+  }> = {}
+): ShieldedOutput {
+  return new ShieldedOutput(
+    overrides.mode ?? ShieldedOutputMode.AMOUNT_SHIELDED,
+    overrides.commitment ?? Buffer.alloc(33, 0xaa),
+    overrides.rangeProof ?? Buffer.alloc(10, 0xbb),
+    overrides.tokenData ?? 0,
+    overrides.script ?? Buffer.from([0x76, 0xa9, 0x14]),
+    overrides.ephemeralPubkey ?? Buffer.alloc(33, 0xcc),
+    overrides.assetCommitment,
+    overrides.surjectionProof,
+    overrides.value ?? 100n
+  );
+}
+
+describe('ShieldedOutput', () => {
+  describe('constructor', () => {
+    it('should set all fields', () => {
+      const out = makeOutput({ tokenData: 1, value: 50n });
+      expect(out.mode).toBe(ShieldedOutputMode.AMOUNT_SHIELDED);
+      expect(out.tokenData).toBe(1);
+      expect(out.value).toBe(50n);
+      expect(out.assetCommitment).toBeUndefined();
+      expect(out.surjectionProof).toBeUndefined();
+    });
+
+    it('should accept optional assetCommitment and surjectionProof', () => {
+      const ac = Buffer.alloc(33, 0xdd);
+      const sp = Buffer.alloc(5, 0xee);
+      const out = makeOutput({
+        mode: ShieldedOutputMode.FULLY_SHIELDED,
+        assetCommitment: ac,
+        surjectionProof: sp,
+      });
+      expect(out.assetCommitment).toBe(ac);
+      expect(out.surjectionProof).toBe(sp);
+    });
+  });
+
+  describe('serialize (AmountShielded)', () => {
+    it('should produce correct wire format', () => {
+      const commitment = Buffer.alloc(33, 0x01);
+      const rangeProof = Buffer.from([0x02, 0x03, 0x04]);
+      const script = Buffer.from([0x76, 0xa9]);
+      const ephemeralPubkey = Buffer.alloc(33, 0x05);
+
+      const out = makeOutput({
+        mode: ShieldedOutputMode.AMOUNT_SHIELDED,
+        commitment,
+        rangeProof,
+        tokenData: 0,
+        script,
+        ephemeralPubkey,
+      });
+
+      const parts = out.serialize();
+      const serialized = Buffer.concat(parts);
+
+      let offset = 0;
+      // mode (1)
+      expect(serialized[offset]).toBe(ShieldedOutputMode.AMOUNT_SHIELDED);
+      offset += 1;
+      // commitment (33)
+      expect(serialized.subarray(offset, offset + 33)).toEqual(commitment);
+      offset += 33;
+      // range_proof length (2) + data
+      expect(serialized.readUInt16BE(offset)).toBe(3);
+      offset += 2;
+      expect(serialized.subarray(offset, offset + 3)).toEqual(rangeProof);
+      offset += 3;
+      // script length (2) + data
+      expect(serialized.readUInt16BE(offset)).toBe(2);
+      offset += 2;
+      expect(serialized.subarray(offset, offset + 2)).toEqual(script);
+      offset += 2;
+      // token_data (1, AmountShielded only)
+      expect(serialized[offset]).toBe(0);
+      offset += 1;
+      // ephemeral_pubkey (33)
+      expect(serialized.subarray(offset, offset + 33)).toEqual(ephemeralPubkey);
+      offset += 33;
+
+      expect(offset).toBe(serialized.length);
+    });
+  });
+
+  describe('serialize (FullShielded)', () => {
+    it('should include asset_commitment and surjection_proof', () => {
+      const assetCommitment = Buffer.alloc(33, 0x07);
+      const surjectionProof = Buffer.from([0x08, 0x09]);
+
+      const out = makeOutput({
+        mode: ShieldedOutputMode.FULLY_SHIELDED,
+        assetCommitment,
+        surjectionProof,
+      });
+
+      const parts = out.serialize();
+      const serialized = Buffer.concat(parts);
+
+      // Find the asset_commitment after script
+      // mode(1) + commitment(33) + rp_len(2) + rp(10) + script_len(2) + script(3)
+      const acOffset = 1 + 33 + 2 + 10 + 2 + 3;
+      expect(serialized.subarray(acOffset, acOffset + 33)).toEqual(assetCommitment);
+      // surjection_proof length (2) + data (2)
+      expect(serialized.readUInt16BE(acOffset + 33)).toBe(2);
+      expect(serialized.subarray(acOffset + 35, acOffset + 37)).toEqual(surjectionProof);
+    });
+
+    it('should throw when FullShielded fields are missing', () => {
+      const out = makeOutput({
+        mode: ShieldedOutputMode.FULLY_SHIELDED,
+      });
+
+      expect(() => out.serialize()).toThrow(
+        'FullShielded output requires assetCommitment and surjectionProof'
+      );
+      expect(() => out.serializeSighash()).toThrow('FullShielded output requires assetCommitment');
+    });
+  });
+
+  describe('serializeSighash', () => {
+    it('should exclude proofs for AmountShielded', () => {
+      const commitment = Buffer.alloc(33, 0x01);
+      const script = Buffer.from([0x76, 0xa9]);
+      const ephemeralPubkey = Buffer.alloc(33, 0x05);
+
+      const out = makeOutput({
+        mode: ShieldedOutputMode.AMOUNT_SHIELDED,
+        commitment,
+        tokenData: 2,
+        script,
+        ephemeralPubkey,
+      });
+
+      const parts = out.serializeSighash();
+      const serialized = Buffer.concat(parts);
+
+      let offset = 0;
+      // mode (1)
+      expect(serialized[offset]).toBe(ShieldedOutputMode.AMOUNT_SHIELDED);
+      offset += 1;
+      // commitment (33)
+      expect(serialized.subarray(offset, offset + 33)).toEqual(commitment);
+      offset += 33;
+      // token_data (1)
+      expect(serialized[offset]).toBe(2);
+      offset += 1;
+      // script (raw, no length prefix)
+      expect(serialized.subarray(offset, offset + 2)).toEqual(script);
+      offset += 2;
+      // ephemeral_pubkey (33)
+      expect(serialized.subarray(offset, offset + 33)).toEqual(ephemeralPubkey);
+      offset += 33;
+
+      expect(offset).toBe(serialized.length);
+    });
+
+    it('should include asset_commitment for FullShielded', () => {
+      const assetCommitment = Buffer.alloc(33, 0xdd);
+
+      const out = makeOutput({
+        mode: ShieldedOutputMode.FULLY_SHIELDED,
+        assetCommitment,
+      });
+
+      const parts = out.serializeSighash();
+      const serialized = Buffer.concat(parts);
+
+      // mode(1) + commitment(33) + asset_commitment(33) + script(3) + ephemeral(33)
+      expect(serialized.length).toBe(1 + 33 + 33 + 3 + 33);
+
+      // asset_commitment is after mode + commitment
+      const acOffset = 1 + 33;
+      expect(serialized.subarray(acOffset, acOffset + 33)).toEqual(assetCommitment);
+    });
+
+    it('should throw when ephemeral pubkey is missing', () => {
+      const out = makeOutput({ ephemeralPubkey: Buffer.alloc(0) });
+      expect(() => out.serializeSighash()).toThrow(/Invalid ephemeral pubkey/);
+    });
+
+    it('should throw when ephemeral pubkey has wrong size', () => {
+      const out = makeOutput({ ephemeralPubkey: Buffer.alloc(32) });
+      expect(() => out.serializeSighash()).toThrow(/expected 33 bytes/);
+    });
+  });
+});

--- a/__tests__/models/shielded_output.test.ts
+++ b/__tests__/models/shielded_output.test.ts
@@ -28,9 +28,8 @@ function makeOutput(
     overrides.tokenData ?? 0,
     overrides.script ?? Buffer.from([0x76, 0xa9, 0x14]),
     overrides.ephemeralPubkey ?? Buffer.alloc(33, 0xcc),
-    overrides.assetCommitment,
-    overrides.surjectionProof,
-    overrides.value ?? 100n
+    overrides.value ?? 100n,
+    { assetCommitment: overrides.assetCommitment, surjectionProof: overrides.surjectionProof }
   );
 }
 
@@ -204,6 +203,33 @@ describe('ShieldedOutput', () => {
     it('should throw when ephemeral pubkey has wrong size', () => {
       const out = makeOutput({ ephemeralPubkey: Buffer.alloc(32) });
       expect(() => out.serializeSighash()).toThrow(/expected 33 bytes/);
+    });
+  });
+
+  describe('defensive throws', () => {
+    // The enum-typed `mode` parameter excludes invalid values at compile
+    // time, but runtime data (JSON ingest, `as` casts) can bypass that.
+    // We exercise the runtime guards with an explicit unsafe cast.
+    const INVALID_MODE = 99 as unknown as ShieldedOutputMode;
+
+    it('serialize throws on unsupported mode', () => {
+      const out = makeOutput({ mode: INVALID_MODE });
+      expect(() => out.serialize()).toThrow(/Unsupported shielded output mode: 99/);
+    });
+
+    it('serializeSighash throws on unsupported mode', () => {
+      const out = makeOutput({ mode: INVALID_MODE });
+      expect(() => out.serializeSighash()).toThrow(/Unsupported shielded output mode: 99/);
+    });
+
+    it('serialize throws when ephemeral pubkey is missing', () => {
+      const out = makeOutput({ ephemeralPubkey: Buffer.alloc(0) });
+      expect(() => out.serialize()).toThrow(/Invalid ephemeral pubkey/);
+    });
+
+    it('serialize throws when ephemeral pubkey has wrong size', () => {
+      const out = makeOutput({ ephemeralPubkey: Buffer.alloc(32) });
+      expect(() => out.serialize()).toThrow(/expected 33 bytes/);
     });
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -146,6 +146,17 @@ export const AUTHORITY_TOKEN_DATA = TOKEN_AUTHORITY_MASK | 1;
 export const NATIVE_TOKEN_UID: string = '00';
 
 /**
+ * Native token uid as 32-byte hex (used in cryptographic operations such as shielded outputs)
+ */
+export const NATIVE_TOKEN_UID_HEX: string = '00'.repeat(32);
+
+/**
+ * Zero blinding factor (32 zero bytes) representing transparent (unblinded)
+ * inputs/outputs in Pedersen commitment balance equations.
+ */
+export const ZERO_TWEAK: Buffer = Buffer.alloc(32, 0);
+
+/**
  * Default HTR token config
  */
 export const DEFAULT_NATIVE_TOKEN_CONFIG = {
@@ -227,9 +238,14 @@ export const TX_WEIGHT_CONSTANTS: TxWeightConstants = {
 export const MAX_INPUTS: number = 255;
 
 /**
- * Maximum number of outputs
+ * Maximum number of transparent outputs
  */
 export const MAX_OUTPUTS: number = 255;
+
+/**
+ * Maximum number of shielded outputs
+ */
+export const MAX_SHIELDED_OUTPUTS: number = 32;
 
 /**
  * Maximum number of fee entries in a FeeHeader
@@ -295,6 +311,21 @@ export const P2SH_ACCT_PATH = `m/45'/${HATHOR_BIP44_CODE}'/0'`;
 export const P2PKH_ACCT_PATH = `m/44'/${HATHOR_BIP44_CODE}'/0'`;
 
 /**
+ * Account path for shielded scan keys (ECDH / view-only access to shielded outputs).
+ * Uses a separate account from legacy P2PKH (account 0') so that the scan key only
+ * grants read access to shielded outputs, not spending authority over legacy funds.
+ * This separation is critical for view key delegation (e.g., scanning services) and
+ * prevents compromising legacy address signing keys when debugging shielded decryption.
+ */
+export const SHIELDED_SCAN_ACCT_PATH = `m/44'/${HATHOR_BIP44_CODE}'/1'`;
+
+/**
+ * Account path for shielded spend keys (signing/spending authority).
+ * Uses account 2' to remain separate from both legacy (0') and scan (1') keys.
+ */
+export const SHIELDED_SPEND_ACCT_PATH = `m/44'/${HATHOR_BIP44_CODE}'/2'`;
+
+/**
  * String to be prefixed before signed messages using bitcore-message
  */
 export const HATHOR_MAGIC_BYTES = 'Hathor Signed Message:\n';
@@ -308,6 +339,18 @@ export const DEFAULT_ADDRESS_SCANNING_POLICY: AddressScanPolicy = SCANNING_POLIC
  * Fee per output
  */
 export const FEE_PER_OUTPUT: bigint = 1n;
+
+/**
+ * Fee per AmountShielded output (in HTR base units).
+ * Defined by hathor-core shielded transaction protocol (no external docs yet).
+ */
+export const FEE_PER_AMOUNT_SHIELDED_OUTPUT: bigint = 1n;
+
+/**
+ * Fee per FullShielded output (in HTR base units).
+ * Defined by hathor-core shielded transaction protocol (no external docs yet).
+ */
+export const FEE_PER_FULL_SHIELDED_OUTPUT: bigint = 2n;
 
 /**
  * Fee divisor

--- a/src/models/shielded_output.ts
+++ b/src/models/shielded_output.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { intToBytes } from '../utils/buffer';
+import { ShieldedOutputMode } from '../shielded/types';
+import { OutputValueType } from '../types';
+
+const EPHEMERAL_PUBKEY_SIZE = 33;
+
+/**
+ * Represents a shielded output in a transaction.
+ *
+ * Wire format (matching hathor-core serialization order):
+ *   mode(1) | commitment(33) | rp_len(2) | range_proof(var) |
+ *   script_len(2) | script(var) |
+ *   [if AMOUNT_SHIELDED]: token_data(1)
+ *   [if FULLY_SHIELDED]:  asset_commitment(33) | sp_len(2) | surjection_proof(var)
+ *   ephemeral_pubkey(33)
+ */
+class ShieldedOutput {
+  mode: ShieldedOutputMode;
+
+  commitment: Buffer;
+
+  rangeProof: Buffer;
+
+  tokenData: number;
+
+  script: Buffer;
+
+  ephemeralPubkey: Buffer;
+
+  assetCommitment?: Buffer;
+
+  surjectionProof?: Buffer;
+
+  /** The plaintext value, used for weight calculation. Not serialized on-chain. */
+  value: OutputValueType;
+
+  // eslint-disable-next-line default-param-last
+  constructor(
+    mode: ShieldedOutputMode,
+    commitment: Buffer,
+    rangeProof: Buffer,
+    tokenData: number,
+    script: Buffer,
+    ephemeralPubkey: Buffer,
+    assetCommitment?: Buffer,
+    surjectionProof?: Buffer,
+    value: OutputValueType = 0n
+  ) {
+    this.mode = mode;
+    this.commitment = commitment;
+    this.rangeProof = rangeProof;
+    this.tokenData = tokenData;
+    this.script = script;
+    this.ephemeralPubkey = ephemeralPubkey;
+    this.assetCommitment = assetCommitment;
+    this.value = value;
+    this.surjectionProof = surjectionProof;
+  }
+
+  /**
+   * Serialize a shielded output to bytes (wire format matching hathor-core).
+   */
+  serialize(): Buffer[] {
+    const arr: Buffer[] = [];
+
+    // Mode (1 byte)
+    arr.push(intToBytes(this.mode, 1));
+
+    // Commitment (33 bytes)
+    arr.push(this.commitment);
+
+    // Range proof (2 bytes length + variable)
+    arr.push(intToBytes(this.rangeProof.length, 2));
+    arr.push(this.rangeProof);
+
+    // Script (2 bytes length + variable)
+    arr.push(intToBytes(this.script.length, 2));
+    arr.push(this.script);
+
+    if (this.mode === ShieldedOutputMode.AMOUNT_SHIELDED) {
+      // Token data (1 byte, AmountShielded only)
+      arr.push(intToBytes(this.tokenData, 1));
+    } else if (this.mode === ShieldedOutputMode.FULLY_SHIELDED) {
+      if (!this.assetCommitment || !this.surjectionProof) {
+        throw new Error('FullShielded output requires assetCommitment and surjectionProof');
+      }
+      // Asset commitment (33 bytes, FullShielded only)
+      arr.push(this.assetCommitment);
+      // Surjection proof (2 bytes length + variable, FullShielded only)
+      arr.push(intToBytes(this.surjectionProof.length, 2));
+      arr.push(this.surjectionProof);
+    } else {
+      throw new Error(`Unsupported shielded output mode: ${this.mode}`);
+    }
+
+    // Ephemeral pubkey (always 33 bytes)
+    if (!this.ephemeralPubkey || this.ephemeralPubkey.length !== EPHEMERAL_PUBKEY_SIZE) {
+      throw new Error(
+        `Invalid ephemeral pubkey: expected ${EPHEMERAL_PUBKEY_SIZE} bytes, ` +
+          `got ${this.ephemeralPubkey?.length ?? 0}`
+      );
+    }
+    arr.push(this.ephemeralPubkey);
+
+    return arr;
+  }
+
+  /**
+   * Serialize for sighash (excludes proofs).
+   */
+  serializeSighash(): Buffer[] {
+    const arr: Buffer[] = [];
+
+    arr.push(intToBytes(this.mode, 1));
+    arr.push(this.commitment);
+
+    if (this.mode === ShieldedOutputMode.AMOUNT_SHIELDED) {
+      arr.push(intToBytes(this.tokenData, 1));
+    } else if (this.mode === ShieldedOutputMode.FULLY_SHIELDED) {
+      if (!this.assetCommitment) {
+        throw new Error('FullShielded output requires assetCommitment');
+      }
+      arr.push(this.assetCommitment);
+    } else {
+      throw new Error(`Unsupported shielded output mode: ${this.mode}`);
+    }
+
+    arr.push(this.script);
+
+    // Always include ephemeral pubkey in sighash
+    if (!this.ephemeralPubkey || this.ephemeralPubkey.length !== EPHEMERAL_PUBKEY_SIZE) {
+      throw new Error(
+        `Invalid ephemeral pubkey: expected ${EPHEMERAL_PUBKEY_SIZE} bytes, ` +
+          `got ${this.ephemeralPubkey?.length ?? 0}`
+      );
+    }
+    arr.push(this.ephemeralPubkey);
+
+    return arr;
+  }
+}
+
+export default ShieldedOutput;

--- a/src/models/shielded_output.ts
+++ b/src/models/shielded_output.ts
@@ -110,15 +110,25 @@ class ShieldedOutput {
     }
 
     // Ephemeral pubkey (always 33 bytes)
+    arr.push(this.getValidatedEphemeralPubkey());
+
+    return arr;
+  }
+
+  /**
+   * Validate that the ephemeral pubkey is exactly `EPHEMERAL_PUBKEY_SIZE`
+   * bytes and return it. Both `serialize` and `serializeSighash` need the
+   * same length check before emitting the pubkey on the wire; centralizing
+   * it here keeps the error message and the gate condition in lockstep.
+   */
+  private getValidatedEphemeralPubkey(): Buffer {
     if (!this.ephemeralPubkey || this.ephemeralPubkey.length !== EPHEMERAL_PUBKEY_SIZE) {
       throw new Error(
         `Invalid ephemeral pubkey: expected ${EPHEMERAL_PUBKEY_SIZE} bytes, ` +
           `got ${this.ephemeralPubkey?.length ?? 0}`
       );
     }
-    arr.push(this.ephemeralPubkey);
-
-    return arr;
+    return this.ephemeralPubkey;
   }
 
   /**
@@ -144,13 +154,7 @@ class ShieldedOutput {
     arr.push(this.script);
 
     // Always include ephemeral pubkey in sighash
-    if (!this.ephemeralPubkey || this.ephemeralPubkey.length !== EPHEMERAL_PUBKEY_SIZE) {
-      throw new Error(
-        `Invalid ephemeral pubkey: expected ${EPHEMERAL_PUBKEY_SIZE} bytes, ` +
-          `got ${this.ephemeralPubkey?.length ?? 0}`
-      );
-    }
-    arr.push(this.ephemeralPubkey);
+    arr.push(this.getValidatedEphemeralPubkey());
 
     return arr;
   }

--- a/src/models/shielded_output.ts
+++ b/src/models/shielded_output.ts
@@ -28,7 +28,15 @@ class ShieldedOutput {
 
   rangeProof: Buffer;
 
-  tokenData: number;
+  /**
+   * AmountShielded only — encodes the token index in `tx.tokens[]` (and the
+   * authority bit, 0x80). FullShielded has no wire slot for `token_data`
+   * because the token is hidden inside `asset_commitment`, so the field is
+   * meaningless for that mode and intentionally optional. `serialize` /
+   * `serializeSighash` throw if it's missing while `mode ===
+   * AMOUNT_SHIELDED`.
+   */
+  tokenData?: number;
 
   script: Buffer;
 
@@ -56,7 +64,7 @@ class ShieldedOutput {
     mode: ShieldedOutputMode,
     commitment: Buffer,
     rangeProof: Buffer,
-    tokenData: number,
+    tokenData: number | undefined,
     script: Buffer,
     ephemeralPubkey: Buffer,
     value: OutputValueType,
@@ -93,26 +101,74 @@ class ShieldedOutput {
     arr.push(intToBytes(this.script.length, 2));
     arr.push(this.script);
 
-    if (this.mode === ShieldedOutputMode.AMOUNT_SHIELDED) {
-      // Token data (1 byte, AmountShielded only)
-      arr.push(intToBytes(this.tokenData, 1));
-    } else if (this.mode === ShieldedOutputMode.FULLY_SHIELDED) {
-      if (!this.assetCommitment || !this.surjectionProof) {
-        throw new Error('FullShielded output requires assetCommitment and surjectionProof');
-      }
-      // Asset commitment (33 bytes, FullShielded only)
-      arr.push(this.assetCommitment);
-      // Surjection proof (2 bytes length + variable, FullShielded only)
-      arr.push(intToBytes(this.surjectionProof.length, 2));
-      arr.push(this.surjectionProof);
-    } else {
-      throw new Error(`Unsupported shielded output mode: ${this.mode}`);
-    }
+    // Mode-specific block (with surjection proof for FullShielded)
+    arr.push(...this.serializeModeSpecificFields({ includeProof: true }));
 
     // Ephemeral pubkey (always 33 bytes)
     arr.push(this.getValidatedEphemeralPubkey());
 
     return arr;
+  }
+
+  /**
+   * Serialize for sighash (excludes proofs).
+   *
+   * Note the script appears AFTER the mode-specific block here, vs BEFORE it
+   * in `serialize` — that ordering difference matches hathor-core's
+   * `get_sighash_bytes` exactly and is not malleable.
+   */
+  serializeSighash(): Buffer[] {
+    const arr: Buffer[] = [];
+
+    arr.push(intToBytes(this.mode, 1));
+    arr.push(this.commitment);
+
+    // Mode-specific block (without surjection proof — sighash excludes proofs)
+    arr.push(...this.serializeModeSpecificFields({ includeProof: false }));
+
+    arr.push(this.script);
+
+    // Always include ephemeral pubkey in sighash
+    arr.push(this.getValidatedEphemeralPubkey());
+
+    return arr;
+  }
+
+  /**
+   * Emit the mode-specific portion of the wire format:
+   *   - AmountShielded: `token_data` (1 byte)
+   *   - FullShielded:   `asset_commitment` (33 bytes), plus
+   *                     `sp_len` (2 bytes) + `surjection_proof` (var) when
+   *                     `includeProof` is true.
+   *
+   * Centralizing this here keeps `serialize` and `serializeSighash` in
+   * lockstep — the only difference between the two paths is whether the
+   * surjection proof is appended, controlled by the `includeProof` flag.
+   * Validation lives here too so the error messages match the gate
+   * conditions one-to-one.
+   */
+  private serializeModeSpecificFields({ includeProof }: { includeProof: boolean }): Buffer[] {
+    if (this.mode === ShieldedOutputMode.AMOUNT_SHIELDED) {
+      if (this.tokenData === undefined) {
+        throw new Error('AmountShielded output requires tokenData');
+      }
+      return [intToBytes(this.tokenData, 1)];
+    }
+    if (this.mode === ShieldedOutputMode.FULLY_SHIELDED) {
+      if (!this.assetCommitment) {
+        throw new Error('FullShielded output requires assetCommitment');
+      }
+      const fields: Buffer[] = [this.assetCommitment];
+      if (includeProof) {
+        if (!this.surjectionProof) {
+          throw new Error('FullShielded output requires surjectionProof');
+        }
+        fields.push(intToBytes(this.surjectionProof.length, 2));
+        fields.push(this.surjectionProof);
+      }
+      return fields;
+    }
+    throw new Error(`Unsupported shielded output mode: ${this.mode}`);
   }
 
   /**
@@ -129,34 +185,6 @@ class ShieldedOutput {
       );
     }
     return this.ephemeralPubkey;
-  }
-
-  /**
-   * Serialize for sighash (excludes proofs).
-   */
-  serializeSighash(): Buffer[] {
-    const arr: Buffer[] = [];
-
-    arr.push(intToBytes(this.mode, 1));
-    arr.push(this.commitment);
-
-    if (this.mode === ShieldedOutputMode.AMOUNT_SHIELDED) {
-      arr.push(intToBytes(this.tokenData, 1));
-    } else if (this.mode === ShieldedOutputMode.FULLY_SHIELDED) {
-      if (!this.assetCommitment) {
-        throw new Error('FullShielded output requires assetCommitment');
-      }
-      arr.push(this.assetCommitment);
-    } else {
-      throw new Error(`Unsupported shielded output mode: ${this.mode}`);
-    }
-
-    arr.push(this.script);
-
-    // Always include ephemeral pubkey in sighash
-    arr.push(this.getValidatedEphemeralPubkey());
-
-    return arr;
   }
 }
 

--- a/src/models/shielded_output.ts
+++ b/src/models/shielded_output.ts
@@ -41,7 +41,17 @@ class ShieldedOutput {
   /** The plaintext value, used for weight calculation. Not serialized on-chain. */
   value: OutputValueType;
 
-  // eslint-disable-next-line default-param-last
+  /**
+   * @param value Plaintext value (required so callers can't silently get
+   *   a 0n placeholder that would skew weight calculation). For wire-
+   *   format outputs whose value is hidden until rewind, pass `0n`
+   *   explicitly — see `ShieldedOutputsHeader.deserialize` in PR 3.
+   * @param options.assetCommitment / options.surjectionProof — required
+   *   for FullShielded mode; absent for AmountShielded mode. Enforced at
+   *   serialize time, not construction time, so deserializers can build
+   *   partial outputs (e.g. during streaming parse) before all fields
+   *   are populated.
+   */
   constructor(
     mode: ShieldedOutputMode,
     commitment: Buffer,
@@ -49,9 +59,8 @@ class ShieldedOutput {
     tokenData: number,
     script: Buffer,
     ephemeralPubkey: Buffer,
-    assetCommitment?: Buffer,
-    surjectionProof?: Buffer,
-    value: OutputValueType = 0n
+    value: OutputValueType,
+    options: { assetCommitment?: Buffer; surjectionProof?: Buffer } = {}
   ) {
     this.mode = mode;
     this.commitment = commitment;
@@ -59,9 +68,9 @@ class ShieldedOutput {
     this.tokenData = tokenData;
     this.script = script;
     this.ephemeralPubkey = ephemeralPubkey;
-    this.assetCommitment = assetCommitment;
     this.value = value;
-    this.surjectionProof = surjectionProof;
+    this.assetCommitment = options.assetCommitment;
+    this.surjectionProof = options.surjectionProof;
   }
 
   /**

--- a/src/shielded/index.ts
+++ b/src/shielded/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export { ShieldedOutputMode } from './types';
+
+export type {
+  IShieldedOutput,
+  IShieldedOutputDecoded,
+  IDecryptedShieldedOutput,
+  ICreatedShieldedOutput,
+  IShieldedCryptoProvider,
+  IProcessedShieldedOutput,
+} from './types';

--- a/src/shielded/index.ts
+++ b/src/shielded/index.ts
@@ -14,4 +14,6 @@ export type {
   ICreatedShieldedOutput,
   IShieldedCryptoProvider,
   IProcessedShieldedOutput,
+  IRewoundAmountShieldedOutput,
+  IRewoundFullShieldedOutput,
 } from './types';

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -51,7 +51,7 @@ export interface IDecryptedShieldedOutput {
   blindingFactor: Buffer;
   tokenUid: string; // hex, 32 bytes
   assetBlindingFactor?: Buffer;
-  outputType: ShieldedOutputMode;
+  mode: ShieldedOutputMode;
 }
 
 /**
@@ -223,7 +223,11 @@ export interface IRewoundAmountShieldedOutput {
 export interface IRewoundFullShieldedOutput {
   value: bigint;
   blindingFactor: Buffer;
-  tokenUid: Buffer; // 32 bytes, recovered from proof message
+  // hex, 32 bytes. Recovered from the proof message. Hex (not Buffer) so the
+  // shielded module presents a single canonical token-UID encoding to every
+  // consumer (storage, history, balance) — matching the rest of wallet-lib
+  // where `IUtxo.token` and friends are hex strings.
+  tokenUid: string;
   assetBlindingFactor: Buffer; // 32 bytes, recovered from proof message
 }
 

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Shielded output modes matching the Hathor protocol.
+ */
+export enum ShieldedOutputMode {
+  AMOUNT_SHIELDED = 1,
+  FULLY_SHIELDED = 2,
+}
+
+/**
+ * A shielded output as received from the full node API.
+ * This is the on-chain data before decryption.
+ */
+export interface IShieldedOutput {
+  // Optional because hathor-core nodes pre-`_shielded_output_to_json`
+  // mode-field addition still send shielded outputs without `mode`.
+  // Readers must fall back to detecting FullShielded via the presence
+  // of `asset_commitment` (the same pattern already used in the
+  // explorer's `TxData.isFullShielded`).
+  mode?: ShieldedOutputMode;
+  commitment: string; // hex, 33 bytes
+  range_proof: string; // hex, variable (~675 bytes)
+  script: string; // hex, output script (P2PKH/P2SH)
+  // FullShielded outputs may omit `token_data` (the token UID is hidden
+  // behind `asset_commitment`, so the field has no meaningful value).
+  token_data?: number; // token index (AmountShielded only)
+  ephemeral_pubkey: string; // hex, 33 bytes
+  decoded: IShieldedOutputDecoded;
+  // FullShielded only:
+  asset_commitment?: string; // hex, 33 bytes
+  surjection_proof?: string; // hex, variable
+}
+
+export interface IShieldedOutputDecoded {
+  type?: string;
+  address?: string;
+  timelock?: number | null;
+}
+
+/**
+ * The result of successfully decrypting a shielded output.
+ */
+export interface IDecryptedShieldedOutput {
+  value: bigint;
+  blindingFactor: Buffer;
+  tokenUid: string; // hex, 32 bytes
+  assetBlindingFactor?: Buffer;
+  outputType: ShieldedOutputMode;
+}
+
+/**
+ * Result of creating a shielded output via the crypto provider.
+ */
+export interface ICreatedShieldedOutput {
+  ephemeralPubkey: Buffer;
+  commitment: Buffer;
+  rangeProof: Buffer;
+  blindingFactor: Buffer;
+  assetCommitment?: Buffer;
+  assetBlindingFactor?: Buffer;
+  surjectionProof?: Buffer;
+}
+
+/**
+ * Swappable crypto provider for shielded output operations.
+ *
+ * Function names follow the SHIELDED-OUTPUTS-CLIENT-GUIDE.md specification.
+ *
+ * Implementations:
+ * - Node.js: @hathor/ct-crypto-node (napi-rs, default)
+ * - iOS: Swift wrapper via UniFFI
+ * - Android: Kotlin wrapper via UniFFI
+ *
+ * Every method returns `Promise<T>`. Some implementations (e.g. the Node
+ * native addon) compute results synchronously, but the interface uniformly
+ * returns Promises so callers don't have to defend against a `T | Promise<T>`
+ * union at every call site. Sync implementations should declare their methods
+ * `async` or wrap the return in `Promise.resolve(...)`.
+ */
+export interface IShieldedCryptoProvider {
+  /**
+   * Generate a random 32-byte blinding factor (valid secp256k1 scalar).
+   * MUST use the Rust crypto RNG — never use JS crypto.randomBytes.
+   */
+  generateRandomBlindingFactor(): Promise<Buffer>;
+
+  /**
+   * Create an AmountShielded output (amount hidden, token visible).
+   * Caller provides the value blinding factor (from generateRandomBlindingFactor
+   * or computeBalancingBlindingFactor).
+   */
+  createAmountShieldedOutput(
+    value: bigint,
+    recipientPubkey: Buffer,
+    tokenUid: Buffer,
+    valueBlindingFactor: Buffer
+  ): Promise<ICreatedShieldedOutput>;
+
+  /**
+   * Create a FullShielded output (amount AND token hidden).
+   * Caller provides both the value and asset blinding factors.
+   */
+  createShieldedOutputWithBothBlindings(
+    value: bigint,
+    recipientPubkey: Buffer,
+    tokenUid: Buffer,
+    valueBlindingFactor: Buffer,
+    assetBlindingFactor: Buffer
+  ): Promise<ICreatedShieldedOutput>;
+
+  /**
+   * Rewind an AmountShielded output to recover value and blinding factor.
+   * The token UID is known from the visible token_data field.
+   */
+  rewindAmountShieldedOutput(
+    privateKey: Buffer,
+    ephemeralPubkey: Buffer,
+    commitment: Buffer,
+    rangeProof: Buffer,
+    tokenUid: Buffer
+  ): Promise<IRewoundAmountShieldedOutput>;
+
+  /**
+   * Rewind a FullShielded output to recover value, blinding factor, token UID,
+   * and asset blinding factor. Does NOT take tokenUid — it's recovered from the proof message.
+   */
+  rewindFullShieldedOutput(
+    privateKey: Buffer,
+    ephemeralPubkey: Buffer,
+    commitment: Buffer,
+    rangeProof: Buffer,
+    assetCommitment: Buffer
+  ): Promise<IRewoundFullShieldedOutput>;
+
+  /**
+   * Compute the balancing blinding factor for the last shielded output.
+   * Uses secp256k1-zkp's compute_adaptive_blinding_factor.
+   *
+   * @param value - The value of the last output
+   * @param generatorBlindingFactor - Generator bf for the last output (zero for AmountShielded)
+   * @param inputs - Array of {value, vbf, gbf} for all inputs
+   * @param otherOutputs - Array of {value, vbf, gbf} for all other outputs (not the last)
+   */
+  computeBalancingBlindingFactor(
+    value: bigint,
+    generatorBlindingFactor: Buffer,
+    inputs: Array<{ value: bigint; vbf: Buffer; gbf: Buffer }>,
+    otherOutputs: Array<{ value: bigint; vbf: Buffer; gbf: Buffer }>
+  ): Promise<Buffer>;
+
+  /**
+   * Derive a raw Tag from a token UID (for surjection proofs and cross-checks).
+   */
+  deriveTag(tokenUid: Buffer): Promise<Buffer>;
+
+  /**
+   * Derive a blinded asset generator from a raw tag and blinding factor.
+   */
+  createAssetCommitment(tag: Buffer, blindingFactor: Buffer): Promise<Buffer>;
+
+  /**
+   * Create a surjection proof proving the output asset derives from one of the input assets.
+   */
+  createSurjectionProof(
+    codomainTag: Buffer,
+    codomainBlindingFactor: Buffer,
+    domain: Array<{ generator: Buffer; tag: Buffer; blindingFactor: Buffer }>
+  ): Promise<Buffer>;
+
+  /**
+   * ECDH shared secret derivation (for scanning optimization).
+   */
+  deriveEcdhSharedSecret(privkey: Buffer, pubkey: Buffer): Promise<Buffer>;
+
+  /**
+   * Recompute the AmountShielded value commitment from the cleartext
+   * `value`, `vbf`, and the (public) `tokenUid`. Equivalent to
+   * `createCommitment(value, vbf, deriveAssetTag(tokenUid))`. Used by
+   * verifier-only consumers (e.g. the explorer's "view tx unblinded"
+   * path) to confirm a shared opening matches the on-chain commitment
+   * without needing a range proof or ephemeral key.
+   *
+   * Returns the 33-byte serialized Pedersen commitment.
+   */
+  openAmountShieldedCommitment(value: bigint, vbf: Buffer, tokenUid: Buffer): Promise<Buffer>;
+
+  /**
+   * Recompute both the value and asset commitments for a FullShielded
+   * output from cleartext `value`, `vbf`, `tokenUid` and `abf`.
+   * Equivalent to:
+   *   tag = deriveTag(tokenUid)
+   *   assetCommitment = createAssetCommitment(tag, abf)
+   *   valueCommitment = createCommitment(value, vbf, assetCommitment)
+   *
+   * Returns both 33-byte serialized commitments. Verifier compares
+   * each to the on-chain bytes.
+   */
+  openFullShieldedCommitment(
+    value: bigint,
+    vbf: Buffer,
+    tokenUid: Buffer,
+    abf: Buffer
+  ): Promise<{ valueCommitment: Buffer; assetCommitment: Buffer }>;
+}
+
+/**
+ * Result of rewinding an AmountShielded output.
+ */
+export interface IRewoundAmountShieldedOutput {
+  value: bigint;
+  blindingFactor: Buffer;
+}
+
+/**
+ * Result of rewinding a FullShielded output.
+ */
+export interface IRewoundFullShieldedOutput {
+  value: bigint;
+  blindingFactor: Buffer;
+  tokenUid: Buffer; // 32 bytes, recovered from proof message
+  assetBlindingFactor: Buffer; // 32 bytes, recovered from proof message
+}
+
+/**
+ * Result of processing shielded outputs for a single transaction.
+ */
+export interface IProcessedShieldedOutput {
+  txId: string;
+  index: number;
+  decrypted: IDecryptedShieldedOutput;
+  address: string;
+  tokenUid: string;
+}


### PR DESCRIPTION
## Summary

Foundational additive types and constants for shielded outputs. **PR 1 of 7** in the decomposition of [PR #1059](https://github.com/HathorNetwork/hathor-wallet-lib/pull/1059) (`feat/shielded-outputs-integration`).

```
master ─ PR1 ◀ PR2 ─ PR3 ─ PR4 ─ PR5 ─ PR6 ─ PR7
```

## Acceptance Criteria

- Wallet-lib exposes a stable shielded-cryptography provider contract (`IShieldedCryptoProvider`) the rest of the codebase can target.
- A `ShieldedOutputMode` enum (`AMOUNT_SHIELDED=1` / `FULLY_SHIELDED=2`) is available as a discriminator across types and runtime checks.
- A serializable `ShieldedOutput` model exists whose `serialize` / `serializeSighash` outputs match the protocol wire format and round-trip via tests for both modes.
- Named constants for the shielded BIP32 derivation paths are defined (`SHIELDED_SCAN_ACCT_PATH = m/44'/280'/1'`, `SHIELDED_SPEND_ACCT_PATH = m/44'/280'/2'`).
- Named constants for the per-output shielded fees are defined (`FEE_PER_AMOUNT_SHIELDED_OUTPUT`, `FEE_PER_FULL_SHIELDED_OUTPUT`).
- Named constants for protocol limits and crypto primitives are defined (`MAX_SHIELDED_OUTPUTS`, `NATIVE_TOKEN_UID_HEX`, `ZERO_TWEAK`).
- No existing runtime path imports any of the new symbols — pure dead code from a runtime standpoint.
- Transparent-only wallets see byte-identical behavior to master.

## What's in this PR

- `src/shielded/types.ts` (new) — `IShieldedCryptoProvider` interface, `ShieldedOutputMode` enum (`AMOUNT_SHIELDED=1`, `FULLY_SHIELDED=2`), and the decoded / decrypted / created / processed output shapes.
- `src/shielded/index.ts` (new) — barrel re-exporting only the types above. Provider / processing implementations land in follow-up PRs.
- `src/models/shielded_output.ts` (new) — `ShieldedOutput` model with `serialize` and `serializeSighash` for inclusion in tx headers (used by PR 3's `ShieldedOutputsHeader`).
- `src/constants.ts` — additive only: `SHIELDED_SCAN_ACCT_PATH` (`m/44'/280'/1'`), `SHIELDED_SPEND_ACCT_PATH` (`m/44'/280'/2'`), `FEE_PER_AMOUNT_SHIELDED_OUTPUT`, `FEE_PER_FULL_SHIELDED_OUTPUT`, `MAX_SHIELDED_OUTPUTS`, `NATIVE_TOKEN_UID_HEX`, `ZERO_TWEAK`.
- `__tests__/models/shielded_output.test.ts` (new) — serialize + sighash round-trip coverage for both modes.

## Behavior preservation

Pure additions. Nothing in this slice is referenced by any existing runtime path — the new module is unreachable until a consumer wires it up in a follow-up PR.

`src/types.ts` is deliberately untouched here: shielded/clean carries breaking changes to `IHistoryInput` / `IHistoryOutput` / `IStore` / `IStorage` in that file, and those ripple to consumers in PR 5/6. The shielded types in `src/shielded/types.ts` are sufficient for this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shielded transaction output support with mode-dependent serialization for amount-shielded and fully-shielded outputs.
  * Introduced configuration constants for shielded transaction limits, fees, and HD wallet derivation paths.
  * Created cryptographic provider interface enabling shielded output creation, rewinding, and commitment operations.

* **Tests**
  * Added comprehensive test suite for shielded output serialization and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-lib/pull/1084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->