### PR TITLE
feat(shielded): address derivation, network version byte, key chains

### DIFF
--- a/__tests__/models/address.test.ts
+++ b/__tests__/models/address.test.ts
@@ -221,6 +221,37 @@ test('Rejects length/version-byte mismatches (crafted addresses with valid check
   expect(goodLegacy.isValid()).toBe(true);
 });
 
+test('Rejects a version byte with no decoded length registered', () => {
+  const testnetNetwork = new Network('testnet');
+
+  // The "no decoded length registered" guard is defensive: today the size
+  // map is keyed by the same three version bytes that isVersionByteValid
+  // accepts, so the two can never disagree through the public path. It exists
+  // for the future case of a byte added to the network's validity check
+  // without a matching size entry — which must fail loudly rather than
+  // default to a length. Simulate that divergence by accepting an unmapped
+  // byte at the network layer.
+  const unmappedByte = 0x99;
+  expect(testnetNetwork.versionBytes.p2pkh).not.toBe(unmappedByte);
+  expect(testnetNetwork.versionBytes.p2sh).not.toBe(unmappedByte);
+  expect(testnetNetwork.versionBytes.shielded).not.toBe(unmappedByte);
+
+  // 25-byte payload (passes the length check) with a valid checksum, so only
+  // the size-map lookup can reject it.
+  const payload = Buffer.concat([Buffer.from([unmappedByte]), Buffer.alloc(20, 0xcc)]);
+  const crafted = encoding.Base58.encode(Buffer.concat([payload, helpers.getChecksum(payload)]));
+  const addr = new Address(crafted, { network: testnetNetwork });
+
+  const spy = jest.spyOn(testnetNetwork, 'isVersionByteValid').mockReturnValue(true);
+  try {
+    expect(() => addr.validateAddress()).toThrow(
+      new RegExp(`No decoded length registered for version byte ${unmappedByte}`)
+    );
+  } finally {
+    spy.mockRestore();
+  }
+});
+
 test('Address script', () => {
   const addr = new Address('wcFwC82mLoUudtgakZGMPyTL2aHcgSJgDZ');
   const p2sh = new P2SH(addr);

--- a/__tests__/models/address.test.ts
+++ b/__tests__/models/address.test.ts
@@ -5,11 +5,35 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { encoding, HDPrivateKey, PublicKey } from 'bitcore-lib';
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
 import P2PKH from '../../src/models/p2pkh';
 import P2SH from '../../src/models/p2sh';
 import { encodeShieldedAddress } from '../../src/utils/shieldedAddress';
+import helpers from '../../src/utils/helpers';
+
+// Deterministic GENUINE curve points for shielded-address tests:
+// encodeShieldedAddress and the pubkey extractors validate on-curve
+// membership, so fake `Buffer.alloc(33, ..)` keys are rejected.
+const testHdRoot = HDPrivateKey.fromSeed(Buffer.alloc(32, 0x01), 'testnet');
+const SCAN_PUBKEY: Buffer = testHdRoot.deriveChild("m/0'/0").publicKey.toBuffer();
+const SPEND_PUBKEY: Buffer = testHdRoot.deriveChild("m/1'/0").publicKey.toBuffer();
+
+// Deterministic OFF-CURVE 33-byte buffer: scan fill bytes until we find an
+// x-coordinate with no point on secp256k1 (~50% of x values). Fixed curve
+// params make the result stable across runs.
+function findOffCurvePubkey(): Buffer {
+  for (let b = 0; b < 256; b++) {
+    const candidate = Buffer.concat([Buffer.from([0x02]), Buffer.alloc(32, b)]);
+    try {
+      PublicKey.fromBuffer(candidate);
+    } catch {
+      return candidate;
+    }
+  }
+  throw new Error('unreachable: no off-curve byte fill found');
+}
 
 test('Validate address', () => {
   // Invalid address
@@ -57,13 +81,7 @@ test('Address getType', () => {
 
 test('Shielded address validation and type detection', () => {
   const testnetNetwork = new Network('testnet');
-  // Create a valid shielded address with known pubkeys
-  const scanPubkey = Buffer.alloc(33, 0x02); // Fake compressed pubkey
-  scanPubkey[0] = 0x02; // Valid compressed prefix
-  const spendPubkey = Buffer.alloc(33, 0x03);
-  spendPubkey[0] = 0x03; // Valid compressed prefix
-
-  const shieldedAddr = encodeShieldedAddress(scanPubkey, spendPubkey, testnetNetwork);
+  const shieldedAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
   const addr = new Address(shieldedAddr, { network: testnetNetwork });
 
   // Should be valid
@@ -75,16 +93,63 @@ test('Shielded address validation and type detection', () => {
 
 test('Shielded address getScanPubkey and getSpendPubkey', () => {
   const testnetNetwork = new Network('testnet');
-  const scanPubkey = Buffer.alloc(33, 0xaa);
-  scanPubkey[0] = 0x02; // Valid compressed prefix
-  const spendPubkey = Buffer.alloc(33, 0xbb);
-  spendPubkey[0] = 0x03; // Valid compressed prefix
-
-  const shieldedAddr = encodeShieldedAddress(scanPubkey, spendPubkey, testnetNetwork);
+  const shieldedAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
   const addr = new Address(shieldedAddr, { network: testnetNetwork });
 
-  expect(addr.getScanPubkey()).toEqual(scanPubkey);
-  expect(addr.getSpendPubkey()).toEqual(spendPubkey);
+  expect(addr.getScanPubkey()).toEqual(SCAN_PUBKEY);
+  expect(addr.getSpendPubkey()).toEqual(SPEND_PUBKEY);
+});
+
+test('Shielded address getSpendAddress and getScript derive the on-chain P2PKH', () => {
+  const testnetNetwork = new Network('testnet');
+  const shieldedAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
+  const addr = new Address(shieldedAddr, { network: testnetNetwork });
+
+  // getSpendAddress: a valid P2PKH on the same network, derived from the spend pubkey
+  const spendAddress = addr.getSpendAddress();
+  expect(spendAddress.isValid()).toBe(true);
+  expect(spendAddress.getType()).toBe('p2pkh');
+
+  // getScript: identical bytes to building a P2PKH script from the spend address —
+  // the shielded address has no script form of its own.
+  const expectedScript = new P2PKH(spendAddress).createScript();
+  expect(addr.getScript()).toStrictEqual(expectedScript);
+
+  // Non-shielded addresses reject getSpendAddress
+  const legacy = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo', { network: testnetNetwork });
+  expect(() => legacy.getSpendAddress()).toThrow('Not a shielded address');
+});
+
+test('Shielded address from another network is rejected', () => {
+  const testnetNetwork = new Network('testnet');
+  const mainnetNetwork = new Network('mainnet');
+  // Encode for testnet (version byte 0x5d), validate against mainnet (expects 0x3c)
+  const testnetAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
+  const addr = new Address(testnetAddr, { network: mainnetNetwork });
+  expect(addr.isValid()).toBe(false);
+  expect(() => addr.validateAddress()).toThrow(/Invalid network byte/);
+});
+
+test('Shielded address with off-curve pubkey is rejected at extraction', () => {
+  const testnetNetwork = new Network('testnet');
+  const offCurve = findOffCurvePubkey();
+
+  // Craft the address manually (encodeShieldedAddress would reject the key):
+  // valid version byte, valid checksum — only the curve check can catch it.
+  const payload = Buffer.concat([
+    Buffer.from([testnetNetwork.versionBytes.shielded]),
+    offCurve,
+    SPEND_PUBKEY,
+  ]);
+  const crafted = encoding.Base58.encode(Buffer.concat([payload, helpers.getChecksum(payload)]));
+  const addr = new Address(crafted, { network: testnetNetwork });
+
+  // Structure (length/checksum/version byte) is fine…
+  expect(addr.isValid()).toBe(true);
+  // …but extracting the scan pubkey fails the on-curve check.
+  expect(() => addr.getScanPubkey()).toThrow(/not a point on the secp256k1 curve/);
+  // The spend key is genuine, so its extraction still works.
+  expect(addr.getSpendPubkey()).toEqual(SPEND_PUBKEY);
 });
 
 test('Non-shielded address getScanPubkey throws', () => {
@@ -92,6 +157,47 @@ test('Non-shielded address getScanPubkey throws', () => {
   expect(() => addr.getScanPubkey()).toThrow('Not a shielded address');
   expect(() => addr.getSpendPubkey()).toThrow('Not a shielded address');
   expect(addr.isShielded()).toBe(false);
+});
+
+test('Rejects length/version-byte mismatches (crafted addresses with valid checksums)', () => {
+  const testnetNetwork = new Network('testnet');
+
+  // Helper: build a base58 address of arbitrary payload with a VALID checksum,
+  // so only the new length↔version-byte cross-check can reject it.
+  function craft(payload: Buffer): string {
+    const checksum = helpers.getChecksum(payload);
+    return encoding.Base58.encode(Buffer.concat([payload, checksum]));
+  }
+
+  // 25-byte (legacy-length) address carrying the SHIELDED version byte.
+  // Without the cross-check this validated and getType() returned 'shielded',
+  // making getScanPubkey() silently clamp its subarray reads.
+  const shortShielded = craft(
+    Buffer.concat([Buffer.from([testnetNetwork.versionBytes.shielded]), Buffer.alloc(20, 0xaa)])
+  );
+  const addr1 = new Address(shortShielded, { network: testnetNetwork });
+  expect(addr1.isValid()).toBe(false);
+  expect(() => addr1.validateAddress()).toThrow(/requires 71 bytes, got 25/);
+  expect(addr1.isShielded()).toBe(false);
+
+  // 71-byte (shielded-length) address carrying the legacy P2PKH version byte.
+  const longLegacy = craft(
+    Buffer.concat([Buffer.from([testnetNetwork.versionBytes.p2pkh]), Buffer.alloc(66, 0xbb)])
+  );
+  const addr2 = new Address(longLegacy, { network: testnetNetwork });
+  expect(addr2.isValid()).toBe(false);
+  expect(() => addr2.validateAddress()).toThrow(/requires 25 bytes, got 71/);
+
+  // Sanity: correctly-shaped addresses of both families still validate.
+  const goodShielded = new Address(
+    encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork),
+    { network: testnetNetwork }
+  );
+  expect(goodShielded.isValid()).toBe(true);
+  const goodLegacy = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo', {
+    network: testnetNetwork,
+  });
+  expect(goodLegacy.isValid()).toBe(true);
 });
 
 test('Address script', () => {

--- a/__tests__/models/address.test.ts
+++ b/__tests__/models/address.test.ts
@@ -146,10 +146,31 @@ test('Shielded address with off-curve pubkey is rejected at extraction', () => {
 
   // Structure (length/checksum/version byte) is fine…
   expect(addr.isValid()).toBe(true);
-  // …but extracting the scan pubkey fails the on-curve check.
+  // …but parsing fails the on-curve check — and an address with ANY invalid
+  // key is invalid as a whole, so both extractors throw, including the one
+  // for the genuine spend key.
+  expect(() => addr.parseShielded()).toThrow(/not a point on the secp256k1 curve/);
   expect(() => addr.getScanPubkey()).toThrow(/not a point on the secp256k1 curve/);
-  // The spend key is genuine, so its extraction still works.
-  expect(addr.getSpendPubkey()).toEqual(SPEND_PUBKEY);
+  expect(() => addr.getSpendPubkey()).toThrow(/not a point on the secp256k1 curve/);
+});
+
+test('parseShielded returns all structural parts of a shielded address', () => {
+  const testnetNetwork = new Network('testnet');
+  const shieldedAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
+  const addr = new Address(shieldedAddr, { network: testnetNetwork });
+
+  const parts = addr.parseShielded();
+  expect(parts.versionByte).toBe(testnetNetwork.versionBytes.shielded);
+  expect(parts.scanPubkey).toEqual(SCAN_PUBKEY);
+  expect(parts.spendPubkey).toEqual(SPEND_PUBKEY);
+  // Checksum is the last 4 bytes of the decoded address and matches what
+  // the validator accepts (the address validated above via isShielded).
+  expect(parts.checksum).toEqual(addr.decode().subarray(-4));
+  expect(parts.checksum.length).toBe(4);
+
+  // Non-shielded addresses reject parseShielded
+  const legacy = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo', { network: testnetNetwork });
+  expect(() => legacy.parseShielded()).toThrow('Not a shielded address');
 });
 
 test('Non-shielded address getScanPubkey throws', () => {

--- a/__tests__/models/address.test.ts
+++ b/__tests__/models/address.test.ts
@@ -9,6 +9,7 @@ import Address from '../../src/models/address';
 import Network from '../../src/models/network';
 import P2PKH from '../../src/models/p2pkh';
 import P2SH from '../../src/models/p2sh';
+import { encodeShieldedAddress } from '../../src/utils/shieldedAddress';
 
 test('Validate address', () => {
   // Invalid address
@@ -52,6 +53,45 @@ test('Address getType', () => {
   // Mainnet p2sh
   const addr4 = new Address('hXRpjKbgVVGF1ioYtscCRavnzvGbsditXn', { network: mainnetNetwork });
   expect(addr4.getType()).toBe('p2sh');
+});
+
+test('Shielded address validation and type detection', () => {
+  const testnetNetwork = new Network('testnet');
+  // Create a valid shielded address with known pubkeys
+  const scanPubkey = Buffer.alloc(33, 0x02); // Fake compressed pubkey
+  scanPubkey[0] = 0x02; // Valid compressed prefix
+  const spendPubkey = Buffer.alloc(33, 0x03);
+  spendPubkey[0] = 0x03; // Valid compressed prefix
+
+  const shieldedAddr = encodeShieldedAddress(scanPubkey, spendPubkey, testnetNetwork);
+  const addr = new Address(shieldedAddr, { network: testnetNetwork });
+
+  // Should be valid
+  expect(addr.isValid()).toBe(true);
+  // Should be recognized as shielded
+  expect(addr.getType()).toBe('shielded');
+  expect(addr.isShielded()).toBe(true);
+});
+
+test('Shielded address getScanPubkey and getSpendPubkey', () => {
+  const testnetNetwork = new Network('testnet');
+  const scanPubkey = Buffer.alloc(33, 0xaa);
+  scanPubkey[0] = 0x02; // Valid compressed prefix
+  const spendPubkey = Buffer.alloc(33, 0xbb);
+  spendPubkey[0] = 0x03; // Valid compressed prefix
+
+  const shieldedAddr = encodeShieldedAddress(scanPubkey, spendPubkey, testnetNetwork);
+  const addr = new Address(shieldedAddr, { network: testnetNetwork });
+
+  expect(addr.getScanPubkey()).toEqual(scanPubkey);
+  expect(addr.getSpendPubkey()).toEqual(spendPubkey);
+});
+
+test('Non-shielded address getScanPubkey throws', () => {
+  const addr = new Address('WZ7pDnkPnxbs14GHdUFivFzPbzitwNtvZo');
+  expect(() => addr.getScanPubkey()).toThrow('Not a shielded address');
+  expect(() => addr.getSpendPubkey()).toThrow('Not a shielded address');
+  expect(addr.isShielded()).toBe(false);
 });
 
 test('Address script', () => {

--- a/__tests__/models/network.test.ts
+++ b/__tests__/models/network.test.ts
@@ -12,12 +12,14 @@ test('Get and set network', () => {
     mainnet: {
       p2pkh: 0x28,
       p2sh: 0x64,
+      shielded: 0x3c,
       xpriv: 0x03523b05,
       xpub: 0x0488b21e,
     },
     testnet: {
       p2pkh: 0x49,
       p2sh: 0x87,
+      shielded: 0x5d,
       xpriv: 0x0434c8c4,
       xpub: 0x0488b21e,
     },
@@ -47,10 +49,12 @@ test('network.isVersionByteValid', () => {
     mainnet: {
       p2pkh: 0x28,
       p2sh: 0x64,
+      shielded: 0x3c,
     },
     testnet: {
       p2pkh: 0x49,
       p2sh: 0x87,
+      shielded: 0x5d,
     },
   };
 
@@ -58,6 +62,7 @@ test('network.isVersionByteValid', () => {
   // Valid version bytes for testnet
   expect(testnet.isVersionByteValid(versionBytes.testnet.p2pkh)).toBe(true);
   expect(testnet.isVersionByteValid(versionBytes.testnet.p2sh)).toBe(true);
+  expect(testnet.isVersionByteValid(versionBytes.testnet.shielded)).toBe(true);
   // Invalid version bytes
   expect(testnet.isVersionByteValid(1)).toBe(false);
   expect(testnet.isVersionByteValid(105)).toBe(false);
@@ -67,6 +72,7 @@ test('network.isVersionByteValid', () => {
   // Valid version bytes for mainnet
   expect(mainnet.isVersionByteValid(versionBytes.mainnet.p2pkh)).toBe(true);
   expect(mainnet.isVersionByteValid(versionBytes.mainnet.p2sh)).toBe(true);
+  expect(mainnet.isVersionByteValid(versionBytes.mainnet.shielded)).toBe(true);
   // Invalid version bytes
   expect(mainnet.isVersionByteValid(1)).toBe(false);
   expect(mainnet.isVersionByteValid(105)).toBe(false);

--- a/__tests__/new/sendTransaction.test.ts
+++ b/__tests__/new/sendTransaction.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { HDPrivateKey } from 'bitcore-lib';
 import { TOKEN_AUTHORITY_MASK, NATIVE_TOKEN_UID } from '../../src/constants';
 import SendTransaction, {
   isDataOutput,
@@ -16,6 +17,41 @@ import { WalletType } from '../../src/types';
 import transaction from '../../src/utils/transaction';
 import { OutputType } from '../../src/wallet/types';
 import { mockGetToken } from '../__mock_helpers__/get-token.mock';
+import { encodeShieldedAddress } from '../../src/utils/shieldedAddress';
+import Network from '../../src/models/network';
+
+test('prepareTxData rejects a shielded address in a transparent output', async () => {
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+  storage.config.setNetwork('testnet');
+
+  // Genuine curve points (encode/extract validate on-curve membership).
+  const root = HDPrivateKey.fromSeed(Buffer.alloc(32, 0x09), 'testnet');
+  const shieldedAddress = encodeShieldedAddress(
+    root.deriveChild("m/0'/0").publicKey.toBuffer(),
+    root.deriveChild("m/1'/0").publicKey.toBuffer(),
+    new Network('testnet')
+  );
+
+  const sendTransaction = new SendTransaction({
+    storage,
+    outputs: [
+      {
+        type: OutputType.P2PKH,
+        address: shieldedAddress,
+        value: 10n,
+        token: NATIVE_TOKEN_UID,
+      },
+    ],
+  });
+
+  // The transparent pipeline must fail loudly BEFORE any utxo selection:
+  // shielded routing only lands in PR 6, and a 71-byte address has no
+  // transparent output script form.
+  await expect(sendTransaction.prepareTxData()).rejects.toThrow(
+    /Shielded addresses cannot be used directly as output script type/
+  );
+});
 
 test('type methods', () => {
   // The ISendInput and ISendOutput were created to satisfy the old facade methods while using typescript

--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -5,18 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HDPublicKey } from 'bitcore-lib';
+import { HDPublicKey, HDPrivateKey } from 'bitcore-lib';
 import Network from '../../src/models/network';
+import Address from '../../src/models/address';
+import P2PKH from '../../src/models/p2pkh';
 import { MemoryStore, Storage } from '../../src/storage';
 import { WalletType } from '../../src/types';
 import {
   getAddressType,
+  createOutputScriptFromAddress,
   deriveAddressFromDataP2SH,
   deriveAddressFromXPubP2PKH,
   deriveAddressP2PKH,
   deriveAddressP2SH,
   getAddressFromPubkey,
 } from '../../src/utils/address';
+import { encodeShieldedAddress } from '../../src/utils/shieldedAddress';
 
 /* eslint-disable @typescript-eslint/no-unused-vars -- These variables also serve as a documentation, even if unused */
 const seed =
@@ -97,6 +101,33 @@ test('Get address type', () => {
   const testnet = new Network('testnet');
   expect(getAddressType(WALLET_DATA.p2pkh.addresses[0], testnet)).toEqual('p2pkh');
   expect(getAddressType(WALLET_DATA.multisig.addresses[3], testnet)).toEqual('p2sh');
+});
+
+test('getAddressType throws for shielded addresses with actionable guidance', () => {
+  const testnet = new Network('testnet');
+  const root = HDPrivateKey.fromSeed(Buffer.alloc(32, 0x07), 'testnet');
+  const scanPubkey = root.deriveChild("m/0'/0").publicKey.toBuffer();
+  const spendPubkey = root.deriveChild("m/1'/0").publicKey.toBuffer();
+  const shieldedAddr = encodeShieldedAddress(scanPubkey, spendPubkey, testnet);
+
+  expect(() => getAddressType(shieldedAddr, testnet)).toThrow(
+    /cannot be used directly as output script type.*getSpendAddress/s
+  );
+});
+
+test('createOutputScriptFromAddress builds the spend-P2PKH script for shielded addresses', () => {
+  const testnet = new Network('testnet');
+  const root = HDPrivateKey.fromSeed(Buffer.alloc(32, 0x07), 'testnet');
+  const scanPubkey = root.deriveChild("m/0'/0").publicKey.toBuffer();
+  const spendPubkey = root.deriveChild("m/1'/0").publicKey.toBuffer();
+  const shieldedAddr = encodeShieldedAddress(scanPubkey, spendPubkey, testnet);
+
+  const script = createOutputScriptFromAddress(shieldedAddr, testnet);
+  // Must equal the P2PKH script of the spend-derived address — the shielded
+  // address itself has no script form.
+  const spendAddress = new Address(shieldedAddr, { network: testnet }).getSpendAddress();
+  const expected = new P2PKH(spendAddress).createScript();
+  expect(script).toStrictEqual(expected);
 });
 
 test('Derive p2pkh address from xpub', () => {

--- a/__tests__/utils/shieldedAddress.test.ts
+++ b/__tests__/utils/shieldedAddress.test.ts
@@ -113,6 +113,17 @@ describe('deriveShieldedAddress', () => {
     expect(info.spendPubkey).toBe(SPEND_PUBKEY.toString('hex'));
   });
 
+  it('rejects out-of-bounds indexes with a deterministic error', () => {
+    const cases = [-1, 1.5, NaN, 0x80000000];
+    for (const bad of cases) {
+      expect(() => deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, bad, 'testnet')).toThrow(
+        /Invalid BIP32 address index/
+      );
+    }
+    // Boundary: the largest non-hardened index is accepted
+    expect(() => deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 0x7fffffff, 'testnet')).not.toThrow();
+  });
+
   it('spendAddress is consistent with Address.getSpendAddress()', () => {
     const info = deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 3, 'testnet');
     const addr = new Address(info.base58, { network: testnetNetwork });

--- a/__tests__/utils/shieldedAddress.test.ts
+++ b/__tests__/utils/shieldedAddress.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { HDPrivateKey, PublicKey } from 'bitcore-lib';
+import {
+  encodeShieldedAddress,
+  deriveShieldedAddress,
+  assertValidCompressedPubkey,
+} from '../../src/utils/shieldedAddress';
+import Address from '../../src/models/address';
+import Network from '../../src/models/network';
+
+const testnetNetwork = new Network('testnet');
+
+// Deterministic key material: fixed seed -> stable xpubs/pubkeys across runs.
+const root = HDPrivateKey.fromSeed(Buffer.alloc(32, 0x42), 'testnet');
+const scanAcct = root.deriveChild("m/44'/280'/1'").deriveChild(0);
+const spendAcct = root.deriveChild("m/44'/280'/2'").deriveChild(0);
+const SCAN_XPUB: string = scanAcct.hdPublicKey.xpubkey;
+const SPEND_XPUB: string = spendAcct.hdPublicKey.xpubkey;
+
+const SCAN_PUBKEY: Buffer = scanAcct.deriveChild(0).publicKey.toBuffer();
+const SPEND_PUBKEY: Buffer = spendAcct.deriveChild(0).publicKey.toBuffer();
+
+// Deterministic off-curve 33-byte buffer (~50% of x values have no curve
+// point; fixed curve params make the scan stable across runs).
+function findOffCurvePubkey(): Buffer {
+  for (let b = 0; b < 256; b++) {
+    const candidate = Buffer.concat([Buffer.from([0x02]), Buffer.alloc(32, b)]);
+    try {
+      PublicKey.fromBuffer(candidate);
+    } catch {
+      return candidate;
+    }
+  }
+  throw new Error('unreachable: no off-curve byte fill found');
+}
+
+describe('assertValidCompressedPubkey', () => {
+  it('accepts a genuine compressed pubkey', () => {
+    expect(() => assertValidCompressedPubkey(SCAN_PUBKEY, 'scan pubkey')).not.toThrow();
+  });
+
+  it('rejects wrong length', () => {
+    expect(() => assertValidCompressedPubkey(Buffer.alloc(32, 0x02), 'scan pubkey')).toThrow(
+      /expected 33-byte compressed EC point.*got 32 bytes/
+    );
+  });
+
+  it('rejects an uncompressed prefix (0x04)', () => {
+    const bad = Buffer.concat([Buffer.from([0x04]), SCAN_PUBKEY.subarray(1)]);
+    expect(() => assertValidCompressedPubkey(bad, 'scan pubkey')).toThrow(/02\/03 prefix/);
+  });
+
+  it('rejects a well-shaped buffer whose x is not on the curve', () => {
+    expect(() => assertValidCompressedPubkey(findOffCurvePubkey(), 'scan pubkey')).toThrow(
+      /not a point on the secp256k1 curve/
+    );
+  });
+});
+
+describe('encodeShieldedAddress', () => {
+  it('round-trips through Address extraction', () => {
+    const base58 = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
+    const addr = new Address(base58, { network: testnetNetwork });
+    expect(addr.isValid()).toBe(true);
+    expect(addr.getType()).toBe('shielded');
+    expect(addr.getScanPubkey()).toEqual(SCAN_PUBKEY);
+    expect(addr.getSpendPubkey()).toEqual(SPEND_PUBKEY);
+  });
+
+  it('rejects invalid scan or spend keys', () => {
+    const offCurve = findOffCurvePubkey();
+    expect(() => encodeShieldedAddress(offCurve, SPEND_PUBKEY, testnetNetwork)).toThrow(
+      /Invalid scan pubkey/
+    );
+    expect(() => encodeShieldedAddress(SCAN_PUBKEY, offCurve, testnetNetwork)).toThrow(
+      /Invalid spend pubkey/
+    );
+    expect(() =>
+      encodeShieldedAddress(Buffer.alloc(20, 0x02), SPEND_PUBKEY, testnetNetwork)
+    ).toThrow(/got 20 bytes/);
+  });
+
+  it('uses the network-specific version byte', () => {
+    const testnetAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, testnetNetwork);
+    const mainnetAddr = encodeShieldedAddress(SCAN_PUBKEY, SPEND_PUBKEY, new Network('mainnet'));
+    expect(testnetAddr).not.toBe(mainnetAddr);
+    // Cross-network validation fails on the version byte
+    const wrongNet = new Address(testnetAddr, { network: new Network('mainnet') });
+    expect(wrongNet.isValid()).toBe(false);
+  });
+});
+
+describe('deriveShieldedAddress', () => {
+  it('is deterministic and index-sensitive', () => {
+    const a = deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 0, 'testnet');
+    const b = deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 0, 'testnet');
+    const c = deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 1, 'testnet');
+    expect(a.base58).toBe(b.base58);
+    expect(a.base58).not.toBe(c.base58);
+    expect(a.bip32AddressIndex).toBe(0);
+    expect(c.bip32AddressIndex).toBe(1);
+  });
+
+  it('derives the same child pubkeys as direct xpub derivation', () => {
+    const info = deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 0, 'testnet');
+    expect(info.scanPubkey).toBe(SCAN_PUBKEY.toString('hex'));
+    expect(info.spendPubkey).toBe(SPEND_PUBKEY.toString('hex'));
+  });
+
+  it('spendAddress is consistent with Address.getSpendAddress()', () => {
+    const info = deriveShieldedAddress(SCAN_XPUB, SPEND_XPUB, 3, 'testnet');
+    const addr = new Address(info.base58, { network: testnetNetwork });
+    expect(addr.getSpendAddress().base58).toBe(info.spendAddress);
+    // And the spendAddress is a valid network P2PKH
+    const spend = new Address(info.spendAddress, { network: testnetNetwork });
+    expect(spend.getType()).toBe('p2pkh');
+  });
+});

--- a/__tests__/utils/wallet.test.ts
+++ b/__tests__/utils/wallet.test.ts
@@ -687,3 +687,138 @@ test('getXprivFromData', () => {
   );
   expect(xpriv).toEqual(hdPrivKey.xprivkey);
 });
+
+describe('migrateShieldedAccessData', () => {
+  const seed =
+    'upon tennis increase embark dismiss diamond monitor face magnet jungle scout salute rural master shoulder cry juice jeans radar present close meat antenna mind';
+
+  function makePreShieldedRecord() {
+    // Freshly-generated record, then strip the four shielded fields to
+    // simulate a persisted record from a pre-shielded wallet-lib version.
+    const full = wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    const { scanXpubkey, scanMainKey, spendXpubkey, spendMainKey, ...preShielded } = full;
+    // Ensure the stripping actually matched the current schema so this test
+    // fails loudly if the fields are renamed.
+    expect(scanXpubkey).toBeDefined();
+    expect(scanMainKey).toBeDefined();
+    expect(spendXpubkey).toBeDefined();
+    expect(spendMainKey).toBeDefined();
+    return preShielded;
+  }
+
+  test('M.1 — no-op when record already has all four shielded fields', () => {
+    const full = wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    const before = { ...full };
+    const migrated = wallet.migrateShieldedAccessData(full, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    expect(migrated).toBe(false);
+    // Fields must be byte-identical — nothing should have been touched.
+    expect(full.scanXpubkey).toBe(before.scanXpubkey);
+    expect(full.scanMainKey).toEqual(before.scanMainKey);
+    expect(full.spendXpubkey).toBe(before.spendXpubkey);
+    expect(full.spendMainKey).toEqual(before.spendMainKey);
+  });
+
+  test('M.2 — no-op when xpub-only (no words to derive from)', () => {
+    // xpub-only records don't carry `words`, so migration has nothing to
+    // decrypt. This includes read-only view wallets that never had a seed.
+    const preShielded = makePreShieldedRecord();
+    delete preShielded.words;
+    const migrated = wallet.migrateShieldedAccessData(preShielded, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    expect(migrated).toBe(false);
+    expect(preShielded.scanXpubkey).toBeUndefined();
+    expect(preShielded.scanMainKey).toBeUndefined();
+    expect(preShielded.spendXpubkey).toBeUndefined();
+    expect(preShielded.spendMainKey).toBeUndefined();
+  });
+
+  test('M.3 — migrates pre-shielded record with the same derivation as fresh-create', () => {
+    const preShielded = makePreShieldedRecord();
+    const migrated = wallet.migrateShieldedAccessData(preShielded, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    expect(migrated).toBe(true);
+
+    const fresh = wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+
+    // xpubs are deterministic (no random salt) — must match byte-for-byte so
+    // a migrated wallet and a freshly-created wallet derive identical
+    // shielded addresses at every index.
+    expect(preShielded.scanXpubkey).toBe(fresh.scanXpubkey);
+    expect(preShielded.spendXpubkey).toBe(fresh.spendXpubkey);
+
+    // mainKeys use a random salt — they will not be byte-identical, but
+    // they must be valid encrypted blobs that decrypt with the same PIN.
+    expect(preShielded.scanMainKey).toBeDefined();
+    expect(preShielded.spendMainKey).toBeDefined();
+    expect(checkPassword(preShielded.scanMainKey!, '123')).toBe(true);
+    expect(checkPassword(preShielded.spendMainKey!, '123')).toBe(true);
+  });
+
+  test('M.4 — idempotent: calling again after migration is a no-op', () => {
+    const record = makePreShieldedRecord();
+    wallet.migrateShieldedAccessData(record, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    const afterFirst = { ...record };
+    const second = wallet.migrateShieldedAccessData(record, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    expect(second).toBe(false);
+    expect(record.scanXpubkey).toBe(afterFirst.scanXpubkey);
+    expect(record.scanMainKey).toEqual(afterFirst.scanMainKey);
+    expect(record.spendXpubkey).toBe(afterFirst.spendXpubkey);
+    expect(record.spendMainKey).toEqual(afterFirst.spendMainKey);
+  });
+
+  test('M.5 — wrong password throws and leaves the record untouched', () => {
+    const record = makePreShieldedRecord();
+    let caught: unknown;
+    try {
+      wallet.migrateShieldedAccessData(record, {
+        pin: '123',
+        password: 'wrong-password',
+        networkName: 'testnet',
+      });
+    } catch (e) {
+      caught = e;
+    }
+    // We wrap decryptData's failure in a specific message so operators
+    // know to provide the wallet password (not PIN). The original
+    // InvalidPasswdError stays available via .cause.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/wallet password \(not PIN\)/);
+    expect((caught as Error & { cause?: unknown }).cause).toBeInstanceOf(InvalidPasswdError);
+    // Critical: no fields should have been assigned before the throw. If
+    // decryptData throws, we must not leave a half-migrated record.
+    expect(record.scanXpubkey).toBeUndefined();
+    expect(record.scanMainKey).toBeUndefined();
+    expect(record.spendXpubkey).toBeUndefined();
+    expect(record.spendMainKey).toBeUndefined();
+  });
+});

--- a/__tests__/utils/wallet.test.ts
+++ b/__tests__/utils/wallet.test.ts
@@ -15,10 +15,16 @@ import {
   InvalidPasswdError,
 } from '../../src/errors';
 import Network from '../../src/models/network';
-import { HD_WALLET_ENTROPY, HATHOR_BIP44_CODE, P2SH_ACCT_PATH } from '../../src/constants';
+import {
+  HD_WALLET_ENTROPY,
+  HATHOR_BIP44_CODE,
+  P2SH_ACCT_PATH,
+  SHIELDED_SCAN_ACCT_PATH,
+  SHIELDED_SPEND_ACCT_PATH,
+} from '../../src/constants';
 import { hexToBuffer } from '../../src/utils/buffer';
 import { WalletType, WALLET_FLAGS } from '../../src/types';
-import { checkPassword } from '../../src/utils/crypto';
+import { checkPassword, decryptData } from '../../src/utils/crypto';
 
 test('Words', () => {
   const words = wallet.generateWalletWords();
@@ -563,6 +569,50 @@ test('access data from xpriv', () => {
   }).toThrow();
 });
 
+test('access data from xpriv — shielded key chains', () => {
+  const seed =
+    'upon tennis increase embark dismiss diamond monitor face magnet jungle scout salute rural master shoulder cry juice jeans radar present close meat antenna mind';
+  // Root xpriv of the seed above (same pair used by 'access data from seed').
+  const xprivkeyRoot =
+    'htpr4yPomy8kcy5uFJFugmAscbbeih6Cir9ZVaTCSKaCmbAgos8Ymq5BxVDpddzdfbwEnofgFJG3qkMbGS9RMexgju6C2Z9K63c5kJdkWZAwcf2';
+  const xprivkeyChange =
+    'htpr58K5ktSehjML89C3uRicPQ9TrrJ7LAbD7Xp1C7AZULDaY75joGmSu7TWGWqb31noixGt9ehSyspRVdFBhCZiJpB1RiuSosUkFw7QezVbECo';
+
+  const xprivRoot = HDPrivateKey.fromString(xprivkeyRoot);
+
+  // Root import: the depth-0 arm of the guard — shielded keys MUST be
+  // derived, at exactly the documented paths.
+  const fromRoot = wallet.generateAccessDataFromXpriv(xprivkeyRoot, { pin: '123' });
+  expect(fromRoot.scanXpubkey).toBe(
+    xprivRoot.deriveNonCompliantChild(SHIELDED_SCAN_ACCT_PATH).deriveNonCompliantChild(0).xpubkey
+  );
+  expect(fromRoot.spendXpubkey).toBe(
+    xprivRoot.deriveNonCompliantChild(SHIELDED_SPEND_ACCT_PATH).deriveNonCompliantChild(0).xpubkey
+  );
+  expect(checkPassword(fromRoot.scanMainKey!, '123')).toBe(true);
+  expect(checkPassword(fromRoot.spendMainKey!, '123')).toBe(true);
+
+  // Change-level import: the depth>0 arm — hardened accounts 1'/2' cannot
+  // be derived from a non-root key, so the fields must be ABSENT (the
+  // invariant documented on IWalletAccessData).
+  const fromChange = wallet.generateAccessDataFromXpriv(xprivkeyChange, { pin: '123' });
+  expect(fromChange.scanXpubkey).toBeUndefined();
+  expect(fromChange.scanMainKey).toBeUndefined();
+  expect(fromChange.spendXpubkey).toBeUndefined();
+  expect(fromChange.spendMainKey).toBeUndefined();
+
+  // Cross-check: a seed import and a root-xpriv import of the SAME wallet
+  // must yield identical shielded keys (guards the compliant/non-compliant
+  // derivation asymmetry this stack is sensitive to).
+  const fromSeed = wallet.generateAccessDataFromSeed(seed, {
+    pin: '123',
+    password: '456',
+    networkName: 'testnet',
+  });
+  expect(fromRoot.scanXpubkey).toBe(fromSeed.scanXpubkey);
+  expect(fromRoot.spendXpubkey).toBe(fromSeed.spendXpubkey);
+});
+
 test('access data from seed', () => {
   const seed =
     'upon tennis increase embark dismiss diamond monitor face magnet jungle scout salute rural master shoulder cry juice jeans radar present close meat antenna mind';
@@ -641,6 +691,8 @@ test('change pin and password', async () => {
   expect(checkPassword(accessData.words, '456')).toEqual(true);
   expect(checkPassword(accessData.mainKey, '123')).toEqual(true);
   expect(checkPassword(accessData.authKey, '123')).toEqual(true);
+  expect(checkPassword(accessData.scanMainKey!, '123')).toEqual(true);
+  expect(checkPassword(accessData.spendMainKey!, '123')).toEqual(true);
 
   expect(() => wallet.changeEncryptionPin(accessData, 'invalid-pin', '321')).toThrow(
     InvalidPasswdError
@@ -653,16 +705,37 @@ test('change pin and password', async () => {
   expect(checkPassword(pinChangedAccessData.words, '456')).toEqual(true);
   expect(checkPassword(pinChangedAccessData.mainKey, '321')).toEqual(true);
   expect(checkPassword(pinChangedAccessData.authKey, '321')).toEqual(true);
+  // Shielded scan/spend keys must be re-encrypted under the new pin…
+  expect(checkPassword(pinChangedAccessData.scanMainKey!, '321')).toEqual(true);
+  expect(checkPassword(pinChangedAccessData.spendMainKey!, '321')).toEqual(true);
+  expect(checkPassword(pinChangedAccessData.scanMainKey!, '123')).toEqual(false);
+  expect(checkPassword(pinChangedAccessData.spendMainKey!, '123')).toEqual(false);
+  // …and decrypt to the SAME xprivs as before (re-encryption, not re-derivation;
+  // also catches an oldPin/newPin swap or a scan/spend copy-paste mix-up).
+  expect(decryptData(pinChangedAccessData.scanMainKey!, '321')).toEqual(
+    decryptData(accessData.scanMainKey!, '123')
+  );
+  expect(decryptData(pinChangedAccessData.spendMainKey!, '321')).toEqual(
+    decryptData(accessData.spendMainKey!, '123')
+  );
+  expect(decryptData(pinChangedAccessData.scanMainKey!, '321')).not.toEqual(
+    decryptData(pinChangedAccessData.spendMainKey!, '321')
+  );
 
   const passwdChangedAccessData = wallet.changeEncryptionPassword(accessData, '456', '654');
   expect(checkPassword(passwdChangedAccessData.words, '654')).toEqual(true);
   expect(checkPassword(passwdChangedAccessData.mainKey, '123')).toEqual(true);
   expect(checkPassword(passwdChangedAccessData.authKey, '123')).toEqual(true);
+  // Password change must NOT touch the pin-encrypted shielded keys.
+  expect(checkPassword(passwdChangedAccessData.scanMainKey!, '123')).toEqual(true);
+  expect(checkPassword(passwdChangedAccessData.spendMainKey!, '123')).toEqual(true);
 
   const bothChangedAccessData = wallet.changeEncryptionPassword(pinChangedAccessData, '456', '654');
   expect(checkPassword(bothChangedAccessData.words, '654')).toEqual(true);
   expect(checkPassword(bothChangedAccessData.mainKey, '321')).toEqual(true);
   expect(checkPassword(bothChangedAccessData.authKey, '321')).toEqual(true);
+  expect(checkPassword(bothChangedAccessData.scanMainKey!, '321')).toEqual(true);
+  expect(checkPassword(bothChangedAccessData.spendMainKey!, '321')).toEqual(true);
 });
 
 test('getWalletIdFromXpub', () => {
@@ -820,5 +893,119 @@ describe('migrateShieldedAccessData', () => {
     expect(record.scanMainKey).toBeUndefined();
     expect(record.spendXpubkey).toBeUndefined();
     expect(record.spendMainKey).toBeUndefined();
+  });
+
+  test('M.6 — wrong PIN throws and leaves the record untouched', () => {
+    // Without the mainKey cross-check, a mismatched PIN silently produces
+    // scan/spend blobs encrypted under a different pin than the rest of the
+    // record — the wallet then fails to decrypt its shielded keys on every
+    // unlock with no hint that migration was the cause.
+    const record = makePreShieldedRecord();
+    let caught: unknown;
+    try {
+      wallet.migrateShieldedAccessData(record, {
+        pin: 'wrong-pin',
+        password: '456',
+        networkName: 'testnet',
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/PIN does not match the wallet mainKey/);
+    expect((caught as Error & { cause?: unknown }).cause).toBeInstanceOf(InvalidPasswdError);
+    expect(record.scanXpubkey).toBeUndefined();
+    expect(record.scanMainKey).toBeUndefined();
+    expect(record.spendXpubkey).toBeUndefined();
+    expect(record.spendMainKey).toBeUndefined();
+  });
+
+  test('M.7 — passphrase wallet: migration with the original passphrase matches fresh-create', () => {
+    const passphrase = 'my-bip39-passphrase';
+    const full = wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      passphrase,
+      networkName: 'testnet',
+    });
+    const {
+      scanXpubkey,
+      scanMainKey: _scanMainKey,
+      spendXpubkey,
+      spendMainKey: _spendMainKey,
+      ...preShielded
+    } = full;
+    expect(scanXpubkey).toBeDefined();
+
+    const migrated = wallet.migrateShieldedAccessData(preShielded, {
+      pin: '123',
+      password: '456',
+      passphrase,
+      networkName: 'testnet',
+    });
+    expect(migrated).toBe(true);
+    // Same passphrase -> same shielded root -> identical keys to fresh-create.
+    expect(preShielded.scanXpubkey).toBe(scanXpubkey);
+    expect(preShielded.spendXpubkey).toBe(spendXpubkey);
+  });
+
+  test('M.8 — passphrase wallet: a different passphrase silently derives different keys', () => {
+    // BIP39 passphrases are unverifiable by design (any passphrase yields a
+    // valid seed), so migration CANNOT detect this. This test pins the
+    // failure mode the doc comment warns about: callers must supply the
+    // wallet's original passphrase.
+    const passphrase = 'my-bip39-passphrase';
+    const full = wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      passphrase,
+      networkName: 'testnet',
+    });
+    const { scanXpubkey, ...preShielded } = full;
+    delete preShielded.scanMainKey;
+    delete preShielded.spendXpubkey;
+    delete preShielded.spendMainKey;
+
+    const migrated = wallet.migrateShieldedAccessData(preShielded, {
+      pin: '123',
+      password: '456',
+      passphrase: 'a-different-passphrase',
+      networkName: 'testnet',
+    });
+    // No error — but the keys come from a different root than the wallet's
+    // legacy keys.
+    expect(migrated).toBe(true);
+    expect(preShielded.scanXpubkey).not.toBe(scanXpubkey);
+  });
+
+  test('M.9 — partial record (some shielded fields missing) is healed by re-derivation', () => {
+    // A partial state can only arise from an interrupted write or manual
+    // tampering, but the re-derive path must heal it deterministically:
+    // same seed -> same keys, so overwriting the surviving fields is safe.
+    const full = wallet.generateAccessDataFromSeed(seed, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    const partial = { ...full };
+    delete partial.scanMainKey;
+    delete partial.spendXpubkey;
+
+    const migrated = wallet.migrateShieldedAccessData(partial, {
+      pin: '123',
+      password: '456',
+      networkName: 'testnet',
+    });
+    expect(migrated).toBe(true);
+    // All four fields repopulated, and the xpubs equal the original record's.
+    expect(partial.scanXpubkey).toBe(full.scanXpubkey);
+    expect(partial.spendXpubkey).toBe(full.spendXpubkey);
+    expect(checkPassword(partial.scanMainKey!, '123')).toBe(true);
+    expect(checkPassword(partial.spendMainKey!, '123')).toBe(true);
+    // The re-derived xprivs decrypt to the same values as the originals.
+    expect(decryptData(partial.scanMainKey!, '123')).toEqual(decryptData(full.scanMainKey!, '123'));
+    expect(decryptData(partial.spendMainKey!, '123')).toEqual(
+      decryptData(full.spendMainKey!, '123')
+    );
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -248,6 +248,18 @@ export const MAX_OUTPUTS: number = 255;
 export const MAX_SHIELDED_OUTPUTS: number = 32;
 
 /**
+ * Decoded byte length of a legacy (P2PKH/P2SH) address:
+ * version(1) + hash(20) + checksum(4)
+ */
+export const LEGACY_ADDRESS_SIZE_BYTES: number = 25;
+
+/**
+ * Decoded byte length of a shielded address:
+ * version(1) + scan_pubkey(33) + spend_pubkey(33) + checksum(4)
+ */
+export const SHIELDED_ADDRESS_SIZE_BYTES: number = 71;
+
+/**
  * Maximum serialized size (bytes) of a shielded output's range proof.
  * Mirrors hathor-core's MAX_RANGE_PROOF_SIZE.
  */

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -17,14 +17,23 @@ import Network from './network';
 import P2PKH from './p2pkh';
 import P2SH from './p2sh';
 import helpers from '../utils/helpers';
+import {
+  COMPRESSED_PUBKEY_SIZE_BYTES,
+  LEGACY_ADDRESS_SIZE_BYTES,
+  SHIELDED_ADDRESS_SIZE_BYTES,
+} from '../constants';
+import type { AddressType } from '../types';
+import type { IShieldedAddressParts } from '../shielded/types';
 
-/** Valid address types */
-export type AddressType = 'p2pkh' | 'p2sh' | 'shielded';
+// Re-export so existing `import { AddressType } from 'models/address'`
+// consumers keep working; the canonical home is src/types.ts.
+export type { AddressType };
 
-/** Shielded address payload length: 1B version + 33B scan + 33B spend = 67B + 4B checksum = 71B */
-const SHIELDED_ADDR_LENGTH = 71;
-/** Legacy address payload length: 1B version + 20B hash + 4B checksum = 25B */
-const LEGACY_ADDR_LENGTH = 25;
+// Shielded address layout offsets, derived from the pubkey size so the
+// 33-byte width is stated once: version(1) | scan(33) | spend(33) | checksum(4)
+const SCAN_PUBKEY_START = 1;
+const SCAN_PUBKEY_END = SCAN_PUBKEY_START + COMPRESSED_PUBKEY_SIZE_BYTES;
+const SPEND_PUBKEY_END = SCAN_PUBKEY_END + COMPRESSED_PUBKEY_SIZE_BYTES;
 
 class Address {
   // String with address as base58
@@ -97,11 +106,11 @@ class Address {
 
     // Validate address length
     if (
-      addressBytes.length !== LEGACY_ADDR_LENGTH &&
-      addressBytes.length !== SHIELDED_ADDR_LENGTH
+      addressBytes.length !== LEGACY_ADDRESS_SIZE_BYTES &&
+      addressBytes.length !== SHIELDED_ADDRESS_SIZE_BYTES
     ) {
       throw new AddressError(
-        `${errorMessage} Address has ${addressBytes.length} bytes and should have ${LEGACY_ADDR_LENGTH} or ${SHIELDED_ADDR_LENGTH}.`
+        `${errorMessage} Address has ${addressBytes.length} bytes and should have ${LEGACY_ADDRESS_SIZE_BYTES} or ${SHIELDED_ADDRESS_SIZE_BYTES}.`
       );
     }
 
@@ -135,7 +144,9 @@ class Address {
     // buffer. Note this runs only when the network is known (not under
     // `skipNetwork`), since the byte→length mapping is network-defined.
     const expectedLength =
-      firstByte === this.network.versionBytes.shielded ? SHIELDED_ADDR_LENGTH : LEGACY_ADDR_LENGTH;
+      firstByte === this.network.versionBytes.shielded
+        ? SHIELDED_ADDRESS_SIZE_BYTES
+        : LEGACY_ADDRESS_SIZE_BYTES;
     if (addressBytes.length !== expectedLength) {
       throw new AddressError(
         `${errorMessage} Version byte ${firstByte} requires ${expectedLength} bytes, got ${addressBytes.length}.`
@@ -195,41 +206,61 @@ class Address {
   }
 
   /**
-   * Extract the 33-byte scan pubkey from a shielded address.
-   * Bytes [1..34) of the decoded address.
+   * Split a shielded address into its structural parts:
+   * version(1) | scan_pubkey(33) | spend_pubkey(33) | checksum(4).
    *
-   * @throws {AddressError} If address is not shielded
+   * Single decode + on-curve validation of BOTH embedded pubkeys; the
+   * individual getters delegate here. Note this is stricter than
+   * extracting one key in isolation: an address with ANY invalid key is
+   * invalid as a whole, so both are checked regardless of which part the
+   * caller wants.
+   *
+   * @throws {AddressError} If address is not shielded or a pubkey is not
+   *   a point on the secp256k1 curve
+   * @return {IShieldedAddressParts}
+   * @memberof Address
+   * @inner
+   */
+  parseShielded(): IShieldedAddressParts {
+    if (!this.isShielded()) {
+      throw new AddressError('Not a shielded address');
+    }
+    const addressBytes = this.decode();
+    const parts: IShieldedAddressParts = {
+      versionByte: addressBytes[0],
+      scanPubkey: Buffer.from(addressBytes.subarray(SCAN_PUBKEY_START, SCAN_PUBKEY_END)),
+      spendPubkey: Buffer.from(addressBytes.subarray(SCAN_PUBKEY_END, SPEND_PUBKEY_END)),
+      checksum: Buffer.from(addressBytes.subarray(SPEND_PUBKEY_END)),
+    };
+    this.assertOnCurve(parts.scanPubkey, 'scan pubkey');
+    this.assertOnCurve(parts.spendPubkey, 'spend pubkey');
+    return parts;
+  }
+
+  /**
+   * Extract the 33-byte scan pubkey from a shielded address.
+   *
+   * @throws {AddressError} If address is not shielded or carries an
+   *   invalid pubkey (see parseShielded)
    * @return {Buffer} 33-byte compressed EC public key
    * @memberof Address
    * @inner
    */
   getScanPubkey(): Buffer {
-    if (!this.isShielded()) {
-      throw new AddressError('Not a shielded address');
-    }
-    const addressBytes = this.decode();
-    const scanPubkey = Buffer.from(addressBytes.subarray(1, 34));
-    this.assertOnCurve(scanPubkey, 'scan pubkey');
-    return scanPubkey;
+    return this.parseShielded().scanPubkey;
   }
 
   /**
    * Extract the 33-byte spend pubkey from a shielded address.
-   * Bytes [34..67) of the decoded address.
    *
-   * @throws {AddressError} If address is not shielded
+   * @throws {AddressError} If address is not shielded or carries an
+   *   invalid pubkey (see parseShielded)
    * @return {Buffer} 33-byte compressed EC public key
    * @memberof Address
    * @inner
    */
   getSpendPubkey(): Buffer {
-    if (!this.isShielded()) {
-      throw new AddressError('Not a shielded address');
-    }
-    const addressBytes = this.decode();
-    const spendPubkey = Buffer.from(addressBytes.subarray(34, 67));
-    this.assertOnCurve(spendPubkey, 'spend pubkey');
-    return spendPubkey;
+    return this.parseShielded().spendPubkey;
   }
 
   /**

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -183,8 +183,14 @@ class Address {
   isShielded(): boolean {
     try {
       return this.getType() === 'shielded';
-    } catch {
-      return false;
+    } catch (e) {
+      // Only AddressError means "structurally not a shielded address".
+      // Anything else is an unexpected failure that must not be silently
+      // converted into a misleading `false`.
+      if (e instanceof AddressError) {
+        return false;
+      }
+      throw e;
     }
   }
 

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -5,13 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { encoding, util } from 'bitcore-lib';
+import {
+  encoding,
+  util,
+  Address as BitcoreAddress,
+  PublicKey as bitcorePublicKey,
+} from 'bitcore-lib';
 import _ from 'lodash';
 import { AddressError } from '../errors';
 import Network from './network';
 import P2PKH from './p2pkh';
 import P2SH from './p2sh';
 import helpers from '../utils/helpers';
+
+/** Valid address types */
+export type AddressType = 'p2pkh' | 'p2sh' | 'shielded';
+
+/** Shielded address payload length: 1B version + 33B scan + 33B spend = 67B + 4B checksum = 71B */
+const SHIELDED_ADDR_LENGTH = 71;
+/** Legacy address payload length: 1B version + 20B hash + 4B checksum = 25B */
+const LEGACY_ADDR_LENGTH = 25;
 
 class Address {
   // String with address as base58
@@ -67,9 +80,10 @@ class Address {
   /**
    * Validate address
    *
-   * 1. Address must have 25 bytes
+   * Supports both legacy 25-byte addresses and 71-byte shielded addresses.
+   * 1. Address must have 25 bytes (legacy) or 71 bytes (shielded)
    * 2. Address checksum must be valid
-   * 3. Address first byte must match one of the options for P2PKH or P2SH
+   * 3. Address first byte must match one of the valid version bytes
    *
    * @throws {AddressError} Will throw an error if address is not valid
    *
@@ -82,9 +96,12 @@ class Address {
     const errorMessage = `Invalid address: ${this.base58}.`;
 
     // Validate address length
-    if (addressBytes.length !== 25) {
+    if (
+      addressBytes.length !== LEGACY_ADDR_LENGTH &&
+      addressBytes.length !== SHIELDED_ADDR_LENGTH
+    ) {
       throw new AddressError(
-        `${errorMessage} Address has ${addressBytes.length} bytes and should have 25.`
+        `${errorMessage} Address has ${addressBytes.length} bytes and should have ${LEGACY_ADDR_LENGTH} or ${SHIELDED_ADDR_LENGTH}.`
       );
     }
 
@@ -102,11 +119,11 @@ class Address {
       return true;
     }
 
-    // Validate version byte. Should be the p2pkh or p2sh
+    // Validate version byte
     const firstByte = addressBytes[0];
     if (!this.network.isVersionByteValid(firstByte)) {
       throw new AddressError(
-        `${errorMessage} Invalid network byte. Expected: ${this.network.versionBytes.p2pkh} or ${this.network.versionBytes.p2sh} and received ${firstByte}.`
+        `${errorMessage} Invalid network byte. Expected: ${this.network.versionBytes.p2pkh}, ${this.network.versionBytes.p2sh}, or ${this.network.versionBytes.shielded} and received ${firstByte}.`
       );
     }
     return true;
@@ -116,19 +133,22 @@ class Address {
    * Get address type
    *
    * Will check the version byte of the address against the network's version bytes.
-   * Valid types are p2pkh and p2sh.
+   * Valid types are p2pkh, p2sh, and shielded.
    *
    * @throws {AddressError} Will throw an error if address is not valid
    *
-   * @return {string}
+   * @return {AddressType}
    * @memberof Address
    * @inner
    */
-  getType(): 'p2pkh' | 'p2sh' {
+  getType(): AddressType {
     this.validateAddress();
     const addressBytes = this.decode();
 
     const firstByte = addressBytes[0];
+    if (firstByte === this.network.versionBytes.shielded) {
+      return 'shielded';
+    }
     if (firstByte === this.network.versionBytes.p2pkh) {
       return 'p2pkh';
     }
@@ -139,10 +159,78 @@ class Address {
   }
 
   /**
+   * Check if this is a shielded address (71-byte format with scan + spend pubkeys)
+   *
+   * @return {boolean}
+   * @memberof Address
+   * @inner
+   */
+  isShielded(): boolean {
+    try {
+      return this.getType() === 'shielded';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Extract the 33-byte scan pubkey from a shielded address.
+   * Bytes [1..34) of the decoded address.
+   *
+   * @throws {AddressError} If address is not shielded
+   * @return {Buffer} 33-byte compressed EC public key
+   * @memberof Address
+   * @inner
+   */
+  getScanPubkey(): Buffer {
+    if (!this.isShielded()) {
+      throw new AddressError('Not a shielded address');
+    }
+    const addressBytes = this.decode();
+    return Buffer.from(addressBytes.subarray(1, 34));
+  }
+
+  /**
+   * Extract the 33-byte spend pubkey from a shielded address.
+   * Bytes [34..67) of the decoded address.
+   *
+   * @throws {AddressError} If address is not shielded
+   * @return {Buffer} 33-byte compressed EC public key
+   * @memberof Address
+   * @inner
+   */
+  getSpendPubkey(): Buffer {
+    if (!this.isShielded()) {
+      throw new AddressError('Not a shielded address');
+    }
+    const addressBytes = this.decode();
+    return Buffer.from(addressBytes.subarray(34, 67));
+  }
+
+  /**
+   * Derive the on-chain P2PKH address from the spend_pubkey of a shielded address.
+   * This is the address that appears on-chain in the shielded output script.
+   *
+   * @throws {AddressError} If address is not shielded
+   * @return {Address} The P2PKH address derived from HASH160(spend_pubkey)
+   * @memberof Address
+   * @inner
+   */
+  getSpendAddress(): Address {
+    const spendPubkey = this.getSpendPubkey();
+    const base58 = new BitcoreAddress(
+      bitcorePublicKey(spendPubkey),
+      this.network.bitcoreNetwork
+    ).toString();
+    return new Address(base58, { network: this.network });
+  }
+
+  /**
    * Get address script
    *
-   * Will get the type of the address (p2pkh or p2sh)
-   * then create the script
+   * Will get the type of the address (p2pkh, p2sh, or shielded)
+   * then create the script.
+   * For shielded addresses, creates a P2PKH script from the spend_pubkey.
    *
    * @throws {AddressError} Will throw an error if address is not valid
    *
@@ -152,6 +240,12 @@ class Address {
    */
   getScript(): Buffer {
     const addressType = this.getType();
+    if (addressType === 'shielded') {
+      // For shielded addresses, derive P2PKH script from spend_pubkey
+      const spendAddress = this.getSpendAddress();
+      const p2pkh = new P2PKH(spendAddress);
+      return p2pkh.createScript();
+    }
     if (addressType === 'p2pkh') {
       const p2pkh = new P2PKH(this);
       return p2pkh.createScript();

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -126,6 +126,21 @@ class Address {
         `${errorMessage} Invalid network byte. Expected: ${this.network.versionBytes.p2pkh}, ${this.network.versionBytes.p2sh}, or ${this.network.versionBytes.shielded} and received ${firstByte}.`
       );
     }
+
+    // Cross-check length against version byte: the length and version-byte
+    // checks above are individually necessary but not jointly sufficient —
+    // without this, a crafted 25-byte address carrying the shielded version
+    // byte (or a 71-byte one carrying a legacy byte) validates, and the
+    // pubkey extractors would silently clamp `subarray` reads on the short
+    // buffer. Note this runs only when the network is known (not under
+    // `skipNetwork`), since the byte→length mapping is network-defined.
+    const expectedLength =
+      firstByte === this.network.versionBytes.shielded ? SHIELDED_ADDR_LENGTH : LEGACY_ADDR_LENGTH;
+    if (addressBytes.length !== expectedLength) {
+      throw new AddressError(
+        `${errorMessage} Version byte ${firstByte} requires ${expectedLength} bytes, got ${addressBytes.length}.`
+      );
+    }
     return true;
   }
 
@@ -187,7 +202,9 @@ class Address {
       throw new AddressError('Not a shielded address');
     }
     const addressBytes = this.decode();
-    return Buffer.from(addressBytes.subarray(1, 34));
+    const scanPubkey = Buffer.from(addressBytes.subarray(1, 34));
+    this.assertOnCurve(scanPubkey, 'scan pubkey');
+    return scanPubkey;
   }
 
   /**
@@ -204,7 +221,30 @@ class Address {
       throw new AddressError('Not a shielded address');
     }
     const addressBytes = this.decode();
-    return Buffer.from(addressBytes.subarray(34, 67));
+    const spendPubkey = Buffer.from(addressBytes.subarray(34, 67));
+    this.assertOnCurve(spendPubkey, 'spend pubkey');
+    return spendPubkey;
+  }
+
+  /**
+   * Assert an extracted pubkey decompresses to a point on the secp256k1
+   * curve. Base58 checksum only protects against transmission corruption —
+   * a deliberately crafted address can carry a 02/03-prefixed buffer whose
+   * x-coordinate has no curve point. Without this check such a key only
+   * fails much later (inside the crypto provider for scan keys, or inside
+   * bitcore for spend keys) with an opaque error far from the cause.
+   *
+   * @throws {AddressError} If the pubkey is not a valid curve point
+   */
+  private assertOnCurve(pubkey: Buffer, label: string): void {
+    try {
+      // bitcore validates curve membership at construction.
+      bitcorePublicKey.fromBuffer(pubkey);
+    } catch (e) {
+      throw new AddressError(
+        `Invalid address: ${this.base58}. The ${label} is not a point on the secp256k1 curve.`
+      );
+    }
   }
 
   /**

--- a/src/models/address.ts
+++ b/src/models/address.ts
@@ -143,10 +143,22 @@ class Address {
     // pubkey extractors would silently clamp `subarray` reads on the short
     // buffer. Note this runs only when the network is known (not under
     // `skipNetwork`), since the byte→length mapping is network-defined.
-    const expectedLength =
-      firstByte === this.network.versionBytes.shielded
-        ? SHIELDED_ADDRESS_SIZE_BYTES
-        : LEGACY_ADDRESS_SIZE_BYTES;
+    //
+    // Each valid version byte maps explicitly to its family's decoded
+    // length. `firstByte` is guaranteed present by isVersionByteValid above,
+    // but a future address family added to the network without an entry
+    // here must fail loudly rather than silently default to a length.
+    const sizeByVersionByte: Record<number, number> = {
+      [this.network.versionBytes.p2pkh]: LEGACY_ADDRESS_SIZE_BYTES,
+      [this.network.versionBytes.p2sh]: LEGACY_ADDRESS_SIZE_BYTES,
+      [this.network.versionBytes.shielded]: SHIELDED_ADDRESS_SIZE_BYTES,
+    };
+    const expectedLength = sizeByVersionByte[firstByte];
+    if (expectedLength === undefined) {
+      throw new AddressError(
+        `${errorMessage} No decoded length registered for version byte ${firstByte}.`
+      );
+    }
     if (addressBytes.length !== expectedLength) {
       throw new AddressError(
         `${errorMessage} Version byte ${firstByte} requires ${expectedLength} bytes, got ${addressBytes.length}.`

--- a/src/models/network.ts
+++ b/src/models/network.ts
@@ -14,18 +14,21 @@ const versionBytes = {
   mainnet: {
     p2pkh: 0x28,
     p2sh: 0x64,
+    shielded: 0x3c,
     xpriv: 0x03523b05, // htpr
     xpub: 0x0488b21e, // xpub // 0x03523a9c -> htpb
   },
   testnet: {
     p2pkh: 0x49,
     p2sh: 0x87,
+    shielded: 0x5d,
     xpriv: 0x0434c8c4, // tnpr
     xpub: 0x0488b21e, // xpub // 0x0434c85b -> tnpb
   },
   privatenet: {
     p2pkh: 0x49,
     p2sh: 0x87,
+    shielded: 0x5d,
     xpriv: 0x0434c8c4, // tnpr
     xpub: 0x0488b21e, // xpub // 0x0434c85b -> tnpb
   },
@@ -115,6 +118,7 @@ const networkOptions = {
 type versionBytesType = {
   p2pkh: number;
   p2sh: number;
+  shielded: number;
 };
 
 class Network {
@@ -164,7 +168,11 @@ class Network {
    */
   isVersionByteValid(version: number): boolean {
     const instanceVersionBytes = this.getVersionBytes();
-    return version === instanceVersionBytes.p2pkh || version === instanceVersionBytes.p2sh;
+    return (
+      version === instanceVersionBytes.p2pkh ||
+      version === instanceVersionBytes.p2sh ||
+      version === instanceVersionBytes.shielded
+    );
   }
 
   /**

--- a/src/new/sendTransaction.ts
+++ b/src/new/sendTransaction.ts
@@ -11,7 +11,7 @@ import txApi from '../api/txApi';
 import { NATIVE_TOKEN_UID, SELECT_OUTPUTS_TIMEOUT } from '../constants';
 import { ErrorMessages } from '../errorMessages';
 import { SendTxError, WalletError } from '../errors';
-import Address from '../models/address';
+import { getAddressType } from '../utils/address';
 import CreateTokenTransaction from '../models/create_token_transaction';
 import { Fee } from '../utils/fee';
 import Transaction from '../models/transaction';
@@ -188,7 +188,6 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
           token: output.token,
         });
       } else {
-        const addressObj = new Address(output.address, { network });
         // We set chooseInputs true as default and may be overwritten by the inputs.
         // chooseInputs should be true if no inputs are given
         tokenMap.set(output.token, true);
@@ -199,7 +198,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
           timelock: output.timelock ? output.timelock : null,
           authorities: 0n,
           token: output.token,
-          type: addressObj.getType(),
+          type: getAddressType(output.address, network),
         });
       }
     }

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -155,3 +155,20 @@ export interface IDataFullShieldedOutput extends IDataShieldedOutputBase {
  * with `if (out.shieldedMode === ShieldedOutputMode.FULLY_SHIELDED)`.
  */
 export type IDataShieldedOutput = IDataAmountShieldedOutput | IDataFullShieldedOutput;
+
+/**
+ * Result of deriving a shielded address at a BIP32 index from the scan and
+ * spend xpubs — return shape of `utils/shieldedAddress.deriveShieldedAddress()`.
+ */
+export interface IShieldedAddressInfo {
+  /** Full shielded address in base58 */
+  base58: string;
+  /** BIP32 index used to derive both scan and spend keys */
+  bip32AddressIndex: number;
+  /** 33-byte compressed scan pubkey (hex) */
+  scanPubkey: string;
+  /** 33-byte compressed spend pubkey (hex) */
+  spendPubkey: string;
+  /** P2PKH address derived from HASH160(spend_pubkey) — the on-chain address */
+  spendAddress: string;
+}

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -172,3 +172,18 @@ export interface IShieldedAddressInfo {
   /** P2PKH address derived from HASH160(spend_pubkey) — the on-chain address */
   spendAddress: string;
 }
+
+/**
+ * Structural parts of a decoded 71-byte shielded address — return shape of
+ * `Address.parseShielded()`: version(1) | scan(33) | spend(33) | checksum(4).
+ */
+export interface IShieldedAddressParts {
+  /** Network version byte (first byte) */
+  versionByte: number;
+  /** 33-byte compressed scan pubkey (ECDH detection) */
+  scanPubkey: Buffer;
+  /** 33-byte compressed spend pubkey (signing authority) */
+  spendPubkey: Buffer;
+  /** 4-byte checksum over the first 67 bytes */
+  checksum: Buffer;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,6 +96,12 @@ export type HistorySyncFunction = (
   shouldProcessHistory?: boolean
 ) => Promise<void>;
 
+/**
+ * Valid address types, as returned by `Address.getType()`:
+ * the two legacy script types plus the 71-byte shielded address format.
+ */
+export type AddressType = 'p2pkh' | 'p2sh' | 'shielded';
+
 export interface IAddressInfo {
   base58: string;
   bip32AddressIndex: number;
@@ -107,7 +113,7 @@ export interface IAddressInfo {
   //   utils/address getAddressType(), which throws for it.
   // 'shielded-spend' = the on-chain P2PKH derived from HASH160(spend_pubkey);
   //   this is the form getAddressType()/script builders accept.
-  addressType?: 'p2pkh' | 'p2sh' | 'shielded' | 'shielded-spend';
+  addressType?: AddressType | 'shielded-spend';
 }
 
 export interface IAddressMetadata {

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,12 @@ export interface IAddressInfo {
   bip32AddressIndex: number;
   // Only for p2pkh, undefined for multisig
   publicKey?: string;
-  // Address type: undefined = legacy, 'shielded' = full shielded address, 'shielded-spend' = on-chain P2PKH from spend key
+  // Address type: undefined = legacy.
+  // 'shielded' = the full 71-byte shielded address string (scan + spend pubkeys);
+  //   it has no output script of its own and must NOT be passed to
+  //   utils/address getAddressType(), which throws for it.
+  // 'shielded-spend' = the on-chain P2PKH derived from HASH160(spend_pubkey);
+  //   this is the form getAddressType()/script builders accept.
   addressType?: 'p2pkh' | 'p2sh' | 'shielded' | 'shielded-spend';
 }
 
@@ -381,7 +386,11 @@ export interface IWalletAccessData {
   multisigData?: IMultisigData;
   walletType: WalletType;
   walletFlags: number;
-  // Shielded address key material (optional, absent on wallets created before shielded feature)
+  // Shielded address key material. Optional: absent on wallets created
+  // before the shielded feature AND on wallets without root-key access —
+  // the scan/spend chains are hardened accounts (1'/2'), derivable only
+  // from the root xpriv, so xpub-only (read-only) wallets and wallets
+  // initialized from an account-level xpriv can never populate these.
   scanXpubkey?: string; // xpub at m/44'/280'/1'/0 (scan chain — view-only access)
   scanMainKey?: IEncryptedData; // encrypted xpriv at m/44'/280'/1'/0
   spendXpubkey?: string; // xpub at m/44'/280'/2'/0 (spend chain — signing authority)

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,8 @@ export interface IAddressInfo {
   bip32AddressIndex: number;
   // Only for p2pkh, undefined for multisig
   publicKey?: string;
+  // Address type: undefined = legacy, 'shielded' = full shielded address, 'shielded-spend' = on-chain P2PKH from spend key
+  addressType?: 'p2pkh' | 'p2sh' | 'shielded' | 'shielded-spend';
 }
 
 export interface IAddressMetadata {
@@ -379,6 +381,11 @@ export interface IWalletAccessData {
   multisigData?: IMultisigData;
   walletType: WalletType;
   walletFlags: number;
+  // Shielded address key material (optional, absent on wallets created before shielded feature)
+  scanXpubkey?: string; // xpub at m/44'/280'/1'/0 (scan chain — view-only access)
+  scanMainKey?: IEncryptedData; // encrypted xpriv at m/44'/280'/1'/0
+  spendXpubkey?: string; // xpub at m/44'/280'/2'/0 (spend chain — signing authority)
+  spendMainKey?: IEncryptedData; // encrypted xpriv at m/44'/280'/2'/0
 }
 
 export enum SCANNING_POLICY {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -20,15 +20,22 @@ import { IMultisigData, IStorage, IAddressInfo } from '../types';
 import { createP2SHRedeemScript } from './scripts';
 
 /**
- * Parse address and return the address type.
- * Returns 'p2pkh' or 'p2sh' for legacy addresses.
- * Throws for shielded addresses — callers expecting an output script type
- * should not receive shielded addresses directly.
+ * Parse address and return its OUTPUT SCRIPT type.
+ *
+ * This util answers "which script does an output to this address use" —
+ * every caller (send pipeline, token utils, storage fillTx, nano builder)
+ * feeds the result into output building. Shielded addresses have no output
+ * script form of their own (on-chain they use the spend-derived P2PKH), so
+ * this throws for them rather than letting a 71-byte address reach script
+ * builders.
+ *
+ * For the general address-family classifier — including 'shielded' — use
+ * `new Address(address, { network }).getType()` instead.
  *
  * @param {string} address
  * @param {Network} network
  *
- * @returns {'p2pkh' | 'p2sh'} output type of the address
+ * @returns {'p2pkh' | 'p2sh'} output script type of the address
  */
 export function getAddressType(address: string, network: Network): 'p2pkh' | 'p2sh' {
   const addressObj = new Address(address, { network });

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -35,7 +35,9 @@ export function getAddressType(address: string, network: Network): 'p2pkh' | 'p2
   const addrType = addressObj.getType();
   if (addrType === 'shielded') {
     throw new Error(
-      'Shielded addresses cannot be used directly as output script type. Use the spend-derived P2PKH address instead.'
+      'Shielded addresses cannot be used directly as output script type. ' +
+        'Use the spend-derived P2PKH address instead — obtain it via ' +
+        '`new Address(addr, { network }).getSpendAddress().base58`.'
     );
   }
   return addrType;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -20,16 +20,35 @@ import { IMultisigData, IStorage, IAddressInfo } from '../types';
 import { createP2SHRedeemScript } from './scripts';
 
 /**
- * Parse address and return the address type
+ * Parse address and return the address type.
+ * Returns 'p2pkh' or 'p2sh' for legacy addresses.
+ * Throws for shielded addresses — callers expecting an output script type
+ * should not receive shielded addresses directly.
  *
  * @param {string} address
  * @param {Network} network
  *
- * @returns {string} output type of the address (p2pkh or p2sh)
+ * @returns {'p2pkh' | 'p2sh'} output type of the address
  */
 export function getAddressType(address: string, network: Network): 'p2pkh' | 'p2sh' {
   const addressObj = new Address(address, { network });
-  return addressObj.getType();
+  const addrType = addressObj.getType();
+  if (addrType === 'shielded') {
+    throw new Error(
+      'Shielded addresses cannot be used directly as output script type. Use the spend-derived P2PKH address instead.'
+    );
+  }
+  return addrType;
+}
+
+/**
+ * Convert a bitcore PublicKey to a base58 P2PKH address string.
+ */
+export function publicKeyToP2PKH(
+  publicKey: InstanceType<typeof bitcorePublicKey>,
+  network: Network
+): string {
+  return new BitcoreAddress(publicKey, network.bitcoreNetwork).toString();
 }
 
 export function deriveAddressFromXPubP2PKH(
@@ -41,7 +60,7 @@ export function deriveAddressFromXPubP2PKH(
   const hdpubkey = new HDPublicKey(xpubkey);
   const key = hdpubkey.deriveChild(index);
   return {
-    base58: new BitcoreAddress(key.publicKey, network.bitcoreNetwork).toString(),
+    base58: publicKeyToP2PKH(key.publicKey, network),
     bip32AddressIndex: index,
     publicKey: key.publicKey.toString('hex'),
   };
@@ -119,6 +138,12 @@ export function createOutputScriptFromAddress(address: string, network: Network)
   if (addressType === 'p2pkh') {
     // P2PKH
     const p2pkh = new P2PKH(addressObj);
+    return p2pkh.createScript();
+  }
+  if (addressType === 'shielded') {
+    // For shielded addresses, derive P2PKH script from spend_pubkey
+    const spendAddress = addressObj.getSpendAddress();
+    const p2pkh = new P2PKH(spendAddress);
     return p2pkh.createScript();
   }
   throw new Error('Invalid address type');

--- a/src/utils/shieldedAddress.ts
+++ b/src/utils/shieldedAddress.ts
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { encoding, HDPublicKey } from 'bitcore-lib';
+import Network from '../models/network';
+import helpers from './helpers';
+import { publicKeyToP2PKH } from './address';
+
+export interface IShieldedAddressInfo {
+  /** Full shielded address in base58 */
+  base58: string;
+  /** BIP32 index used to derive both scan and spend keys */
+  bip32AddressIndex: number;
+  /** 33-byte compressed scan pubkey (hex) */
+  scanPubkey: string;
+  /** 33-byte compressed spend pubkey (hex) */
+  spendPubkey: string;
+  /** P2PKH address derived from HASH160(spend_pubkey) — the on-chain address */
+  spendAddress: string;
+}
+
+/**
+ * Encode a shielded address from two public keys.
+ * Format: Base58(version_byte(1B) || scan_pubkey(33B) || spend_pubkey(33B) || checksum(4B))
+ *
+ * @param scanPubkey 33-byte compressed EC public key for scanning (ECDH)
+ * @param spendPubkey 33-byte compressed EC public key for spending
+ * @param network Network instance
+ * @returns Base58-encoded shielded address (~97 characters)
+ */
+export function encodeShieldedAddress(
+  scanPubkey: Buffer,
+  spendPubkey: Buffer,
+  network: Network
+): string {
+  if (scanPubkey.length !== 33 || (scanPubkey[0] !== 0x02 && scanPubkey[0] !== 0x03)) {
+    throw new Error(
+      `Invalid scan pubkey: expected 33-byte compressed EC point (02/03 prefix), ` +
+        `got ${scanPubkey.length} bytes with prefix 0x${scanPubkey[0]?.toString(16).padStart(2, '0')}`
+    );
+  }
+  if (spendPubkey.length !== 33 || (spendPubkey[0] !== 0x02 && spendPubkey[0] !== 0x03)) {
+    throw new Error(
+      `Invalid spend pubkey: expected 33-byte compressed EC point (02/03 prefix), ` +
+        `got ${spendPubkey.length} bytes with prefix 0x${spendPubkey[0]?.toString(16).padStart(2, '0')}`
+    );
+  }
+
+  const versionByte = Buffer.from([network.versionBytes.shielded]);
+  const payload = Buffer.concat([versionByte, scanPubkey, spendPubkey]);
+  const checksum = helpers.getChecksum(payload);
+  const full = Buffer.concat([payload, checksum]);
+  return encoding.Base58.encode(full);
+}
+
+/**
+ * Derive a shielded address at a given BIP32 index from xpub keys.
+ *
+ * @param scanXpubkey xpub at the scan chain (m/44'/280'/1'/0)
+ * @param spendXpubkey xpub at the spend chain (m/44'/280'/2'/0)
+ * @param index BIP32 address index
+ * @param networkName Network name (mainnet, testnet, privatenet)
+ * @returns Shielded address info
+ */
+export function deriveShieldedAddress(
+  scanXpubkey: string,
+  spendXpubkey: string,
+  index: number,
+  networkName: string
+): IShieldedAddressInfo {
+  const network = new Network(networkName);
+
+  const scanHdPub = new HDPublicKey(scanXpubkey);
+  const spendHdPub = new HDPublicKey(spendXpubkey);
+
+  // Standard BIP32 derivation for public keys.
+  // Note: private key derivation (in processing.ts) uses deriveNonCompliantChild
+  // due to a historical bitcore-lib bug. Do not align these — the asymmetry is intentional.
+  const scanKey = scanHdPub.deriveChild(index);
+  const spendKey = spendHdPub.deriveChild(index);
+
+  const scanPubkeyBuf: Buffer = scanKey.publicKey.toBuffer();
+  const spendPubkeyBuf: Buffer = spendKey.publicKey.toBuffer();
+
+  const base58 = encodeShieldedAddress(scanPubkeyBuf, spendPubkeyBuf, network);
+
+  // Derive on-chain P2PKH from spend_pubkey
+  const spendAddress = publicKeyToP2PKH(spendKey.publicKey, network);
+
+  return {
+    base58,
+    bip32AddressIndex: index,
+    scanPubkey: scanPubkeyBuf.toString('hex'),
+    spendPubkey: spendPubkeyBuf.toString('hex'),
+    spendAddress,
+  };
+}

--- a/src/utils/shieldedAddress.ts
+++ b/src/utils/shieldedAddress.ts
@@ -5,10 +5,37 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { encoding, HDPublicKey } from 'bitcore-lib';
+import { encoding, HDPublicKey, PublicKey } from 'bitcore-lib';
 import Network from '../models/network';
 import helpers from './helpers';
 import { publicKeyToP2PKH } from './address';
+
+/**
+ * Assert a buffer is a valid compressed secp256k1 public key: 33 bytes,
+ * 02/03 prefix, AND an x-coordinate that decompresses to a point on the
+ * curve. The shape checks alone would accept ~50% of random 33-byte
+ * buffers (any x without a curve point fails only at decompression), so
+ * skipping the curve check lets a malformed address be encoded/sent around
+ * and only fail much later, inside the crypto provider, with an opaque
+ * error far from the cause.
+ */
+export function assertValidCompressedPubkey(pubkey: Buffer, label: string): void {
+  if (pubkey.length !== 33 || (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)) {
+    throw new Error(
+      `Invalid ${label}: expected 33-byte compressed EC point (02/03 prefix), ` +
+        `got ${pubkey.length} bytes with prefix 0x${pubkey[0]?.toString(16).padStart(2, '0')}`
+    );
+  }
+  try {
+    // bitcore validates curve membership at construction (throws on
+    // invalid x / point not on curve).
+    PublicKey.fromBuffer(pubkey);
+  } catch (e) {
+    throw new Error(
+      `Invalid ${label}: not a point on the secp256k1 curve (${e instanceof Error ? e.message : e})`
+    );
+  }
+}
 
 export interface IShieldedAddressInfo {
   /** Full shielded address in base58 */
@@ -37,18 +64,8 @@ export function encodeShieldedAddress(
   spendPubkey: Buffer,
   network: Network
 ): string {
-  if (scanPubkey.length !== 33 || (scanPubkey[0] !== 0x02 && scanPubkey[0] !== 0x03)) {
-    throw new Error(
-      `Invalid scan pubkey: expected 33-byte compressed EC point (02/03 prefix), ` +
-        `got ${scanPubkey.length} bytes with prefix 0x${scanPubkey[0]?.toString(16).padStart(2, '0')}`
-    );
-  }
-  if (spendPubkey.length !== 33 || (spendPubkey[0] !== 0x02 && spendPubkey[0] !== 0x03)) {
-    throw new Error(
-      `Invalid spend pubkey: expected 33-byte compressed EC point (02/03 prefix), ` +
-        `got ${spendPubkey.length} bytes with prefix 0x${spendPubkey[0]?.toString(16).padStart(2, '0')}`
-    );
-  }
+  assertValidCompressedPubkey(scanPubkey, 'scan pubkey');
+  assertValidCompressedPubkey(spendPubkey, 'spend pubkey');
 
   const versionByte = Buffer.from([network.versionBytes.shielded]);
   const payload = Buffer.concat([versionByte, scanPubkey, spendPubkey]);

--- a/src/utils/shieldedAddress.ts
+++ b/src/utils/shieldedAddress.ts
@@ -7,8 +7,10 @@
 
 import { encoding, HDPublicKey, PublicKey } from 'bitcore-lib';
 import Network from '../models/network';
+import { COMPRESSED_PUBKEY_SIZE_BYTES } from '../constants';
 import helpers from './helpers';
 import { publicKeyToP2PKH } from './address';
+import type { IShieldedAddressInfo } from '../shielded/types';
 
 /**
  * Assert a buffer is a valid compressed secp256k1 public key: 33 bytes,
@@ -18,11 +20,19 @@ import { publicKeyToP2PKH } from './address';
  * skipping the curve check lets a malformed address be encoded/sent around
  * and only fail much later, inside the crypto provider, with an opaque
  * error far from the cause.
+ *
+ * The explicit shape check is NOT redundant with `PublicKey.fromBuffer`:
+ * bitcore also accepts 65-byte UNCOMPRESSED keys (04/06/07 prefix), which
+ * would silently corrupt the fixed 33-byte slots of the address layout —
+ * and its own rejection message for bad shapes is an opaque 'Invalid X'.
  */
 export function assertValidCompressedPubkey(pubkey: Buffer, label: string): void {
-  if (pubkey.length !== 33 || (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)) {
+  if (
+    pubkey.length !== COMPRESSED_PUBKEY_SIZE_BYTES ||
+    (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)
+  ) {
     throw new Error(
-      `Invalid ${label}: expected 33-byte compressed EC point (02/03 prefix), ` +
+      `Invalid ${label}: expected ${COMPRESSED_PUBKEY_SIZE_BYTES}-byte compressed EC point (02/03 prefix), ` +
         `got ${pubkey.length} bytes with prefix 0x${pubkey[0]?.toString(16).padStart(2, '0')}`
     );
   }
@@ -35,19 +45,6 @@ export function assertValidCompressedPubkey(pubkey: Buffer, label: string): void
       `Invalid ${label}: not a point on the secp256k1 curve (${e instanceof Error ? e.message : e})`
     );
   }
-}
-
-export interface IShieldedAddressInfo {
-  /** Full shielded address in base58 */
-  base58: string;
-  /** BIP32 index used to derive both scan and spend keys */
-  bip32AddressIndex: number;
-  /** 33-byte compressed scan pubkey (hex) */
-  scanPubkey: string;
-  /** 33-byte compressed spend pubkey (hex) */
-  spendPubkey: string;
-  /** P2PKH address derived from HASH160(spend_pubkey) — the on-chain address */
-  spendAddress: string;
 }
 
 /**

--- a/src/utils/shieldedAddress.ts
+++ b/src/utils/shieldedAddress.ts
@@ -89,6 +89,14 @@ export function deriveShieldedAddress(
   index: number,
   networkName: string
 ): IShieldedAddressInfo {
+  // Fail loud with a deterministic error: negative/non-integer/hardened-range
+  // indexes would otherwise die deep inside bitcore with low-level errors
+  // (xpubs cannot derive hardened children, i.e. index >= 2^31).
+  if (!Number.isInteger(index) || index < 0 || index >= 0x80000000) {
+    throw new Error(
+      `Invalid BIP32 address index: expected a non-negative integer < 2^31, got ${index}`
+    );
+  }
   const network = new Network(networkName);
 
   const scanHdPub = new HDPublicKey(scanXpubkey);

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -754,6 +754,14 @@ const wallet = {
    * false})` later throws "Current shielded address is not loaded
    * (index=-1)". Running this migration on the next `wallet.start()` fixes
    * the state permanently.
+   *
+   * IMPORTANT: `passphrase` must be the wallet's original BIP39 passphrase.
+   * A different passphrase derives the shielded keys from a different root
+   * than the wallet's legacy keys — and this is NOT detectable here, since
+   * BIP39 passphrases are unverifiable by design (any passphrase yields a
+   * valid seed). The PIN, however, IS cross-checked against `mainKey` below
+   * so the new blobs can never be encrypted under a PIN that differs from
+   * the rest of the record.
    */
   migrateShieldedAccessData(
     accessData: IWalletAccessData,
@@ -793,6 +801,26 @@ const wallet = {
       (wrapped as Error & { cause?: unknown }).cause = e;
       throw wrapped;
     }
+
+    // Cross-check the PIN against the record's existing key material before
+    // writing anything: without this, a mismatched PIN silently produces
+    // scan/spend blobs encrypted under a DIFFERENT pin than mainKey — the
+    // wallet then fails to decrypt its shielded keys on every unlock, with
+    // no hint that the migration was the cause. BIP39 passphrases cannot be
+    // validated the same way (see doc comment), but the PIN can and must be.
+    if (accessData.mainKey) {
+      try {
+        decryptData(accessData.mainKey, pin);
+      } catch (e) {
+        const wrapped = new Error(
+          'Shielded migration PIN does not match the wallet mainKey. ' +
+            'The new shielded keys must be encrypted under the same PIN as the rest of the record.'
+        );
+        (wrapped as Error & { cause?: unknown }).cause = e;
+        throw wrapped;
+      }
+    }
+
     const code = new Mnemonic(words);
     const rootXpriv = code.toHDPrivateKey(passphrase, new Network(networkName));
 

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -13,6 +13,8 @@ import {
   HATHOR_BIP44_CODE,
   P2SH_ACCT_PATH,
   P2PKH_ACCT_PATH,
+  SHIELDED_SCAN_ACCT_PATH,
+  SHIELDED_SPEND_ACCT_PATH,
   WALLET_SERVICE_AUTH_DERIVATION_PATH,
 } from '../constants';
 import { OP_0 } from '../opcodes';
@@ -619,6 +621,21 @@ const wallet = {
       accessData.acctPathKey = encryptedAcctPathKey;
     }
 
+    // Derive shielded scan and spend keys if root key is available.
+    // Scan (account 1') and spend (account 2') use separate derivation paths from legacy (account 0')
+    // so the scan key only grants view access, not spending authority over legacy funds.
+    if (argXpriv.depth === 0) {
+      const scanAcctXpriv = argXpriv.deriveNonCompliantChild(SHIELDED_SCAN_ACCT_PATH);
+      const scanXpriv = scanAcctXpriv.deriveNonCompliantChild(0);
+      accessData.scanXpubkey = scanXpriv.xpubkey;
+      accessData.scanMainKey = encryptData(scanXpriv.xprivkey, pin);
+
+      const spendAcctXpriv = argXpriv.deriveNonCompliantChild(SHIELDED_SPEND_ACCT_PATH);
+      const spendXpriv2 = spendAcctXpriv.deriveNonCompliantChild(0);
+      accessData.spendXpubkey = spendXpriv2.xpubkey;
+      accessData.spendMainKey = encryptData(spendXpriv2.xprivkey, pin);
+    }
+
     if (authXpriv || derivedAuthKey) {
       let authKey: IEncryptedData;
       if (authXpriv) {
@@ -690,6 +707,13 @@ const wallet = {
       };
     }
 
+    // Derive shielded scan (account 1') and spend (account 2') keys.
+    // Separate from legacy (account 0') so scan key only grants view access.
+    const scanAcctXpriv = rootXpriv.deriveNonCompliantChild(SHIELDED_SCAN_ACCT_PATH);
+    const scanXpriv = scanAcctXpriv.deriveNonCompliantChild(0);
+    const spendAcctXpriv = rootXpriv.deriveNonCompliantChild(SHIELDED_SPEND_ACCT_PATH);
+    const spendXpriv = spendAcctXpriv.deriveNonCompliantChild(0);
+
     return {
       walletType,
       multisigData,
@@ -699,7 +723,93 @@ const wallet = {
       authKey: encryptedAuthPathKey,
       words: encryptedWords,
       walletFlags: 0,
+      scanXpubkey: scanXpriv.xpubkey,
+      scanMainKey: encryptData(scanXpriv.xprivkey, pin),
+      spendXpubkey: spendXpriv.xpubkey,
+      spendMainKey: encryptData(spendXpriv.xprivkey, pin),
     };
+  },
+
+  /**
+   * Re-derive the shielded scan/spend keys on an access-data record that was
+   * persisted before shielded support existed. No-op if the record already
+   * has all four shielded fields, or if the record lacks the encrypted seed
+   * (xpub-only wallets have nothing to derive from).
+   *
+   * The derivation MUST exactly match what `generateAccessDataFromSeed`
+   * produces for a fresh wallet (same paths, same encryption) so that a
+   * wallet that migrates and a wallet that was created fresh with the same
+   * seed end up with identical scan/spend keys and, therefore, identical
+   * shielded addresses.
+   *
+   * Mutates `accessData` in place when migration runs. Returns true iff
+   * any fields were written; the caller is expected to `saveAccessData` in
+   * that case.
+   *
+   * Existing wallet users hit this path when they upgrade from a
+   * pre-shielded wallet-lib (e.g. 0.37.0) to a shielded-capable one: the
+   * persisted access-data entry has no scan/spend fields, `loadAddresses`
+   * skips shielded derivation (`deriveShieldedAddressFromStorage` returns
+   * null when `scanXpubkey` is missing), and `getCurrentAddress({legacy:
+   * false})` later throws "Current shielded address is not loaded
+   * (index=-1)". Running this migration on the next `wallet.start()` fixes
+   * the state permanently.
+   */
+  migrateShieldedAccessData(
+    accessData: IWalletAccessData,
+    {
+      pin,
+      password,
+      passphrase = '',
+      networkName,
+    }: { pin: string; password: string; passphrase?: string; networkName: string }
+  ): boolean {
+    const hasAll =
+      !!accessData.scanXpubkey &&
+      !!accessData.scanMainKey &&
+      !!accessData.spendXpubkey &&
+      !!accessData.spendMainKey;
+    if (hasAll) return false;
+    if (!accessData.words) return false;
+
+    // `decryptData` throws InvalidPasswdError / DecryptionError. We wrap it
+    // here so the operator sees the *specific* failure mode — the wallet
+    // password (not the PIN) is required to decrypt the seed during shielded
+    // migration. Without context, "InvalidPasswdError" during wallet.start
+    // looks like a generic password problem and operators commonly retry
+    // with the PIN. We do NOT partially write fields before the throw, so a
+    // failed migration leaves the record untouched.
+    let words: string;
+    try {
+      words = decryptData(accessData.words, password);
+    } catch (e) {
+      // Project tsconfig predates ES2022 ErrorOptions; attach `cause` via
+      // property assignment so the original InvalidPasswdError/DecryptionError
+      // is still recoverable from `(err as Error & { cause? }).cause`.
+      const wrapped = new Error(
+        'Shielded migration requires the wallet password (not PIN) to decrypt the seed. ' +
+          'Ensure you provided the password and not the PIN, then retry wallet.start.'
+      );
+      (wrapped as Error & { cause?: unknown }).cause = e;
+      throw wrapped;
+    }
+    const code = new Mnemonic(words);
+    const rootXpriv = code.toHDPrivateKey(passphrase, new Network(networkName));
+
+    // Paths + encryption must match `generateAccessDataFromSeed` exactly.
+    const scanAcctXpriv = rootXpriv.deriveNonCompliantChild(SHIELDED_SCAN_ACCT_PATH);
+    const scanXpriv = scanAcctXpriv.deriveNonCompliantChild(0);
+    const spendAcctXpriv = rootXpriv.deriveNonCompliantChild(SHIELDED_SPEND_ACCT_PATH);
+    const spendXpriv = spendAcctXpriv.deriveNonCompliantChild(0);
+
+    /* eslint-disable no-param-reassign */
+    accessData.scanXpubkey = scanXpriv.xpubkey;
+    accessData.scanMainKey = encryptData(scanXpriv.xprivkey, pin);
+    accessData.spendXpubkey = spendXpriv.xpubkey;
+    accessData.spendMainKey = encryptData(spendXpriv.xprivkey, pin);
+    /* eslint-enable no-param-reassign */
+
+    return true;
   },
 
   /**
@@ -737,6 +847,16 @@ const wallet = {
       const acctPathKey = decryptData(data.acctPathKey, oldPin);
       const newEncryptedAcctPathKey = encryptData(acctPathKey, newPin);
       data.acctPathKey = newEncryptedAcctPathKey;
+    }
+
+    if (data.scanMainKey) {
+      const scanKey = decryptData(data.scanMainKey, oldPin);
+      data.scanMainKey = encryptData(scanKey, newPin);
+    }
+
+    if (data.spendMainKey) {
+      const spendKey = decryptData(data.spendMainKey, oldPin);
+      data.spendMainKey = encryptData(spendKey, newPin);
     }
 
     return data;

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -631,9 +631,9 @@ const wallet = {
       accessData.scanMainKey = encryptData(scanXpriv.xprivkey, pin);
 
       const spendAcctXpriv = argXpriv.deriveNonCompliantChild(SHIELDED_SPEND_ACCT_PATH);
-      const spendXpriv2 = spendAcctXpriv.deriveNonCompliantChild(0);
-      accessData.spendXpubkey = spendXpriv2.xpubkey;
-      accessData.spendMainKey = encryptData(spendXpriv2.xprivkey, pin);
+      const spendXpriv = spendAcctXpriv.deriveNonCompliantChild(0);
+      accessData.spendXpubkey = spendXpriv.xpubkey;
+      accessData.spendMainKey = encryptData(spendXpriv.xprivkey, pin);
     }
 
     if (authXpriv || derivedAuthKey) {


### PR DESCRIPTION
## Summary

Establishes the shielded address format (71-byte: 1B version + 33B scan + 33B spend + 4B checksum) and the BIP32 key-chain layout that backs it. **PR 4 of 7** in the decomposition of [PR #1059](https://github.com/HathorNetwork/hathor-wallet-lib/pull/1059).

```
master ─ PR1 ─ PR2 ─ PR3 ─ PR4 ◀ PR5 ─ PR6 ─ PR7
```

Base: `shielded/pr-3-headers`.

## Acceptance Criteria

- Wallet-lib can encode a 71-byte shielded address (`encodeShieldedAddress`) and decode it back to its scan + spend pubkeys.
- Wallet-lib can derive a shielded address pair at a given BIP32 index from scan/spend xpubs (`deriveShieldedAddress`).
- The `Address` model recognizes the 71-byte shielded format and exposes `isShielded()`, `getScanPubkey()`, `getSpendPubkey()`, `getSpendAddress()`, `getScript()`.
- Mainnet shielded version byte is `0x3c`, testnet/privatenet is `0x5d` — matches the protocol spec.
- `Network.isVersionByteValid` accepts the new byte alongside the existing P2PKH/P2SH ones.
- BIP32 paths `m/44'/280'/1'/0` (scan) and `m/44'/280'/2'/0` (spend) match the spec.
- Fresh seed-derived and xpriv-derived wallets land with shielded scan + spend keys in their access-data record automatically.
- Existing wallets persisted before shielded support can be upgraded via `migrateShieldedAccessData`, which is idempotent and safely no-ops for xpub-only / xpriv-imported wallets.
- PIN changes via `changePinOnAccessData` correctly re-encrypt the shielded keys when present.
- The transparent send pipeline rejects shielded addresses with a clear error (`getAddressType` throws — shielded routing lands in PR 6).
- `createOutputScriptFromAddress` correctly emits a P2PKH script derived from the spend pubkey for a shielded address.
- Malformed shielded addresses are rejected even with valid checksums: length must match the version-byte family, and both embedded pubkeys must be points on secp256k1.
- No behavior change for transparent-only wallets — existing serialized access-data, addresses, and tx flows remain identical.

## Behavior preservation

- `Network.versionBytes.shielded` is read only by `Address.getType()` when the first byte matches. Existing addresses never satisfy.
- `Address(71-byte string)` now constructs successfully (previously threw). To preserve the transparent send pipeline, `sendTransaction.ts` now routes through `getAddressType()` which throws on shielded input.
- New shielded keys land in `accessData` for **fresh** seed-derived / xpriv-derived wallets only; existing serialized `accessData` is untouched until `migrateShieldedAccessData` is called (no caller invokes it yet — that wiring is in PR 6).
- `migrateShieldedAccessData` is itself idempotent and returns `false` (no-op) on xpub-only / xpriv-imported / already-migrated records.

## Plan deviation

Storage-coupled derivation (`deriveShieldedAddressFromStorage`) is **deferred to PR 5** along with the `IStorage` shielded extensions (`getScanXPubKey`, `getSpendXPubKey`) that it depends on. That keeps PR 4 focused on the primitives + key chains and PR 5 focused on storage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shielded address support: detection, validation, on-chain spend-address derivation, and P2PKH output-script handling; networks now recognize shielded version bytes; wallet access data can generate, migrate, and re-encrypt shielded scan/spend key material.

* **Tests**
  * Added comprehensive tests covering shielded encoding/decoding, curve/key validation, cross-network checks, deterministic derivation, spend-address/script derivation, wallet migration, and PIN/passphrase edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->