### PR TITLE
feat(shielded): data model + storage layer for shielded addresses

### DIFF
--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -11,7 +11,7 @@ import { MemoryStore, Storage } from '../../src/storage';
 import tx_history from '../__fixtures__/tx_history';
 import walletApi from '../../src/api/wallet';
 import { encryptData } from '../../src/utils/crypto';
-import { TokenVersion, WalletType } from '../../src/types';
+import { IHistoryTx, TokenVersion, WalletType } from '../../src/types';
 import { processHistory } from '../../src/utils/storage';
 
 test('default values', async () => {
@@ -417,6 +417,45 @@ test('selectUtxos resolves a shielded filter_address to its spend P2PKH via ctMa
   for await (const u of store.selectUtxos({ filter_address: 'spend-0' })) bySpend.push(u);
   expect(bySpend).toHaveLength(1);
   expect(bySpend[0].txId).toEqual('txS');
+});
+
+test('addTx advances the shielded cursor from a shielded receive in tx.shielded_outputs', async () => {
+  const store = new MemoryStore();
+  // Own a shielded-spend P2PKH at index 7 (the on-chain form of a shielded
+  // receive). SEPARATED model: the receive lands in tx.shielded_outputs, NOT
+  // tx.outputs, so the address-index tracking must look there too.
+  await store.saveAddress({
+    base58: 'spend-7',
+    bip32AddressIndex: 7,
+    addressType: 'shielded-spend',
+    ctMappingAddress: 'ct-7',
+  });
+  expect(store.walletData.shieldedLastUsedAddressIndex).toEqual(-1);
+
+  await store.saveTx({
+    tx_id: 'a'.repeat(64),
+    version: 1,
+    weight: 1,
+    timestamp: 123,
+    is_voided: false,
+    inputs: [],
+    outputs: [],
+    shielded_outputs: [
+      {
+        commitment: 'aa',
+        range_proof: 'bb',
+        script: 'cc',
+        ephemeral_pubkey: 'dd',
+        token_data: 0,
+        decoded: { address: 'spend-7' },
+      },
+    ],
+    parents: [],
+  } as unknown as IHistoryTx);
+
+  // The shielded chain cursor advances to 7; the legacy cursor is untouched.
+  expect(store.walletData.shieldedLastUsedAddressIndex).toEqual(7);
+  expect(store.walletData.lastUsedAddressIndex).toEqual(-1);
 });
 
 test('access data methods', async () => {

--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -106,26 +106,18 @@ test('addressIter chain-selection (legacy vs shielded)', async () => {
   expect(legacyBases.sort()).toEqual(defaultBases.sort());
 
   // legacy: false → user-facing shielded receive addresses only, in
-  // BIP32-index order. shielded-spend MUST NOT leak through (it's
-  // internal — surfacing it would let callers send to a wallet's
+  // insertion (== BIP32-index) order. shielded-spend MUST NOT leak through
+  // (it's internal — surfacing it would let callers send to a wallet's
   // spend P2PKH thinking it's a shielded address).
   const shieldedBases: string[] = [];
   for await (const info of store.addressIter({ legacy: false })) shieldedBases.push(info.base58);
   expect(shieldedBases).toEqual(['shi-0', 'shi-1']);
-});
 
-test('addressIter shielded chain yields BIP32-index order even when saved out of order', async () => {
-  const store = new MemoryStore();
-  // Save shielded receive addresses with indices out of order to prove the
-  // iterator sorts by BIP32 index rather than relying on insertion order.
-  await store.saveAddress({ base58: 'shi-3', bip32AddressIndex: 3, addressType: 'shielded' });
-  await store.saveAddress({ base58: 'shi-0', bip32AddressIndex: 0, addressType: 'shielded' });
-  await store.saveAddress({ base58: 'shi-2', bip32AddressIndex: 2, addressType: 'shielded' });
-  await store.saveAddress({ base58: 'shi-1', bip32AddressIndex: 1, addressType: 'shielded' });
-
-  const bases: string[] = [];
-  for await (const info of store.addressIter({ legacy: false })) bases.push(info.base58);
-  expect(bases).toEqual(['shi-0', 'shi-1', 'shi-2', 'shi-3']);
+  // addressCount is per-chain: legacy counts leg-0/leg-1/p2sh-2 (3), shielded
+  // counts shi-0/shi-1 (2); the internal shielded-spend is in neither.
+  await expect(store.addressCount()).resolves.toEqual(3);
+  await expect(store.addressCount({ legacy: true })).resolves.toEqual(3);
+  await expect(store.addressCount({ legacy: false })).resolves.toEqual(2);
 });
 
 test('history methods', async () => {

--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -372,6 +372,53 @@ test('utxo methods', async () => {
   expect(buf[0].shielded).not.toBe(true);
 });
 
+test('selectUtxos resolves a shielded filter_address to its spend P2PKH via ctMappingAddress', async () => {
+  const store = new MemoryStore();
+  // A shielded receive pair at index 0, cross-linked via ctMappingAddress the
+  // same way deriveShieldedAddressFromStorage sets it: the user-facing ct
+  // address points to its on-chain spend P2PKH and vice-versa.
+  await store.saveAddress({
+    base58: 'ct-0',
+    bip32AddressIndex: 0,
+    addressType: 'shielded',
+    ctMappingAddress: 'spend-0',
+  });
+  await store.saveAddress({
+    base58: 'spend-0',
+    bip32AddressIndex: 0,
+    addressType: 'shielded-spend',
+    ctMappingAddress: 'ct-0',
+  });
+  // The on-chain UTXO is labelled with the spend P2PKH, never the 71-byte ct form.
+  await store.saveUtxo({
+    txId: 'txS',
+    index: 0,
+    token: '00',
+    address: 'spend-0',
+    value: 50n,
+    authorities: 0n,
+    timelock: null,
+    type: 1,
+    height: null,
+    shielded: true,
+    blindingFactor: 'bb'.repeat(32),
+  });
+
+  // Filtering by the user-facing ct address must resolve (O(1) via
+  // ctMappingAddress) to the spend P2PKH and find the UTXO.
+  const byCt = [];
+  for await (const u of store.selectUtxos({ filter_address: 'ct-0' })) byCt.push(u);
+  expect(byCt).toHaveLength(1);
+  expect(byCt[0].txId).toEqual('txS');
+  expect(byCt[0].address).toEqual('spend-0');
+
+  // Filtering by the spend P2PKH directly also matches (no swap needed).
+  const bySpend = [];
+  for await (const u of store.selectUtxos({ filter_address: 'spend-0' })) bySpend.push(u);
+  expect(bySpend).toHaveLength(1);
+  expect(bySpend[0].txId).toEqual('txS');
+});
+
 test('access data methods', async () => {
   const store = new MemoryStore();
   const xpriv = new HDPrivateKey();

--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -48,7 +48,7 @@ test('addresses methods', async () => {
   await expect(store.getAddressMeta('b')).resolves.toEqual(5);
   await expect(store.addressCount()).resolves.toEqual(3);
 
-  await expect(store.getCurrentAddress()).rejects.toThrow('Current address is not loaded');
+  await expect(store.getCurrentAddress()).rejects.toThrow('Current legacy address is not loaded');
   expect(store.walletData.currentAddressIndex).toEqual(-1);
   expect(store.walletData.lastLoadedAddressIndex).toEqual(0);
   await store.saveAddress({
@@ -74,6 +74,44 @@ test('addresses methods', async () => {
   await expect(store.getCurrentAddress()).resolves.toEqual('d');
   await expect(store.getCurrentAddress(true)).resolves.toEqual('d');
   await expect(store.getCurrentAddress()).resolves.toEqual('e');
+});
+
+test('addressIter chain-selection (legacy vs shielded)', async () => {
+  const store = new MemoryStore();
+
+  // Mixed-chain fixture: two legacy P2PKHs (with explicit + implicit
+  // addressType), one shielded receive, one shielded-spend (internal),
+  // and one P2SH. The iterator must filter strictly by chain.
+  await store.saveAddress({ base58: 'leg-0', bip32AddressIndex: 0, addressType: 'p2pkh' });
+  await store.saveAddress({ base58: 'leg-1', bip32AddressIndex: 1 }); // untyped → legacy
+  await store.saveAddress({ base58: 'p2sh-2', bip32AddressIndex: 2, addressType: 'p2sh' });
+  await store.saveAddress({ base58: 'shi-0', bip32AddressIndex: 0, addressType: 'shielded' });
+  await store.saveAddress({ base58: 'shi-1', bip32AddressIndex: 1, addressType: 'shielded' });
+  await store.saveAddress({
+    base58: 'shi-spend-0',
+    bip32AddressIndex: 0,
+    addressType: 'shielded-spend',
+  });
+
+  // Default (no opts) → legacy chain only. shielded + shielded-spend
+  // entries are filtered out (the receive pipeline relies on the
+  // shielded-spend P2PKH being invisible at this surface).
+  const defaultBases: string[] = [];
+  for await (const info of store.addressIter()) defaultBases.push(info.base58);
+  expect(defaultBases.sort()).toEqual(['leg-0', 'leg-1', 'p2sh-2'].sort());
+
+  // legacy: true is the explicit form of the default.
+  const legacyBases: string[] = [];
+  for await (const info of store.addressIter({ legacy: true })) legacyBases.push(info.base58);
+  expect(legacyBases.sort()).toEqual(defaultBases.sort());
+
+  // legacy: false → user-facing shielded receive addresses only, in
+  // BIP32-index order. shielded-spend MUST NOT leak through (it's
+  // internal — surfacing it would let callers send to a wallet's
+  // spend P2PKH thinking it's a shielded address).
+  const shieldedBases: string[] = [];
+  for await (const info of store.addressIter({ legacy: false })) shieldedBases.push(info.base58);
+  expect(shieldedBases).toEqual(['shi-0', 'shi-1']);
 });
 
 test('history methods', async () => {
@@ -283,6 +321,46 @@ test('utxo methods', async () => {
   }
   expect(buf).toHaveLength(1);
   expect(buf[0].txId).toEqual('tx02');
+
+  // Add a shielded UTXO
+  await store.saveUtxo({
+    txId: 'tx03',
+    index: 0,
+    token: '00',
+    address: 'addr3',
+    value: 30n,
+    authorities: 0n,
+    timelock: null,
+    type: 1,
+    height: null,
+    shielded: true,
+    blindingFactor: 'aa'.repeat(32),
+  });
+
+  // Default (no shielded filter) returns all including shielded
+  buf = [];
+  for await (const u of store.selectUtxos({})) {
+    buf.push(u);
+  }
+  expect(buf).toHaveLength(2); // tx01 (HTR) + tx03 (HTR shielded)
+
+  // shielded: true returns only shielded
+  buf = [];
+  for await (const u of store.selectUtxos({ shielded: true })) {
+    buf.push(u);
+  }
+  expect(buf).toHaveLength(1);
+  expect(buf[0].txId).toEqual('tx03');
+  expect(buf[0].shielded).toBe(true);
+
+  // shielded: false returns only transparent
+  buf = [];
+  for await (const u of store.selectUtxos({ shielded: false })) {
+    buf.push(u);
+  }
+  expect(buf).toHaveLength(1);
+  expect(buf[0].txId).toEqual('tx01');
+  expect(buf[0].shielded).toBeUndefined();
 });
 
 test('access data methods', async () => {

--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -114,6 +114,20 @@ test('addressIter chain-selection (legacy vs shielded)', async () => {
   expect(shieldedBases).toEqual(['shi-0', 'shi-1']);
 });
 
+test('addressIter shielded chain yields BIP32-index order even when saved out of order', async () => {
+  const store = new MemoryStore();
+  // Save shielded receive addresses with indices out of order to prove the
+  // iterator sorts by BIP32 index rather than relying on insertion order.
+  await store.saveAddress({ base58: 'shi-3', bip32AddressIndex: 3, addressType: 'shielded' });
+  await store.saveAddress({ base58: 'shi-0', bip32AddressIndex: 0, addressType: 'shielded' });
+  await store.saveAddress({ base58: 'shi-2', bip32AddressIndex: 2, addressType: 'shielded' });
+  await store.saveAddress({ base58: 'shi-1', bip32AddressIndex: 1, addressType: 'shielded' });
+
+  const bases: string[] = [];
+  for await (const info of store.addressIter({ legacy: false })) bases.push(info.base58);
+  expect(bases).toEqual(['shi-0', 'shi-1', 'shi-2', 'shi-3']);
+});
+
 test('history methods', async () => {
   const store = new MemoryStore();
   await store.saveAddress({ base58: 'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ', bip32AddressIndex: 0 });
@@ -360,7 +374,10 @@ test('utxo methods', async () => {
   }
   expect(buf).toHaveLength(1);
   expect(buf[0].txId).toEqual('tx01');
-  expect(buf[0].shielded).toBeUndefined();
+  // Assert the transparent classification (filter treats both `undefined` and
+  // `false` as transparent), not the exact stored representation — a store
+  // that normalized transparent UTXOs to `shielded: false` is still correct.
+  expect(buf[0].shielded).not.toBe(true);
 });
 
 test('access data methods', async () => {

--- a/__tests__/storage/memory_store.test.ts
+++ b/__tests__/storage/memory_store.test.ts
@@ -419,7 +419,7 @@ test('selectUtxos resolves a shielded filter_address to its spend P2PKH via ctMa
   expect(bySpend[0].txId).toEqual('txS');
 });
 
-test('addTx advances the shielded cursor from a shielded receive in tx.shielded_outputs', async () => {
+test('addTx advances the shielded cursor only for a DECODED owned shielded receive', async () => {
   const store = new MemoryStore();
   // Own a shielded-spend P2PKH at index 7 (the on-chain form of a shielded
   // receive). SEPARATED model: the receive lands in tx.shielded_outputs, NOT
@@ -432,6 +432,9 @@ test('addTx advances the shielded cursor from a shielded receive in tx.shielded_
   });
   expect(store.walletData.shieldedLastUsedAddressIndex).toEqual(-1);
 
+  // SECURITY: an UNDECODED shielded output (value undefined) that carries our
+  // spend P2PKH on the (untrusted) wire must NOT advance the cursor —
+  // decoded.address is not an ownership signal; only a decoded entry is ours.
   await store.saveTx({
     tx_id: 'a'.repeat(64),
     version: 1,
@@ -447,6 +450,31 @@ test('addTx advances the shielded cursor from a shielded receive in tx.shielded_
         script: 'cc',
         ephemeral_pubkey: 'dd',
         token_data: 0,
+        decoded: { address: 'spend-7' },
+      },
+    ],
+    parents: [],
+  } as unknown as IHistoryTx);
+  expect(store.walletData.shieldedLastUsedAddressIndex).toEqual(-1);
+
+  // A DECODED owned shielded receive (value written in place) DOES advance it.
+  await store.saveTx({
+    tx_id: 'b'.repeat(64),
+    version: 1,
+    weight: 1,
+    timestamp: 124,
+    is_voided: false,
+    inputs: [],
+    outputs: [],
+    shielded_outputs: [
+      {
+        commitment: 'aa',
+        range_proof: 'bb',
+        script: 'cc',
+        ephemeral_pubkey: 'dd',
+        token_data: 0,
+        value: 50n,
+        token: '00',
         decoded: { address: 'spend-7' },
       },
     ],

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -94,7 +94,7 @@ describe('handleStop', () => {
     await storage.registerNanoContract('abc', testNano);
     // We have 1 transaction
     await expect(store.historyCount()).resolves.toEqual(1);
-    // 20 addresses
+    // addressCount returns only legacy addresses (shielded/shielded-spend are filtered)
     await expect(store.addressCount()).resolves.toEqual(20);
     // And 1 registered token
     let tokens = await toArray(storage.getRegisteredTokens());
@@ -134,7 +134,7 @@ describe('handleStop', () => {
 
     // handleStop with cleanStorage = true
     await storage.handleStop({ cleanStorage: true });
-    // Will clean the history bit not addresses or registered tokens
+    // Will clean the history but not addresses or registered tokens
     await expect(store.historyCount()).resolves.toEqual(0);
     await expect(store.addressCount()).resolves.toEqual(20);
     await expect(store.isTokenRegistered(testToken.uid)).resolves.toBeTruthy();
@@ -177,7 +177,7 @@ describe('handleStop', () => {
     // handleStop with cleanAddresses = true
     await loadAddresses(0, 20, storage);
     await storage.handleStop({ cleanTokens: true });
-    // Will clean the history bit not addresses
+    // Will clean the tokens but not addresses
     await expect(store.historyCount()).resolves.toEqual(1);
     await expect(store.addressCount()).resolves.toEqual(20);
     await expect(store.isTokenRegistered(testToken.uid)).resolves.toBeFalsy();

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -714,6 +714,33 @@ describe('getChangeAddress', () => {
     await getChangeAddressTest(store);
   });
 
+  it('converts a wallet-owned shielded change address to its spend-derived P2PKH', async () => {
+    const { deriveShieldedAddress } = await import('../../src/utils/shieldedAddress');
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    storage.config.setNetwork('testnet');
+    const networkName = storage.config.getNetwork().name;
+
+    // A real 71-byte shielded address (encode validates on-curve pubkeys).
+    const scanXpubkey = new HDPrivateKey().xpubkey;
+    const spendXpubkey = new HDPrivateKey().xpubkey;
+    const info = deriveShieldedAddress(scanXpubkey, spendXpubkey, 0, networkName);
+
+    // Wallet owns the shielded address (saved during shielded derivation).
+    await store.saveAddress({
+      base58: info.base58,
+      bip32AddressIndex: 0,
+      addressType: 'shielded',
+    });
+
+    // A shielded address has no transparent output script form, so the change
+    // address must resolve to its on-chain spend-derived P2PKH (same pubkey
+    // hash) rather than be returned as-is or rejected.
+    await expect(storage.getChangeAddress({ changeAddress: info.base58 })).resolves.toEqual(
+      info.spendAddress
+    );
+  });
+
   async function getChangeAddressTest(store) {
     const storage = new Storage(store);
     const addr0 = 'WYiD1E8n5oB9weZ8NMyM3KoCjKf1KCjWAZ';

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -1180,3 +1180,70 @@ describe('getAddressPubkey', () => {
     await expect(storage.getAddressPubkey(20)).resolves.toEqual(publicKey20);
   });
 });
+
+describe('shielded key access (smoke)', () => {
+  const PIN = '1234';
+
+  async function shieldedWallet() {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const legacy = new HDPrivateKey();
+    const scan = new HDPrivateKey();
+    const spend = new HDPrivateKey();
+    await store.saveAccessData({
+      xpubkey: legacy.xpubkey,
+      mainKey: cryptoUtils.encryptData(legacy.xprivkey, PIN),
+      scanMainKey: cryptoUtils.encryptData(scan.xprivkey, PIN),
+      spendMainKey: cryptoUtils.encryptData(spend.xprivkey, PIN),
+      scanXpubkey: scan.xpubkey,
+      spendXpubkey: spend.xpubkey,
+      walletType: 'p2pkh' as const,
+      walletFlags: 0,
+    });
+    return { storage, scan, spend };
+  }
+
+  it('returns the scan/spend xpubs and decrypts the xprivs with the PIN', async () => {
+    const { storage, scan, spend } = await shieldedWallet();
+    await expect(storage.getScanXPubKey()).resolves.toEqual(scan.xpubkey);
+    await expect(storage.getSpendXPubKey()).resolves.toEqual(spend.xpubkey);
+    await expect(storage.getScanXPrivKey(PIN)).resolves.toEqual(scan.xprivkey);
+    await expect(storage.getSpendXPrivKey(PIN)).resolves.toEqual(spend.xprivkey);
+  });
+
+  it('throws cleanly when the wallet has no shielded keys', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const legacy = new HDPrivateKey();
+    await store.saveAccessData({
+      xpubkey: legacy.xpubkey,
+      mainKey: cryptoUtils.encryptData(legacy.xprivkey, PIN),
+      walletType: 'p2pkh' as const,
+      walletFlags: 0,
+    });
+    await expect(storage.getScanXPrivKey(PIN)).rejects.toThrow('Scan private key is not present');
+    await expect(storage.getSpendXPrivKey(PIN)).rejects.toThrow('Spend private key is not present');
+    // The xpub getters are non-throwing: pre-shielded wallets simply have none.
+    await expect(storage.getScanXPubKey()).resolves.toBeUndefined();
+    await expect(storage.getSpendXPubKey()).resolves.toBeUndefined();
+  });
+
+  it('rejects xpriv decryption with a wrong PIN', async () => {
+    const { storage } = await shieldedWallet();
+    await expect(storage.getScanXPrivKey('9999')).rejects.toThrow();
+    await expect(storage.getSpendXPrivKey('9999')).rejects.toThrow();
+  });
+
+  it('round-trips the shielded crypto provider field/setter', () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    expect(storage.shieldedCryptoProvider).toBeUndefined();
+    const provider = {
+      id: 'mock',
+    } as unknown as import('../../src/shielded/types').IShieldedCryptoProvider;
+    storage.setShieldedCryptoProvider(provider);
+    expect(storage.shieldedCryptoProvider).toBe(provider);
+    storage.setShieldedCryptoProvider(undefined);
+    expect(storage.shieldedCryptoProvider).toBeUndefined();
+  });
+});

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -714,7 +714,7 @@ describe('getChangeAddress', () => {
     await getChangeAddressTest(store);
   });
 
-  it('converts a wallet-owned shielded change address to its spend-derived P2PKH', async () => {
+  it('returns a wallet-owned shielded change address as-is (no eager script conversion)', async () => {
     const { deriveShieldedAddress } = await import('../../src/utils/shieldedAddress');
     const store = new MemoryStore();
     const storage = new Storage(store);
@@ -733,12 +733,15 @@ describe('getChangeAddress', () => {
       addressType: 'shielded',
     });
 
-    // A shielded address has no transparent output script form, so the change
-    // address must resolve to its on-chain spend-derived P2PKH (same pubkey
-    // hash) rather than be returned as-is or rejected.
+    // getChangeAddress is a storage-layer resolver: it returns the owned
+    // address verbatim, including the 71-byte shielded form. The
+    // shielded -> spend-derived-P2PKH rule for the output script is applied
+    // later by the transaction layer (createOutputScript /
+    // createOutputScriptFromAddress), not duplicated here.
     await expect(storage.getChangeAddress({ changeAddress: info.base58 })).resolves.toEqual(
-      info.spendAddress
+      info.base58
     );
+    expect(info.base58).not.toEqual(info.spendAddress);
   });
 
   async function getChangeAddressTest(store) {

--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -208,8 +208,6 @@ test('Get address from pubkey', async () => {
 });
 
 test('deriveShieldedAddressFromStorage returns null when shielded keys unavailable', async () => {
-  // HDPrivateKey comes from the top-level import (added by the pr-4 review
-  // tests); re-importing it here shadowed that declaration.
   const { deriveShieldedAddressFromStorage } = await import('../../src/utils/address');
   const { encryptData } = await import('../../src/utils/crypto');
   const store = new MemoryStore();

--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -257,20 +257,24 @@ test('deriveShieldedAddressFromStorage returns paired shielded + spend records',
   // Independent oracle: the same inputs through the pure derivation helper.
   const expected = deriveShieldedAddress(scanXpubkey, spendXpubkey, index, networkName);
 
-  // User-facing shielded receive record (71-byte encoded form).
+  // User-facing shielded receive record (71-byte encoded form). Its
+  // ctMappingAddress links to the paired on-chain spend P2PKH.
   expect(result!.shieldedAddress).toEqual({
     base58: expected.base58,
     bip32AddressIndex: index,
     publicKey: expected.scanPubkey,
     addressType: 'shielded',
+    ctMappingAddress: expected.spendAddress,
   });
 
-  // Internal on-chain spend-derived P2PKH record (HASH160(spend_pubkey)).
+  // Internal on-chain spend-derived P2PKH record (HASH160(spend_pubkey)). Its
+  // ctMappingAddress links back to the paired user-facing shielded address.
   expect(result!.spendAddress).toEqual({
     base58: expected.spendAddress,
     bip32AddressIndex: index,
     publicKey: expected.spendPubkey,
     addressType: 'shielded-spend',
+    ctMappingAddress: expected.base58,
   });
 
   // Both records share the BIP32 index; the spend address is the on-chain

--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -228,3 +228,54 @@ test('deriveShieldedAddressFromStorage returns null when shielded keys unavailab
   const result = await deriveShieldedAddressFromStorage(0, storage);
   expect(result).toBeNull();
 });
+
+test('deriveShieldedAddressFromStorage returns paired shielded + spend records', async () => {
+  const { deriveShieldedAddressFromStorage } = await import('../../src/utils/address');
+  const { deriveShieldedAddress } = await import('../../src/utils/shieldedAddress');
+  const { encryptData } = await import('../../src/utils/crypto');
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+  storage.config.setNetwork('testnet');
+  const networkName = storage.config.getNetwork().name;
+
+  // Independent scan and spend public chains (the wallet derives both from
+  // hardened accounts; for this test any two xpubs exercise the same path).
+  const xpriv = new HDPrivateKey();
+  const scanXpubkey = new HDPrivateKey().xpubkey;
+  const spendXpubkey = new HDPrivateKey().xpubkey;
+  await store.saveAccessData({
+    xpubkey: xpriv.xpubkey,
+    mainKey: encryptData(xpriv.xprivkey, '123'),
+    walletType: 'p2pkh' as const,
+    walletFlags: 0,
+    scanXpubkey,
+    spendXpubkey,
+  });
+
+  const index = 5;
+  const result = await deriveShieldedAddressFromStorage(index, storage);
+  expect(result).not.toBeNull();
+
+  // Independent oracle: the same inputs through the pure derivation helper.
+  const expected = deriveShieldedAddress(scanXpubkey, spendXpubkey, index, networkName);
+
+  // User-facing shielded receive record (71-byte encoded form).
+  expect(result!.shieldedAddress).toEqual({
+    base58: expected.base58,
+    bip32AddressIndex: index,
+    publicKey: expected.scanPubkey,
+    addressType: 'shielded',
+  });
+
+  // Internal on-chain spend-derived P2PKH record (HASH160(spend_pubkey)).
+  expect(result!.spendAddress).toEqual({
+    base58: expected.spendAddress,
+    bip32AddressIndex: index,
+    publicKey: expected.spendPubkey,
+    addressType: 'shielded-spend',
+  });
+
+  // Both records share the BIP32 index; the spend address is the on-chain
+  // P2PKH while the shielded address is the user-facing encoded form.
+  expect(result!.shieldedAddress.base58).not.toEqual(result!.spendAddress.base58);
+});

--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -206,3 +206,25 @@ test('Get address from pubkey', async () => {
   expect(address.base58).toBe(base58);
   expect(address.validateAddress()).toBeTruthy();
 });
+
+test('deriveShieldedAddressFromStorage returns null when shielded keys unavailable', async () => {
+  // HDPrivateKey comes from the top-level import (added by the pr-4 review
+  // tests); re-importing it here shadowed that declaration.
+  const { deriveShieldedAddressFromStorage } = await import('../../src/utils/address');
+  const { encryptData } = await import('../../src/utils/crypto');
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+
+  // Provide minimal access data WITHOUT shielded keys (legacy-only wallet)
+  const xpriv = new HDPrivateKey();
+  await store.saveAccessData({
+    xpubkey: xpriv.xpubkey,
+    mainKey: encryptData(xpriv.xprivkey, '123'),
+    walletType: 'p2pkh' as const,
+    walletFlags: 0,
+    // No scanXpubkey, no spendXpubkey — shielded keys absent
+  });
+
+  const result = await deriveShieldedAddressFromStorage(0, storage);
+  expect(result).toBeNull();
+});

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -241,19 +241,26 @@ export class MemoryStore implements IStore {
    */
   async *addressIter(opts: IAddressChainOptions = {}): AsyncGenerator<IAddressInfo, void, void> {
     const legacy = opts.legacy ?? true;
+    if (!legacy) {
+      // Shielded chain: walk shieldedAddressIndexes in ascending BIP32-index
+      // order. Sorting the keys keeps the documented order even if shielded
+      // addresses were saved or restored out of order (the index map, like
+      // any Map, otherwise reflects insertion order). The map holds only the
+      // user-facing 'shielded' receive entries — legacy addresses and the
+      // internal shielded-spend P2PKHs are excluded by saveAddress routing.
+      const indexes = [...this.shieldedAddressIndexes.keys()].sort((a, b) => a - b);
+      for (const index of indexes) {
+        const base58 = this.shieldedAddressIndexes.get(index)!;
+        yield this.addresses.get(base58)!;
+      }
+      return;
+    }
     for (const addrInfo of this.addresses.values()) {
-      if (legacy) {
-        // Legacy chain: skip shielded receive AND shielded-spend (the
-        // latter is the internal P2PKH the receive pipeline uses to
-        // match incoming shielded outputs — surfacing it under the
-        // legacy chain would leak an internal address).
-        if (addrInfo.addressType === 'shielded' || addrInfo.addressType === 'shielded-spend') {
-          continue;
-        }
-      } else if (addrInfo.addressType !== 'shielded') {
-        // Shielded chain: only the user-facing shielded receive entry
-        // (71-byte encoded form). Legacy entries and the internal
-        // shielded-spend P2PKHs are skipped.
+      // Legacy chain: skip shielded receive AND shielded-spend (the latter is
+      // the internal P2PKH the receive pipeline uses to match incoming
+      // shielded outputs — surfacing it under the legacy chain would leak an
+      // internal address).
+      if (addrInfo.addressType === 'shielded' || addrInfo.addressType === 'shielded-spend') {
         continue;
       }
       yield addrInfo;

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -220,43 +220,42 @@ export class MemoryStore implements IStore {
   /** ADDRESSES */
 
   /**
-   * Iterate on the wallet's addresses for one chain.
+   * The index→base58 map for the chain selected by `opts.legacy` (defaults
+   * `true`):
+   *   - legacy  → `addressIndexes`         (p2pkh / p2sh / undefined)
+   *   - !legacy → `shieldedAddressIndexes` (user-facing 'shielded' receives)
    *
-   * `opts.legacy` defaults to `true` and selects which chain to walk:
-   *   - `true`  → p2pkh / p2sh / undefined (the user-facing legacy
-   *               chain). `shielded` and `shielded-spend` entries are
-   *               filtered out — they're internal to the receive
-   *               pipeline and surfacing them under the legacy chain
-   *               would leak the spend-derived P2PKH the wallet uses
-   *               to match incoming shielded outputs.
-   *   - `false` → user-facing shielded receive addresses (the 71-byte
-   *               encoded form). The internal `shielded-spend` entries are
-   *               still excluded — callers consuming this iterator (e.g. a
-   *               wallet's `/addresses` API) want the user-facing shape, not
-   *               the spend P2PKHs.
+   * `saveAddress` is the sole writer of both maps and routes by address type:
+   * 'shielded' into `shieldedAddressIndexes`, legacy into `addressIndexes`, and
+   * 'shielded-spend' into NEITHER. That last exclusion is deliberate and
+   * security-relevant — 'shielded-spend' is the internal spend-derived P2PKH the
+   * receive pipeline uses to match incoming shielded outputs, and surfacing it
+   * to callers (e.g. a wallet's `/addresses` API) would leak an internal
+   * address. Because it lives in neither map, every read path that goes through
+   * this helper (addressIter, addressCount, getAddressAtIndex) excludes it
+   * automatically — the partition is defined once, here + in `saveAddress`.
+   */
+  private chainIndexMap(opts?: IAddressChainOptions): Map<number, string> {
+    const legacy = opts?.legacy ?? true;
+    return legacy ? this.addressIndexes : this.shieldedAddressIndexes;
+  }
+
+  /**
+   * Iterate the wallet's addresses for one chain (`opts.legacy` defaults
+   * `true`), backed by that chain's index map (see `chainIndexMap`).
    *
-   * Both chains yield in insertion order, which equals BIP32-index order
-   * because addresses are saved sequentially per index by `loadAddresses` —
-   * the same ordering the legacy chain has always relied on.
+   * Yields in the index map's insertion order, which equals BIP32-index order
+   * for everything `loadAddresses` derives (it saves sequentially per index).
+   * The legacy chain additionally inherits whatever order the stream sync
+   * delivers in — the same ordering the legacy chain has always relied on, and
+   * identical to iterating `this.addresses` directly, since both are written in
+   * lockstep by `saveAddress`.
    *
    * @returns {AsyncGenerator<IAddressInfo>}
    */
   async *addressIter(opts: IAddressChainOptions = {}): AsyncGenerator<IAddressInfo, void, void> {
-    const legacy = opts.legacy ?? true;
-    for (const addrInfo of this.addresses.values()) {
-      if (legacy) {
-        // Legacy chain: skip shielded receive AND shielded-spend (the latter
-        // is the internal P2PKH the receive pipeline uses to match incoming
-        // shielded outputs — surfacing it under the legacy chain would leak
-        // an internal address).
-        if (addrInfo.addressType === 'shielded' || addrInfo.addressType === 'shielded-spend') {
-          continue;
-        }
-      } else if (addrInfo.addressType !== 'shielded') {
-        // Shielded chain: only the user-facing 'shielded' receive entry.
-        continue;
-      }
-      yield addrInfo;
+    for (const base58 of this.chainIndexMap(opts).values()) {
+      yield this.addresses.get(base58) as IAddressInfo;
     }
   }
 
@@ -294,19 +293,15 @@ export class MemoryStore implements IStore {
   }
 
   /**
-   * Count the number of addresses in storage for one chain.
-   *
-   * `opts.legacy` defaults to `true`. Each index map holds exactly its chain's
-   * addresses — `saveAddress` routes `shielded` into `shieldedAddressIndexes`,
-   * legacy (p2pkh/p2sh/undefined) into `addressIndexes`, and `shielded-spend`
-   * into neither (it's an internal P2PKH, not a counted chain address) — so
-   * the map size is the per-chain count in O(1).
+   * Count the number of addresses in storage for one chain (`opts.legacy`
+   * defaults `true`). The chain's index map holds exactly its addresses (see
+   * `chainIndexMap`), so its size is the per-chain count in O(1).
    *
    * @async
    * @returns {Promise<number>} A promise with the number of addresses
    */
   async addressCount(opts?: IAddressChainOptions): Promise<number> {
-    return opts?.legacy === false ? this.shieldedAddressIndexes.size : this.addressIndexes.size;
+    return this.chainIndexMap(opts).size;
   }
 
   /**
@@ -319,9 +314,7 @@ export class MemoryStore implements IStore {
     index: number,
     opts?: IAddressChainOptions
   ): Promise<IAddressInfo | null> {
-    const isLegacy = opts?.legacy !== false;
-    const indexMap = isLegacy ? this.addressIndexes : this.shieldedAddressIndexes;
-    const addr = indexMap.get(index);
+    const addr = this.chainIndexMap(opts).get(index);
     if (addr === undefined) {
       // We do not have this index loaded on storage, it should be generated instead
       return null;

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -763,27 +763,18 @@ export class MemoryStore implements IStore {
     let utxoNum = 0;
 
     // Resolve filter_address to its on-chain form. UTXOs always carry the
-    // address that actually labels the on-chain output — for shielded
-    // outputs that's the spend-derived P2PKH (`addressType:
-    // 'shielded-spend'`), not the user-facing 71-byte encoded shielded
-    // address. So if the caller passed the user-facing shielded form,
-    // swap to the matching spend P2PKH at the same BIP32 index before
-    // comparing against utxo.address. Without this swap the filter would
-    // never match a shielded UTXO when a shielded receive address was
-    // passed.
+    // address that actually labels the on-chain output — for shielded outputs
+    // that's the spend-derived P2PKH (`addressType: 'shielded-spend'`), not the
+    // user-facing 71-byte encoded shielded address. So if the caller passed the
+    // user-facing shielded form, swap to its paired spend P2PKH before comparing
+    // against utxo.address. The pairing is stored on the address record
+    // (`ctMappingAddress`, set at derivation), so this is an O(1) lookup — no
+    // scan over all addresses, no parallel index map.
     let effectiveFilterAddress = options.filter_address;
     if (effectiveFilterAddress) {
       const info = this.addresses.get(effectiveFilterAddress);
-      if (info?.addressType === 'shielded') {
-        for (const candidate of this.addresses.values()) {
-          if (
-            candidate.addressType === 'shielded-spend' &&
-            candidate.bip32AddressIndex === info.bip32AddressIndex
-          ) {
-            effectiveFilterAddress = candidate.base58;
-            break;
-          }
-        }
+      if (info?.addressType === 'shielded' && info.ctMappingAddress) {
+        effectiveFilterAddress = info.ctMappingAddress;
       }
     }
 

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -399,7 +399,6 @@ export class MemoryStore implements IStore {
       ? this.walletData.currentAddressIndex
       : this.walletData.shieldedCurrentAddressIndex;
 
-    // Reuse the chain-aware index lookup instead of duplicating it.
     const addressInfo = await this.getAddressAtIndex(currentIndex, opts);
     if (!addressInfo) {
       const chain = isLegacy ? 'legacy' : 'shielded';

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -25,6 +25,8 @@ import {
   SCANNING_POLICY,
   INcData,
   TokenVersion,
+  IAddressChainOptions,
+  IUtxoId,
 } from '../types';
 import { GAP_LIMIT, NATIVE_TOKEN_UID } from '../constants';
 import transactionUtils from '../utils/transaction';
@@ -33,6 +35,9 @@ const DEFAULT_ADDRESSES_WALLET_DATA = {
   lastLoadedAddressIndex: 0,
   lastUsedAddressIndex: -1,
   currentAddressIndex: -1,
+  shieldedLastLoadedAddressIndex: 0,
+  shieldedLastUsedAddressIndex: -1,
+  shieldedCurrentAddressIndex: -1,
 };
 
 const DEFAULT_SCAN_POLICY_DATA: AddressScanPolicyData = {
@@ -97,8 +102,15 @@ export class MemoryStore implements IStore {
   /**
    * Map<index, base58>
    * where index is the address index and base58 is the address in base58
+   * Tracks legacy (P2PKH/P2SH) addresses.
    */
   addressIndexes: Map<number, string>;
+
+  /**
+   * Map<index, base58>
+   * Tracks shielded (user-facing) addresses by BIP32 index.
+   */
+  shieldedAddressIndexes: Map<number, string>;
 
   /**
    * Map<base58, IAddressMetadata>
@@ -176,6 +188,7 @@ export class MemoryStore implements IStore {
   constructor() {
     this.addresses = new Map<string, IAddressInfo>();
     this.addressIndexes = new Map<number, string>();
+    this.shieldedAddressIndexes = new Map<number, string>();
     this.addressesMetadata = new Map<string, IAddressMetadata>();
     this.seqnumMetadata = new Map<string, number>();
     this.tokens = new Map<string, ITokenData>();
@@ -207,13 +220,42 @@ export class MemoryStore implements IStore {
   /** ADDRESSES */
 
   /**
-   * Iterate on all addresses
+   * Iterate on the wallet's addresses for one chain.
    *
-   * @async
+   * `opts.legacy` defaults to `true` and selects which chain to walk:
+   *   - `true`  → p2pkh / p2sh / undefined (the user-facing legacy
+   *               chain). `shielded` and `shielded-spend` entries are
+   *               filtered out — they're internal to the receive
+   *               pipeline and surfacing them under the legacy chain
+   *               would leak the spend-derived P2PKH the wallet uses
+   *               to match incoming shielded outputs.
+   *   - `false` → user-facing shielded receive addresses (the 71-byte
+   *               encoded form), enumerated by walking
+   *               `shieldedAddressIndexes` in BIP32-index order. The
+   *               internal `shielded-spend` entries are still
+   *               excluded — callers consuming this iterator (e.g. a
+   *               wallet's `/addresses` API) want the user-facing
+   *               shape, not the spend P2PKHs.
+   *
    * @returns {AsyncGenerator<IAddressInfo>}
    */
-  async *addressIter(): AsyncGenerator<IAddressInfo, void, void> {
+  async *addressIter(opts: IAddressChainOptions = {}): AsyncGenerator<IAddressInfo, void, void> {
+    const legacy = opts.legacy ?? true;
     for (const addrInfo of this.addresses.values()) {
+      if (legacy) {
+        // Legacy chain: skip shielded receive AND shielded-spend (the
+        // latter is the internal P2PKH the receive pipeline uses to
+        // match incoming shielded outputs — surfacing it under the
+        // legacy chain would leak an internal address).
+        if (addrInfo.addressType === 'shielded' || addrInfo.addressType === 'shielded-spend') {
+          continue;
+        }
+      } else if (addrInfo.addressType !== 'shielded') {
+        // Shielded chain: only the user-facing shielded receive entry
+        // (71-byte encoded form). Legacy entries and the internal
+        // shielded-spend P2PKHs are skipped.
+        continue;
+      }
       yield addrInfo;
     }
   }
@@ -257,7 +299,13 @@ export class MemoryStore implements IStore {
    * @returns {Promise<number>} A promise with the number of addresses
    */
   async addressCount(): Promise<number> {
-    return this.addresses.size;
+    let count = 0;
+    for (const addrInfo of this.addresses.values()) {
+      if (addrInfo.addressType !== 'shielded' && addrInfo.addressType !== 'shielded-spend') {
+        count++;
+      }
+    }
+    return count;
   }
 
   /**
@@ -266,8 +314,13 @@ export class MemoryStore implements IStore {
    * @async
    * @returns {Promise<IAddressInfo | null>} The address info or null if not in storage
    */
-  async getAddressAtIndex(index: number): Promise<IAddressInfo | null> {
-    const addr = this.addressIndexes.get(index);
+  async getAddressAtIndex(
+    index: number,
+    opts?: IAddressChainOptions
+  ): Promise<IAddressInfo | null> {
+    const isLegacy = opts?.legacy !== false;
+    const indexMap = isLegacy ? this.addressIndexes : this.shieldedAddressIndexes;
+    const addr = indexMap.get(index);
     if (addr === undefined) {
       // We do not have this index loaded on storage, it should be generated instead
       return null;
@@ -291,14 +344,34 @@ export class MemoryStore implements IStore {
 
     // Saving address info
     this.addresses.set(info.base58, info);
-    this.addressIndexes.set(info.bip32AddressIndex, info.base58);
 
-    if (this.walletData.currentAddressIndex === -1) {
-      await this.setCurrentAddressIndex(info.bip32AddressIndex);
+    // Route to the correct index map based on address type.
+    // Each BIP32 index can have up to 3 addresses: legacy, shielded, and shielded-spend.
+    if (info.addressType === 'shielded') {
+      this.shieldedAddressIndexes.set(info.bip32AddressIndex, info.base58);
+    } else if (info.addressType !== 'shielded-spend') {
+      // Legacy P2PKH/P2SH (addressType undefined, 'p2pkh', or 'p2sh')
+      this.addressIndexes.set(info.bip32AddressIndex, info.base58);
     }
 
-    if (info.bip32AddressIndex > this.walletData.lastLoadedAddressIndex) {
-      this.walletData.lastLoadedAddressIndex = info.bip32AddressIndex;
+    // Update per-chain tracking: currentAddressIndex and lastLoadedAddressIndex.
+    // Only the 'shielded' type (not 'shielded-spend') advances the cursor, since
+    // getCurrentAddress looks up shieldedAddressIndexes which only contains 'shielded' entries.
+    if (info.addressType === 'shielded') {
+      if (this.walletData.shieldedCurrentAddressIndex === -1) {
+        await this.setCurrentAddressIndex(info.bip32AddressIndex, { legacy: false });
+      }
+      if (info.bip32AddressIndex > this.walletData.shieldedLastLoadedAddressIndex) {
+        this.walletData.shieldedLastLoadedAddressIndex = info.bip32AddressIndex;
+      }
+    } else if (info.addressType !== 'shielded-spend') {
+      // Legacy P2PKH/P2SH only — shielded-spend does not track its own cursor
+      if (this.walletData.currentAddressIndex === -1) {
+        await this.setCurrentAddressIndex(info.bip32AddressIndex);
+      }
+      if (info.bip32AddressIndex > this.walletData.lastLoadedAddressIndex) {
+        this.walletData.lastLoadedAddressIndex = info.bip32AddressIndex;
+      }
     }
   }
 
@@ -319,30 +392,46 @@ export class MemoryStore implements IStore {
    * @async
    * @returns {Promise<string>} The address in base58 format
    */
-  async getCurrentAddress(markAsUsed?: boolean): Promise<string> {
-    const addressInfo = await this.getAddressAtIndex(this.walletData.currentAddressIndex);
-    if (!addressInfo) {
-      throw new Error('Current address is not loaded');
+  async getCurrentAddress(markAsUsed?: boolean, opts?: IAddressChainOptions): Promise<string> {
+    const isLegacy = opts?.legacy !== false;
+
+    const currentIndex = isLegacy
+      ? this.walletData.currentAddressIndex
+      : this.walletData.shieldedCurrentAddressIndex;
+    const lastLoaded = isLegacy
+      ? this.walletData.lastLoadedAddressIndex
+      : this.walletData.shieldedLastLoadedAddressIndex;
+    const indexMap = isLegacy ? this.addressIndexes : this.shieldedAddressIndexes;
+
+    const base58 = indexMap.get(currentIndex);
+    if (!base58) {
+      const chain = isLegacy ? 'legacy' : 'shielded';
+      throw new Error(
+        `Current ${chain} address is not loaded (index=${currentIndex}). ` +
+          `Derive at least one ${chain} address before calling getCurrentAddress.`
+      );
     }
 
     if (markAsUsed) {
-      // Will move the address index only if we have not reached the gap limit
-      await this.setCurrentAddressIndex(
-        Math.min(this.walletData.lastLoadedAddressIndex, this.walletData.currentAddressIndex + 1)
-      );
+      const nextIndex = Math.min(lastLoaded, currentIndex + 1);
+      await this.setCurrentAddressIndex(nextIndex, opts);
     }
-    return addressInfo.base58;
+    return base58;
   }
 
   /**
    * Set the value of the current address index.
    * @param {number} index The index to set
    */
-  async setCurrentAddressIndex(index: number): Promise<void> {
+  async setCurrentAddressIndex(index: number, opts?: IAddressChainOptions): Promise<void> {
     if (this.walletData.scanPolicyData?.policy === SCANNING_POLICY.SINGLE_ADDRESS && index > 0) {
       return;
     }
-    this.walletData.currentAddressIndex = index;
+    if (opts?.legacy === false) {
+      this.walletData.shieldedCurrentAddressIndex = index;
+    } else {
+      this.walletData.currentAddressIndex = index;
+    }
   }
 
   /**
@@ -375,12 +464,21 @@ export class MemoryStore implements IStore {
    * @async
    * @returns {AsyncGenerator<IHistoryTx>}
    */
-  async *historyIter(tokenUid?: string | undefined): AsyncGenerator<IHistoryTx> {
+  async *historyIter(
+    tokenUid?: string | undefined,
+    options: { order?: 'asc' | 'desc' } = {}
+  ): AsyncGenerator<IHistoryTx> {
     /**
-     * We iterate in reverse order so the most recent transactions are yielded first.
-     * This is to maintain the behavior in the wallets and allow the user to see the most recent transactions first.
+     * Default `desc` walks `historyTs` from the newest entry back to the
+     * oldest — this is what the wallet UI consumes (most-recent-first).
+     * Pass `order: 'asc'` for the chronological replay used by
+     * `processHistory`, where a tx spending a previous tx's UTXO needs
+     * the parent already saved when its own input loop runs.
      */
-    for (let i = this.historyTs.length - 1; i >= 0; i -= 1) {
+    const order = options.order ?? 'desc';
+    const len = this.historyTs.length;
+    for (let n = 0; n < len; n += 1) {
+      const i = order === 'asc' ? n : len - 1 - n;
       const orderKey = this.historyTs[i];
       const { txId } = getPartsFromOrderingKey(orderKey);
       const tx = this.history.get(txId);
@@ -398,7 +496,7 @@ export class MemoryStore implements IStore {
       let found = false;
       for (const input of tx.inputs) {
         if (
-          input.decoded.address &&
+          input.decoded?.address &&
           this.addresses.has(input.decoded.address) &&
           input.token === tokenUid
         ) {
@@ -456,21 +554,38 @@ export class MemoryStore implements IStore {
 
     this.history.set(tx.tx_id, tx);
 
-    let maxIndex = this.walletData.lastUsedAddressIndex;
+    let legacyMaxIndex = this.walletData.lastUsedAddressIndex;
+    let shieldedMaxIndex = this.walletData.shieldedLastUsedAddressIndex;
     for (const el of [...tx.inputs, ...tx.outputs]) {
-      if (el.decoded.address && (await this.addressExists(el.decoded.address))) {
-        const index = this.addresses.get(el.decoded.address)!.bip32AddressIndex;
-        if (index > maxIndex) {
-          maxIndex = index;
+      if (el.decoded?.address && (await this.addressExists(el.decoded.address))) {
+        const addrInfo = this.addresses.get(el.decoded.address)!;
+        const index = addrInfo.bip32AddressIndex;
+        if (addrInfo.addressType === 'shielded-spend') {
+          if (index > shieldedMaxIndex) shieldedMaxIndex = index;
+        } else if (
+          !addrInfo.addressType ||
+          addrInfo.addressType === 'p2pkh' ||
+          addrInfo.addressType === 'p2sh'
+        ) {
+          if (index > legacyMaxIndex) legacyMaxIndex = index;
         }
       }
     }
-    if (this.walletData.currentAddressIndex < maxIndex) {
+    // Update legacy chain tracking
+    if (this.walletData.currentAddressIndex < legacyMaxIndex) {
       await this.setCurrentAddressIndex(
-        Math.min(maxIndex + 1, this.walletData.lastLoadedAddressIndex)
+        Math.min(legacyMaxIndex + 1, this.walletData.lastLoadedAddressIndex)
       );
     }
-    this.walletData.lastUsedAddressIndex = maxIndex;
+    this.walletData.lastUsedAddressIndex = legacyMaxIndex;
+    // Update shielded chain tracking
+    if (this.walletData.shieldedCurrentAddressIndex < shieldedMaxIndex) {
+      await this.setCurrentAddressIndex(
+        Math.min(shieldedMaxIndex + 1, this.walletData.shieldedLastLoadedAddressIndex),
+        { legacy: false }
+      );
+    }
+    this.walletData.shieldedLastUsedAddressIndex = shieldedMaxIndex;
   }
 
   /**
@@ -656,6 +771,31 @@ export class MemoryStore implements IStore {
     let sumAmount = 0n;
     let utxoNum = 0;
 
+    // Resolve filter_address to its on-chain form. UTXOs always carry the
+    // address that actually labels the on-chain output — for shielded
+    // outputs that's the spend-derived P2PKH (`addressType:
+    // 'shielded-spend'`), not the user-facing 71-byte encoded shielded
+    // address. So if the caller passed the user-facing shielded form,
+    // swap to the matching spend P2PKH at the same BIP32 index before
+    // comparing against utxo.address. Without this swap the filter would
+    // never match a shielded UTXO when a shielded receive address was
+    // passed.
+    let effectiveFilterAddress = options.filter_address;
+    if (effectiveFilterAddress) {
+      const info = this.addresses.get(effectiveFilterAddress);
+      if (info?.addressType === 'shielded') {
+        for (const candidate of this.addresses.values()) {
+          if (
+            candidate.addressType === 'shielded-spend' &&
+            candidate.bip32AddressIndex === info.bip32AddressIndex
+          ) {
+            effectiveFilterAddress = candidate.base58;
+            break;
+          }
+        }
+      }
+    }
+
     // Map.prototype.values() is an iterable but orderBy returns an array
     // Both work with for...of so we can use them interchangeably
     let iter: IterableIterator<IUtxo> | IUtxo[];
@@ -681,7 +821,9 @@ export class MemoryStore implements IStore {
         (options.filter_method && !options.filter_method(utxo)) ||
         (options.amount_bigger_than && utxo.value <= options.amount_bigger_than) ||
         (options.amount_smaller_than && utxo.value >= options.amount_smaller_than) ||
-        (options.filter_address && utxo.address !== options.filter_address) ||
+        (effectiveFilterAddress && utxo.address !== effectiveFilterAddress) ||
+        (options.shielded === true && !utxo.shielded) ||
+        (options.shielded === false && !!utxo.shielded) ||
         !authority_match ||
         utxo.token !== token
       ) {
@@ -721,6 +863,10 @@ export class MemoryStore implements IStore {
    */
   async saveUtxo(utxo: IUtxo): Promise<void> {
     this.utxos.set(`${utxo.txId}:${utxo.index}`, utxo);
+  }
+
+  async getUtxo(utxoId: IUtxoId): Promise<IUtxo | null> {
+    return this.utxos.get(`${utxoId.txId}:${utxoId.index}`) ?? null;
   }
 
   /**
@@ -781,7 +927,10 @@ export class MemoryStore implements IStore {
    * @async
    * @returns {Promise<number>}
    */
-  async getLastLoadedAddressIndex(): Promise<number> {
+  async getLastLoadedAddressIndex(opts?: IAddressChainOptions): Promise<number> {
+    if (opts?.legacy === false) {
+      return this.walletData.shieldedLastLoadedAddressIndex;
+    }
     return this.walletData.lastLoadedAddressIndex;
   }
 
@@ -790,7 +939,10 @@ export class MemoryStore implements IStore {
    * @async
    * @returns {Promise<number>}
    */
-  async getLastUsedAddressIndex(): Promise<number> {
+  async getLastUsedAddressIndex(opts?: IAddressChainOptions): Promise<number> {
+    if (opts?.legacy === false) {
+      return this.walletData.shieldedLastUsedAddressIndex;
+    }
     return this.walletData.lastUsedAddressIndex;
   }
 
@@ -807,8 +959,12 @@ export class MemoryStore implements IStore {
    * Set the last bip32 address index used on storage.
    * @param {number} index The index to set as last used address.
    */
-  async setLastUsedAddressIndex(index: number): Promise<void> {
-    this.walletData.lastUsedAddressIndex = index;
+  async setLastUsedAddressIndex(index: number, opts?: IAddressChainOptions): Promise<void> {
+    if (opts?.legacy === false) {
+      this.walletData.shieldedLastUsedAddressIndex = index;
+    } else {
+      this.walletData.lastUsedAddressIndex = index;
+    }
   }
 
   /**
@@ -941,6 +1097,7 @@ export class MemoryStore implements IStore {
     if (cleanAddresses) {
       this.addresses = new Map<string, IAddressInfo>();
       this.addressIndexes = new Map<number, string>();
+      this.shieldedAddressIndexes = new Map<number, string>();
       this.addressesMetadata = new Map<string, IAddressMetadata>();
       this.seqnumMetadata = new Map<string, number>();
       this.walletData = { ...this.walletData, ...DEFAULT_ADDRESSES_WALLET_DATA };

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -552,14 +552,22 @@ export class MemoryStore implements IStore {
     // chain cursor — each owned shielded output's `decoded.address` is our
     // 'shielded-spend' P2PKH. Without this, shieldedLastUsedAddressIndex never
     // moves on receives and the shielded gap-limit fails to extend, so funds on
-    // higher shielded indices would be missed. (Shielded outputs we don't own
-    // carry a foreign address and are skipped by the addressExists check.)
+    // higher shielded indices would be missed.
     for (const el of [...tx.inputs, ...tx.outputs, ...(tx.shielded_outputs ?? [])]) {
       if (el.decoded?.address && (await this.addressExists(el.decoded.address))) {
         const addrInfo = this.addresses.get(el.decoded.address)!;
         const index = addrInfo.bip32AddressIndex;
         if (addrInfo.addressType === 'shielded-spend') {
-          if (index > shieldedMaxIndex) shieldedMaxIndex = index;
+          // Gate on the SEPARATED ownership marker (value !== undefined), same
+          // as every other shielded consumer. `decoded.address` is UNTRUSTED
+          // wire data — the fullnode emits it even for outputs we cannot
+          // decrypt — so advancing the cursor off a non-decoded entry would let
+          // a crafted tx claiming our spend P2PKH push the gap cursor. Decode-
+          // verified advancement on first receipt is handled by processNewTx;
+          // here we only honor entries already decoded as ours (value set).
+          if ((el as { value?: unknown }).value !== undefined && index > shieldedMaxIndex) {
+            shieldedMaxIndex = index;
+          }
         } else if (
           !addrInfo.addressType ||
           addrInfo.addressType === 'p2pkh' ||

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -230,37 +230,30 @@ export class MemoryStore implements IStore {
    *               would leak the spend-derived P2PKH the wallet uses
    *               to match incoming shielded outputs.
    *   - `false` → user-facing shielded receive addresses (the 71-byte
-   *               encoded form), enumerated by walking
-   *               `shieldedAddressIndexes` in BIP32-index order. The
-   *               internal `shielded-spend` entries are still
-   *               excluded — callers consuming this iterator (e.g. a
-   *               wallet's `/addresses` API) want the user-facing
-   *               shape, not the spend P2PKHs.
+   *               encoded form). The internal `shielded-spend` entries are
+   *               still excluded — callers consuming this iterator (e.g. a
+   *               wallet's `/addresses` API) want the user-facing shape, not
+   *               the spend P2PKHs.
+   *
+   * Both chains yield in insertion order, which equals BIP32-index order
+   * because addresses are saved sequentially per index by `loadAddresses` —
+   * the same ordering the legacy chain has always relied on.
    *
    * @returns {AsyncGenerator<IAddressInfo>}
    */
   async *addressIter(opts: IAddressChainOptions = {}): AsyncGenerator<IAddressInfo, void, void> {
     const legacy = opts.legacy ?? true;
-    if (!legacy) {
-      // Shielded chain: walk shieldedAddressIndexes in ascending BIP32-index
-      // order. Sorting the keys keeps the documented order even if shielded
-      // addresses were saved or restored out of order (the index map, like
-      // any Map, otherwise reflects insertion order). The map holds only the
-      // user-facing 'shielded' receive entries — legacy addresses and the
-      // internal shielded-spend P2PKHs are excluded by saveAddress routing.
-      const indexes = [...this.shieldedAddressIndexes.keys()].sort((a, b) => a - b);
-      for (const index of indexes) {
-        const base58 = this.shieldedAddressIndexes.get(index)!;
-        yield this.addresses.get(base58)!;
-      }
-      return;
-    }
     for (const addrInfo of this.addresses.values()) {
-      // Legacy chain: skip shielded receive AND shielded-spend (the latter is
-      // the internal P2PKH the receive pipeline uses to match incoming
-      // shielded outputs — surfacing it under the legacy chain would leak an
-      // internal address).
-      if (addrInfo.addressType === 'shielded' || addrInfo.addressType === 'shielded-spend') {
+      if (legacy) {
+        // Legacy chain: skip shielded receive AND shielded-spend (the latter
+        // is the internal P2PKH the receive pipeline uses to match incoming
+        // shielded outputs — surfacing it under the legacy chain would leak
+        // an internal address).
+        if (addrInfo.addressType === 'shielded' || addrInfo.addressType === 'shielded-spend') {
+          continue;
+        }
+      } else if (addrInfo.addressType !== 'shielded') {
+        // Shielded chain: only the user-facing 'shielded' receive entry.
         continue;
       }
       yield addrInfo;
@@ -301,18 +294,19 @@ export class MemoryStore implements IStore {
   }
 
   /**
-   * Count the number of addresses in storage.
+   * Count the number of addresses in storage for one chain.
+   *
+   * `opts.legacy` defaults to `true`. Each index map holds exactly its chain's
+   * addresses — `saveAddress` routes `shielded` into `shieldedAddressIndexes`,
+   * legacy (p2pkh/p2sh/undefined) into `addressIndexes`, and `shielded-spend`
+   * into neither (it's an internal P2PKH, not a counted chain address) — so
+   * the map size is the per-chain count in O(1).
+   *
    * @async
    * @returns {Promise<number>} A promise with the number of addresses
    */
-  async addressCount(): Promise<number> {
-    let count = 0;
-    for (const addrInfo of this.addresses.values()) {
-      if (addrInfo.addressType !== 'shielded' && addrInfo.addressType !== 'shielded-spend') {
-        count++;
-      }
-    }
-    return count;
+  async addressCount(opts?: IAddressChainOptions): Promise<number> {
+    return opts?.legacy === false ? this.shieldedAddressIndexes.size : this.addressIndexes.size;
   }
 
   /**
@@ -401,17 +395,13 @@ export class MemoryStore implements IStore {
    */
   async getCurrentAddress(markAsUsed?: boolean, opts?: IAddressChainOptions): Promise<string> {
     const isLegacy = opts?.legacy !== false;
-
     const currentIndex = isLegacy
       ? this.walletData.currentAddressIndex
       : this.walletData.shieldedCurrentAddressIndex;
-    const lastLoaded = isLegacy
-      ? this.walletData.lastLoadedAddressIndex
-      : this.walletData.shieldedLastLoadedAddressIndex;
-    const indexMap = isLegacy ? this.addressIndexes : this.shieldedAddressIndexes;
 
-    const base58 = indexMap.get(currentIndex);
-    if (!base58) {
+    // Reuse the chain-aware index lookup instead of duplicating it.
+    const addressInfo = await this.getAddressAtIndex(currentIndex, opts);
+    if (!addressInfo) {
       const chain = isLegacy ? 'legacy' : 'shielded';
       throw new Error(
         `Current ${chain} address is not loaded (index=${currentIndex}). ` +
@@ -420,10 +410,12 @@ export class MemoryStore implements IStore {
     }
 
     if (markAsUsed) {
-      const nextIndex = Math.min(lastLoaded, currentIndex + 1);
-      await this.setCurrentAddressIndex(nextIndex, opts);
+      const lastLoaded = isLegacy
+        ? this.walletData.lastLoadedAddressIndex
+        : this.walletData.shieldedLastLoadedAddressIndex;
+      await this.setCurrentAddressIndex(Math.min(lastLoaded, currentIndex + 1), opts);
     }
-    return base58;
+    return addressInfo.base58;
   }
 
   /**

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -547,7 +547,14 @@ export class MemoryStore implements IStore {
 
     let legacyMaxIndex = this.walletData.lastUsedAddressIndex;
     let shieldedMaxIndex = this.walletData.shieldedLastUsedAddressIndex;
-    for (const el of [...tx.inputs, ...tx.outputs]) {
+    // SEPARATED model: shielded outputs live in `tx.shielded_outputs`, not
+    // `tx.outputs`. Include them so a shielded RECEIVE advances the shielded
+    // chain cursor — each owned shielded output's `decoded.address` is our
+    // 'shielded-spend' P2PKH. Without this, shieldedLastUsedAddressIndex never
+    // moves on receives and the shielded gap-limit fails to extend, so funds on
+    // higher shielded indices would be missed. (Shielded outputs we don't own
+    // carry a foreign address and are skipped by the addressExists check.)
+    for (const el of [...tx.inputs, ...tx.outputs, ...(tx.shielded_outputs ?? [])]) {
       if (el.decoded?.address && (await this.addressExists(el.decoded.address))) {
         const addrInfo = this.addresses.get(el.decoded.address)!;
         const index = addrInfo.bip32AddressIndex;

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -6,6 +6,7 @@
  */
 
 import { HDPublicKey } from 'bitcore-lib';
+import Address from '../models/address';
 import Input from '../models/input';
 import {
   ApiVersion,
@@ -40,7 +41,9 @@ import {
   getDefaultLogger,
   AuthorityType,
   TokenVersion,
+  IAddressChainOptions,
 } from '../types';
+import type { IShieldedCryptoProvider } from '../shielded/types';
 import transactionUtils from '../utils/transaction';
 import {
   processHistory as processHistoryUtil,
@@ -79,6 +82,8 @@ export class Storage implements IStorage {
 
   txSignFunc: EcdsaTxSign | null;
 
+  shieldedCryptoProvider?: IShieldedCryptoProvider;
+
   /**
    * This promise is used to chain the calls to process unlocked utxos.
    * This way we can avoid concurrent calls.
@@ -98,6 +103,7 @@ export class Storage implements IStorage {
     this.version = null;
     this.utxoUnlockWait = Promise.resolve();
     this.txSignFunc = null;
+    this.shieldedCryptoProvider = undefined;
     this.logger = getDefaultLogger();
   }
 
@@ -168,6 +174,14 @@ export class Storage implements IStorage {
   }
 
   /**
+   * Set the shielded crypto provider for confidential transaction support.
+   * @param provider The crypto provider, or undefined to clear it
+   */
+  setShieldedCryptoProvider(provider?: IShieldedCryptoProvider): void {
+    this.shieldedCryptoProvider = provider;
+  }
+
+  /**
    * Sign the transaction
    * @param {Transaction} tx The transaction to sign
    * @param {string} pinCode The pin code
@@ -193,14 +207,22 @@ export class Storage implements IStorage {
   }
 
   /**
-   * Fetch all addresses from storage
+   * Fetch all addresses from storage for one chain.
+   *
+   * `opts.legacy` defaults to `true`; pass `legacy: false` to
+   * enumerate the wallet's user-facing shielded receive addresses
+   * (the 71-byte encoded form) in BIP32-index order. See
+   * `IStore.addressIter` for the chain-selection semantics.
    *
    * @async
    * @generator
+   * @param {IAddressChainOptions} [opts]
    * @yields {Promise<IAddressInfo & Partial<IAddressMetadata>>} The addresses in store.
    */
-  async *getAllAddresses(): AsyncGenerator<IAddressInfo & IAddressMetadata> {
-    for await (const address of this.store.addressIter()) {
+  async *getAllAddresses(
+    opts?: IAddressChainOptions
+  ): AsyncGenerator<IAddressInfo & IAddressMetadata> {
+    for await (const address of this.store.addressIter(opts)) {
       const meta = await this.store.getAddressMeta(address.base58);
       yield { ...address, ...DEFAULT_ADDRESS_META, ...meta };
     }
@@ -232,8 +254,11 @@ export class Storage implements IStorage {
    * @async
    * @returns {Promise<IAddressInfo|null>} The address info or null if not found
    */
-  async getAddressAtIndex(index: number): Promise<IAddressInfo | null> {
-    return this.store.getAddressAtIndex(index);
+  async getAddressAtIndex(
+    index: number,
+    opts?: IAddressChainOptions
+  ): Promise<IAddressInfo | null> {
+    return this.store.getAddressAtIndex(index, opts);
   }
 
   /**
@@ -280,8 +305,8 @@ export class Storage implements IStorage {
    * @param {boolean|undefined} markAsUsed If we should set the next address as current
    * @returns {Promise<string>} The address in base58 encoding
    */
-  async getCurrentAddress(markAsUsed?: boolean): Promise<string> {
-    return this.store.getCurrentAddress(markAsUsed);
+  async getCurrentAddress(markAsUsed?: boolean, opts?: IAddressChainOptions): Promise<string> {
+    return this.store.getCurrentAddress(markAsUsed, opts);
   }
 
   /**
@@ -298,6 +323,20 @@ export class Storage implements IStorage {
     if (changeAddress) {
       if (!(await this.isAddressMine(changeAddress))) {
         throw new Error('Change address is not from the wallet');
+      }
+      // Shielded addresses can't be used directly as an output script type —
+      // `getAddressType` throws on them downstream. But their on-chain
+      // equivalent is the spend-derived P2PKH (same pubkey hash), so resolve
+      // here and hand the P2PKH back. The wallet still tracks the output as
+      // its own because the P2PKH is stored in the address index during
+      // shielded-address derivation (see `deriveShieldedAddressFromStorage`).
+      // `isShielded()` is non-throwing — it returns false on any address
+      // that doesn't decode as shielded under the current network — so a
+      // version-byte mismatch on a legacy address falls through to the
+      // unchanged passthrough below.
+      const addrObj = new Address(changeAddress, { network: this.config.getNetwork() });
+      if (addrObj.isShielded()) {
+        return addrObj.getSpendAddress().base58;
       }
       return changeAddress;
     }
@@ -381,7 +420,9 @@ export class Storage implements IStorage {
     // Keep tx-timestamp index sorted
     await this.store.preProcessHistory();
     // Process the single tx we received
-    await processSingleTxUtil(this, tx, { rewardLock: this.version?.reward_spend_min_blocks });
+    await processSingleTxUtil(this, tx, {
+      rewardLock: this.version?.reward_spend_min_blocks,
+    });
   }
 
   /**
@@ -474,6 +515,13 @@ export class Storage implements IStorage {
    * @param {Omit<IUtxoFilterOptions, 'reward_lock'>} [options={}] Options to filter utxos and stop when the target is found.
    * @returns {AsyncGenerator<IUtxo, any, unknown>}
    */
+  /**
+   * Look up a specific UTXO by txId and index.
+   */
+  async getUtxo(utxoId: IUtxoId): Promise<IUtxo | null> {
+    return this.store.getUtxo(utxoId);
+  }
+
   async *selectUtxos(
     options: Omit<IUtxoFilterOptions, 'reward_lock'> = {}
   ): AsyncGenerator<IUtxo, void, void> {
@@ -718,11 +766,15 @@ export class Storage implements IStorage {
    */
   async utxoSelectAsInput(utxo: IUtxoId, markAs: boolean, ttl?: number): Promise<void> {
     const tx = await this.getTx(utxo.txId);
-    if (!tx || !tx.outputs[utxo.index]) {
+    if (!tx) {
+      return;
+    }
+    const output = tx.outputs[utxo.index];
+    if (!output) {
       return;
     }
 
-    if (markAs && tx.outputs[utxo.index].spent_by !== null) {
+    if (markAs && output.spent_by !== null) {
       // Already spent, no need to mark as selected_as_input
       return;
     }
@@ -901,6 +953,50 @@ export class Storage implements IStorage {
 
     // decryptData handles pin validation
     return decryptData(accessData.acctPathKey, pinCode);
+  }
+
+  /**
+   * Get the scan chain xprivkey for shielded ECDH.
+   * Uses account 1' (m/44'/280'/1'/0), separate from legacy (account 0').
+   */
+  async getScanXPrivKey(pinCode: string): Promise<string> {
+    const accessData = await this._getValidAccessData();
+    if (!accessData.scanMainKey) {
+      throw new Error('Scan private key is not present on this wallet.');
+    }
+    return decryptData(accessData.scanMainKey, pinCode);
+  }
+
+  /**
+   * Get the spend chain xprivkey for shielded UTXO signing.
+   * Uses account 2' (m/44'/280'/2'/0).
+   */
+  async getSpendXPrivKey(pinCode: string): Promise<string> {
+    const accessData = await this._getValidAccessData();
+    if (!accessData.spendMainKey) {
+      throw new Error('Spend private key is not present on this wallet.');
+    }
+    return decryptData(accessData.spendMainKey, pinCode);
+  }
+
+  /**
+   * Get the scan chain xpubkey for shielded address derivation.
+   * Uses account 1' (m/44'/280'/1'/0).
+   * Returns undefined if wallet was created before shielded feature.
+   */
+  async getScanXPubKey(): Promise<string | undefined> {
+    const accessData = await this._getValidAccessData();
+    return accessData.scanXpubkey;
+  }
+
+  /**
+   * Get the spend chain xpubkey for shielded address derivation.
+   * Uses account 2' (m/44'/280'/2'/0).
+   * Returns undefined if wallet was created before shielded feature.
+   */
+  async getSpendXPubKey(): Promise<string | undefined> {
+    const accessData = await this._getValidAccessData();
+    return accessData.spendXpubkey;
   }
 
   /**

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -6,7 +6,6 @@
  */
 
 import { HDPublicKey } from 'bitcore-lib';
-import Address from '../models/address';
 import Input from '../models/input';
 import {
   ApiVersion,
@@ -324,20 +323,12 @@ export class Storage implements IStorage {
       if (!(await this.isAddressMine(changeAddress))) {
         throw new Error('Change address is not from the wallet');
       }
-      // Shielded addresses can't be used directly as an output script type —
-      // `getAddressType` throws on them downstream. But their on-chain
-      // equivalent is the spend-derived P2PKH (same pubkey hash), so resolve
-      // here and hand the P2PKH back. The wallet still tracks the output as
-      // its own because the P2PKH is stored in the address index during
-      // shielded-address derivation (see `deriveShieldedAddressFromStorage`).
-      // `isShielded()` is non-throwing — it returns false on any address
-      // that doesn't decode as shielded under the current network — so a
-      // version-byte mismatch on a legacy address falls through to the
-      // unchanged passthrough below.
-      const addrObj = new Address(changeAddress, { network: this.config.getNetwork() });
-      if (addrObj.isShielded()) {
-        return addrObj.getSpendAddress().base58;
-      }
+      // Return the resolved change address as-is, including a 71-byte shielded
+      // address. The shielded -> spend-derived-P2PKH rule for output scripts is
+      // owned by the transaction layer (createOutputScript /
+      // createOutputScriptFromAddress), which resolves every output address
+      // uniformly at script-building time. getChangeAddress is a storage-layer
+      // resolver and deliberately does not duplicate that send-side rule.
       return changeAddress;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ import Transaction from './models/transaction';
 import Input from './models/input';
 import FullNodeConnection from './new/connection';
 import Header from './headers/base';
+import type { IShieldedCryptoProvider, ShieldedOutputMode } from './shielded/types';
 
 /**
  * Token version used to identify the type of token during the token creation process.
@@ -114,6 +115,14 @@ export interface IAddressInfo {
   // 'shielded-spend' = the on-chain P2PKH derived from HASH160(spend_pubkey);
   //   this is the form getAddressType()/script builders accept.
   addressType?: AddressType | 'shielded-spend';
+}
+
+/**
+ * Options for address methods that can operate on either the legacy or shielded address chain.
+ * Defaults to legacy (true) for backward compatibility.
+ */
+export interface IAddressChainOptions {
+  legacy?: boolean; // default: true
 }
 
 export interface IAddressMetadata {
@@ -238,6 +247,45 @@ export interface IHistoryTx {
   nc_context?: IHistoryNanoContractContext;
   nc_seqnum?: number; // For nano contract
   first_block?: string | null;
+  shielded_outputs?: IHistoryShieldedOutput[]; // For confidential transactions
+  /**
+   * Tx-level headers persisted from the wire payload (FeeHeader,
+   * UnshieldBalanceHeader, ...). The wallet keeps them as the original
+   * untyped on-chain shape (each entry has `id` + header-specific
+   * fields like `entries[]` for FeeHeader); reconstructing the typed
+   * `Header` instance here would force `processNewTx` to call into the
+   * tx parser unnecessarily. Display layers can read the entries and
+   * compute network fees directly.
+   */
+  headers?: { id?: number; entries?: { tokenIndex?: number; amount?: bigint }[] }[];
+}
+
+// Equivalent to IShieldedOutput in shielded/types.ts but uses IHistoryOutputDecoded
+// (which includes the extra `data?` field). Keep both in sync when modifying.
+export interface IHistoryShieldedOutput {
+  // Optional because hathor-core nodes pre-`_shielded_output_to_json`
+  // mode-field addition still send shielded outputs without `mode`.
+  // Readers fall back to inferring FullShielded vs AmountShielded from
+  // the presence of `asset_commitment`.
+  mode?: ShieldedOutputMode;
+  commitment: string; // hex
+  range_proof: string; // hex
+  script: string; // hex
+  // Optional + defaults to 0 in the parser. FullShielded outputs may
+  // omit `token_data` (the token UID is hidden behind asset_commitment).
+  token_data?: number;
+  ephemeral_pubkey: string; // hex
+  decoded: IHistoryOutputDecoded;
+  asset_commitment?: string; // hex (FullShielded only)
+  surjection_proof?: string; // hex (FullShielded only)
+  // Set by the fullnode when the shielded output is spent by another tx.
+  // Null when the slot is still unspent. Mirrors the transparent
+  // `IHistoryOutput.spent_by` semantics — see hathor-core's
+  // `_shielded_output_to_json` + `meta.get_output_spent_by` in
+  // `base_transaction.py`. Threaded through normalizeShieldedOutputs and
+  // the processNewTx decryption append so the wallet treats shielded
+  // and transparent outputs identically when checking spend status.
+  spent_by?: string | null;
 }
 
 export enum TxHistoryProcessingStatus {
@@ -366,6 +414,9 @@ export interface IUtxo {
   timelock: number | null;
   type: number; // tx.version, is the value of the transaction version byte
   height: number | null; // only for block outputs
+  shielded?: boolean; // marks this as a shielded UTXO (confidential transaction)
+  blindingFactor?: string; // hex, 32 bytes — value blinding factor from decryption
+  assetBlindingFactor?: string; // hex, 32 bytes — asset blinding factor (FullShielded only)
 }
 
 export interface ILockedUtxo {
@@ -464,6 +515,10 @@ export interface IWalletData {
   lastLoadedAddressIndex: number;
   lastUsedAddressIndex: number;
   currentAddressIndex: number;
+  // Shielded address chain tracking (separate gap-limit scanning)
+  shieldedLastLoadedAddressIndex: number;
+  shieldedLastUsedAddressIndex: number;
+  shieldedCurrentAddressIndex: number;
   bestBlockHeight: number;
   scanPolicyData: AddressScanPolicyData;
 }
@@ -497,6 +552,11 @@ export interface IUtxoFilterOptions {
   // Will order utxos by value, asc or desc
   // If not set, will not order
   order_by_value?: 'asc' | 'desc';
+  // Filter by shielded status:
+  // undefined (default) → all UTXOs (transparent + shielded)
+  // true → only shielded UTXOs
+  // false → only transparent UTXOs
+  shielded?: boolean;
 }
 
 export type UtxoSelectionAlgorithm = (
@@ -538,11 +598,11 @@ export interface IStore {
   validate(): Promise<void>;
   preProcessHistory(): Promise<void>;
   // Address methods
-  addressIter(): AsyncGenerator<IAddressInfo>;
+  addressIter(opts?: IAddressChainOptions): AsyncGenerator<IAddressInfo>;
   getAddress(base58: string): Promise<IAddressInfo | null>;
   getAddressMeta(base58: string): Promise<IAddressMetadata | null>;
   getSeqnumMeta(base58: string): Promise<number | null>;
-  getAddressAtIndex(index: number): Promise<IAddressInfo | null>;
+  getAddressAtIndex(index: number, opts?: IAddressChainOptions): Promise<IAddressInfo | null>;
   saveAddress(info: IAddressInfo): Promise<void>;
   addressExists(base58: string): Promise<boolean>;
   addressCount(): Promise<number>;
@@ -550,7 +610,17 @@ export interface IStore {
   editSeqnumMeta(base58: string, seqnum: number): Promise<void>;
 
   // tx history methods
-  historyIter(tokenUid?: string): AsyncGenerator<IHistoryTx>;
+  /**
+   * Yield txs from the local history.
+   *
+   * @param tokenUid Optional. If set, only yield txs that involve this token
+   *   on a wallet-owned address (input or output).
+   * @param options.order `'desc'` (default) yields newest-first — the order
+   *   the wallet UI consumes. `'asc'` yields oldest-first, used by
+   *   `processHistory` to replay txs chronologically so a tx that spends a
+   *   previous tx's UTXO finds it already saved.
+   */
+  historyIter(tokenUid?: string, options?: { order?: 'asc' | 'desc' }): AsyncGenerator<IHistoryTx>;
   saveTx(tx: IHistoryTx): Promise<void>;
   getTx(txId: string): Promise<IHistoryTx | null>;
   historyCount(): Promise<number>;
@@ -570,6 +640,7 @@ export interface IStore {
   utxoIter(): AsyncGenerator<IUtxo>;
   selectUtxos(options: IUtxoFilterOptions): AsyncGenerator<IUtxo>;
   saveUtxo(utxo: IUtxo): Promise<void>;
+  getUtxo(utxoId: IUtxoId): Promise<IUtxo | null>;
   saveLockedUtxo(lockedUtxo: ILockedUtxo): Promise<void>;
   iterateLockedUtxos(): AsyncGenerator<ILockedUtxo>;
   unlockUtxo(lockedUtxo: ILockedUtxo): Promise<void>;
@@ -579,13 +650,13 @@ export interface IStore {
   getAccessData(): Promise<IWalletAccessData | null>;
   saveAccessData(data: IWalletAccessData): Promise<void>;
   getWalletData(): Promise<IWalletData>;
-  getLastLoadedAddressIndex(): Promise<number>;
-  getLastUsedAddressIndex(): Promise<number>;
-  setLastUsedAddressIndex(index: number): Promise<void>;
+  getLastLoadedAddressIndex(opts?: IAddressChainOptions): Promise<number>;
+  getLastUsedAddressIndex(opts?: IAddressChainOptions): Promise<number>;
+  setLastUsedAddressIndex(index: number, opts?: IAddressChainOptions): Promise<void>;
   getCurrentHeight(): Promise<number>;
   setCurrentHeight(height: number): Promise<void>;
-  getCurrentAddress(markAsUsed?: boolean): Promise<string>;
-  setCurrentAddressIndex(index: number): Promise<void>;
+  getCurrentAddress(markAsUsed?: boolean, opts?: IAddressChainOptions): Promise<string>;
+  setCurrentAddressIndex(index: number, opts?: IAddressChainOptions): Promise<void>;
   setGapLimit(value: number): Promise<void>;
   getGapLimit(): Promise<number>;
   getIndexLimit(): Promise<Omit<IIndexLimitAddressScanPolicy, 'policy'> | null>;
@@ -620,6 +691,10 @@ export interface IStorage {
   version: ApiVersion | null;
   logger: ILogger;
 
+  // Shielded (confidential transaction) crypto provider
+  shieldedCryptoProvider?: IShieldedCryptoProvider;
+  setShieldedCryptoProvider(provider?: IShieldedCryptoProvider): void;
+
   setApiVersion(version: ApiVersion): void;
   getDecimalPlaces(): number;
   saveNativeToken(): Promise<void>;
@@ -631,13 +706,13 @@ export interface IStorage {
   getTxSignatures(tx: Transaction, pinCode: string): Promise<ITxSignatureData>;
 
   // Address methods
-  getAllAddresses(): AsyncGenerator<IAddressInfo & IAddressMetadata>;
+  getAllAddresses(opts?: IAddressChainOptions): AsyncGenerator<IAddressInfo & IAddressMetadata>;
   getAddressInfo(base58: string): Promise<(IAddressInfo & IAddressMetadata) | null>;
-  getAddressAtIndex(index: number): Promise<IAddressInfo | null>;
+  getAddressAtIndex(index: number, opts?: IAddressChainOptions): Promise<IAddressInfo | null>;
   getAddressPubkey(index: number): Promise<string>;
   saveAddress(info: IAddressInfo): Promise<void>;
   isAddressMine(base58: string): Promise<boolean>;
-  getCurrentAddress(markAsUsed?: boolean): Promise<string>;
+  getCurrentAddress(markAsUsed?: boolean, opts?: IAddressChainOptions): Promise<string>;
   getChangeAddress(options?: { changeAddress?: null | string }): Promise<string>;
 
   // Transaction methods
@@ -648,6 +723,7 @@ export interface IStorage {
   addTx(tx: IHistoryTx): Promise<void>;
   processHistory(): Promise<void>;
   processNewTx(tx: IHistoryTx): Promise<void>;
+  getUtxo(utxoId: IUtxoId): Promise<IUtxo | null>;
 
   // Tokens
   addToken(data: ITokenData): Promise<void>;
@@ -678,6 +754,12 @@ export interface IStorage {
   getMainXPrivKey(pinCode: string): Promise<string>;
   getAcctPathXPrivKey(pinCode: string): Promise<string>;
   getAuthPrivKey(pinCode: string): Promise<string>;
+
+  // Shielded key methods (return undefined if wallet was created before shielded feature)
+  getScanXPrivKey(pinCode: string): Promise<string>;
+  getSpendXPrivKey(pinCode: string): Promise<string>;
+  getScanXPubKey(): Promise<string | undefined>;
+  getSpendXPubKey(): Promise<string | undefined>;
   getWalletData(): Promise<IWalletData>;
   getWalletType(): Promise<WalletType>;
   getCurrentHeight(): Promise<number>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -595,7 +595,7 @@ export interface IStore {
   getAddressAtIndex(index: number, opts?: IAddressChainOptions): Promise<IAddressInfo | null>;
   saveAddress(info: IAddressInfo): Promise<void>;
   addressExists(base58: string): Promise<boolean>;
-  addressCount(): Promise<number>;
+  addressCount(opts?: IAddressChainOptions): Promise<number>;
   editAddressMeta(base58: string, meta: IAddressMetadata): Promise<void>;
   editSeqnumMeta(base58: string, seqnum: number): Promise<void>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,15 @@ export interface IAddressInfo {
   // 'shielded-spend' = the on-chain P2PKH derived from HASH160(spend_pubkey);
   //   this is the form getAddressType()/script builders accept.
   addressType?: AddressType | 'shielded-spend';
+  // Cross-link between the two records of a shielded address pair (which share
+  // the same BIP32 index), so callers translate between them in O(1) without a
+  // full-address scan or a parallel index map:
+  //   - on a 'shielded' record       → the paired 'shielded-spend' P2PKH base58
+  //   - on a 'shielded-spend' record → the paired 'shielded' (71-byte) base58
+  // Undefined for legacy records. Set once when the pair is derived
+  // (deriveShieldedAddressFromStorage), so `this.addresses` stays the single
+  // source of truth for the mapping.
+  ctMappingAddress?: string;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ import Transaction from './models/transaction';
 import Input from './models/input';
 import FullNodeConnection from './new/connection';
 import Header from './headers/base';
-import type { IShieldedCryptoProvider, ShieldedOutputMode } from './shielded/types';
+import type { IShieldedCryptoProvider, IShieldedOutput } from './shielded/types';
 
 /**
  * Token version used to identify the type of token during the token creation process.
@@ -260,24 +260,14 @@ export interface IHistoryTx {
   headers?: { id?: number; entries?: { tokenIndex?: number; amount?: bigint }[] }[];
 }
 
-// Equivalent to IShieldedOutput in shielded/types.ts but uses IHistoryOutputDecoded
-// (which includes the extra `data?` field). Keep both in sync when modifying.
-export interface IHistoryShieldedOutput {
-  // Optional because hathor-core nodes pre-`_shielded_output_to_json`
-  // mode-field addition still send shielded outputs without `mode`.
-  // Readers fall back to inferring FullShielded vs AmountShielded from
-  // the presence of `asset_commitment`.
-  mode?: ShieldedOutputMode;
-  commitment: string; // hex
-  range_proof: string; // hex
-  script: string; // hex
-  // Optional + defaults to 0 in the parser. FullShielded outputs may
-  // omit `token_data` (the token UID is hidden behind asset_commitment).
-  token_data?: number;
-  ephemeral_pubkey: string; // hex
+// The history/storage shape of a shielded output: structurally the wire
+// `IShieldedOutput` (shielded/types.ts) plus spend tracking. It overrides
+// `decoded` with the richer `IHistoryOutputDecoded` (which adds the `data?`
+// field) and adds `spent_by`. Extending keeps the crypto wire fields
+// (mode/commitment/range_proof/…) single-source, so the two shapes cannot
+// drift out of sync.
+export interface IHistoryShieldedOutput extends Omit<IShieldedOutput, 'decoded'> {
   decoded: IHistoryOutputDecoded;
-  asset_commitment?: string; // hex (FullShielded only)
-  surjection_proof?: string; // hex (FullShielded only)
   // Set by the fullnode when the shielded output is spent by another tx.
   // Null when the slot is still unspent. Mirrors the transparent
   // `IHistoryOutput.spent_by` semantics — see hathor-core's

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -18,6 +18,7 @@ import Network from '../models/network';
 import { hexToBuffer } from './buffer';
 import { IMultisigData, IStorage, IAddressInfo } from '../types';
 import { createP2SHRedeemScript } from './scripts';
+import { deriveShieldedAddress } from './shieldedAddress';
 
 /**
  * Parse address and return its OUTPUT SCRIPT type.
@@ -172,4 +173,48 @@ export function getAddressFromPubkey(pubkey: string, network: Network): Address 
     network.bitcoreNetwork
   ).toString();
   return new Address(base58, { network });
+}
+
+/**
+ * Derive shielded address and its on-chain spend address from storage at a given index.
+ *
+ * Returns two IAddressInfo entries:
+ * 1. The shielded address (user-facing, 71-byte format)
+ * 2. The spend-derived P2PKH address (on-chain, for matching incoming txs)
+ *
+ * Returns null if the wallet doesn't have shielded key material.
+ */
+export async function deriveShieldedAddressFromStorage(
+  index: number,
+  storage: IStorage
+): Promise<{ shieldedAddress: IAddressInfo; spendAddress: IAddressInfo } | null> {
+  const scanXpub = await storage.getScanXPubKey();
+  const spendXpub = await storage.getSpendXPubKey();
+  if (!scanXpub || !spendXpub) {
+    return null;
+  }
+
+  const networkName = storage.config.getNetwork().name;
+  const info = deriveShieldedAddress(scanXpub, spendXpub, index, networkName);
+
+  // The user-facing shielded address encodes both scan and spend pubkeys.
+  // This is what users share with senders to receive shielded outputs.
+  const shieldedAddress: IAddressInfo = {
+    base58: info.base58,
+    bip32AddressIndex: index,
+    publicKey: info.scanPubkey,
+    addressType: 'shielded',
+  };
+
+  // The on-chain P2PKH derived from the spend pubkey (spend_pubkey → HASH160 → P2PKH).
+  // Stored separately so the wallet can match incoming transactions by decoded.address,
+  // since on-chain scripts reference this P2PKH, not the shielded address.
+  const spendAddress: IAddressInfo = {
+    base58: info.spendAddress,
+    bip32AddressIndex: index,
+    publicKey: info.spendPubkey,
+    addressType: 'shielded-spend',
+  };
+
+  return { shieldedAddress, spendAddress };
 }

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -204,6 +204,8 @@ export async function deriveShieldedAddressFromStorage(
     bip32AddressIndex: index,
     publicKey: info.scanPubkey,
     addressType: 'shielded',
+    // Pair link: from the user-facing shielded address to its on-chain spend P2PKH.
+    ctMappingAddress: info.spendAddress,
   };
 
   // The on-chain P2PKH derived from the spend pubkey (spend_pubkey → HASH160 → P2PKH).
@@ -214,6 +216,8 @@ export async function deriveShieldedAddressFromStorage(
     bip32AddressIndex: index,
     publicKey: info.spendPubkey,
     addressType: 'shielded-spend',
+    // Pair link: from the on-chain spend P2PKH back to the user-facing shielded address.
+    ctMappingAddress: info.base58,
   };
 
   return { shieldedAddress, spendAddress };

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -763,7 +763,9 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
     }
 
     for (const txin of tx.inputs) {
-      if (transaction.isAuthorityOutput(txin)) {
+      // Shielded inputs don't have value/token/token_data fields
+      if (txin.token === undefined) continue;
+      if (transaction.isAuthorityOutput({ token_data: txin.token_data! })) {
         if (options.includeAuthorities) {
           if (!balance[txin.token]) {
             balance[txin.token] = 0n;
@@ -775,7 +777,7 @@ class HathorWalletServiceWallet extends EventEmitter implements IHathorWallet {
         if (!balance[txin.token]) {
           balance[txin.token] = 0n;
         }
-        balance[txin.token] -= txin.value;
+        balance[txin.token] -= txin.value!;
       }
     }
 


### PR DESCRIPTION
## Summary

This layer answers **"where shielded data lives"** — types, stores, indexes, key access. Purely additive: nothing consumes these capabilities yet (5b/5c do), so existing wallets behave exactly as before.

This is the first part of PR5 (5a).

```
master ─ PR1 ─ PR2 ─ PR3 ─ PR4 ─ PR5 ◀ PR6 ─ PR7
```

Base: `shielded/pr-4-address-derivation`.

This is the largest source-code PR — **2200 net additions across 17 files**. Suggested two reviewers (one for storage, one for the data-model ripple).

## Acceptance Criteria

- Shielded key material is reachable through storage: `getScanXPrivKey(pin)` / `getSpendXPrivKey(pin)` decrypt with the PIN; `getScanXPubKey()` / `getSpendXPubKey()` return the public chains; `shieldedCryptoProvider` has a field + setter.
- `MemoryStore.saveAddress` routes by `addressType`: `shielded` addresses index into the new `shieldedAddressIndexes` map; `shielded-spend` records are stored but not indexed (matched later by base58).
- Address-chain methods (`getAddressAtIndex`, `getCurrentAddress`, index getters/setters) accept `IAddressChainOptions` — `{ legacy: false }` selects the shielded chain; omitting it preserves legacy behavior.
- `IWalletData` tracks the shielded chain's loaded / used / current indices independently of the legacy chain.
- `IUtxo` can carry `shielded` / `blindingFactor` / `assetBlindingFactor`; `IUtxoFilterOptions.shielded` filters them.
- No behavior change for existing wallets — every new field and method param is optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added chain-aware address iteration/indexing with legacy vs shielded filtering.
  - Added ordered transaction history iteration (ascending/descending).
  - Added direct UTXO lookup and improved UTXO selection filtering for transparent vs shielded.
  - Added shielded crypto provider support plus scan/spend key accessors.
- **Bug Fixes**
  - Improved wallet balance calculations by skipping incomplete shielded inputs.
  - Preserves user-provided shielded change addresses instead of converting them.
- **Tests**
  - Expanded coverage for legacy vs shielded behavior, ordering, and filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->