### PR TITLE
feat(shielded): wallet lifecycle, send pipeline, schema relaxation

### DIFF
--- a/__tests__/models/partial_tx.test.ts
+++ b/__tests__/models/partial_tx.test.ts
@@ -533,4 +533,45 @@ describe('PartialTx.validate', () => {
 
     await expect(partialTx.validate()).resolves.toEqual(false);
   });
+
+  it('should reject (clear error) an input referencing a shielded output slot', async () => {
+    // SEPARATED model: parent tx has 1 transparent output (T=1) and 1 shielded
+    // output. The shielded slot's on-chain absolute index is T + 0 = 1, which
+    // lands in the shielded range. Partial transactions are transparent-only;
+    // such an input must be rejected with a clear error rather than silently
+    // resolving false.
+    spy.mockImplementation(async (txId, cb) => {
+      return new Promise(resolve => {
+        process.nextTick(() => {
+          resolve({
+            success: true,
+            tx: {
+              outputs: [{ token_data: 0, value: 27n, decoded: { address: addr1 } }],
+              shielded_outputs: [
+                {
+                  mode: 1,
+                  commitment: 'aa',
+                  range_proof: '',
+                  script: '',
+                  token_data: 0,
+                  ephemeral_pubkey: '',
+                  decoded: { type: 'P2PKH', address: addr1, timelock: null },
+                },
+              ],
+            },
+          });
+        });
+      }).then(data => {
+        cb(data);
+      });
+    });
+
+    const partialTx = new PartialTx(testnet);
+    // index 1 == outputs.length + 0 → shielded slot
+    partialTx.inputs = [new ProposalInput(txId1, 1, 27n, addr1)];
+
+    await expect(partialTx.validate()).rejects.toThrow(
+      'Shielded inputs are not supported in partial transactions'
+    );
+  });
 });

--- a/__tests__/models/transaction.test.ts
+++ b/__tests__/models/transaction.test.ts
@@ -17,7 +17,12 @@ import ShieldedOutput from '../../src/models/shielded_output';
 import ShieldedOutputsHeader from '../../src/headers/shielded_outputs';
 import { hexToBuffer, bufferToHex } from '../../src/utils/buffer';
 import helpers from '../../src/utils/helpers';
-import { DEFAULT_TX_VERSION, MAX_OUTPUTS, DEFAULT_SIGNAL_BITS } from '../../src/constants';
+import {
+  DEFAULT_TX_VERSION,
+  MAX_OUTPUTS,
+  MAX_SHIELDED_OUTPUTS,
+  DEFAULT_SIGNAL_BITS,
+} from '../../src/constants';
 import {
   CreateTokenTxInvalid,
   MaximumNumberInputsError,
@@ -673,4 +678,39 @@ test('shieldedOutputs getter returns a frozen empty array when there is no heade
   expect(() =>
     (tx.shieldedOutputs as ShieldedOutput[]).push({} as unknown as ShieldedOutput)
   ).toThrow();
+});
+
+describe('Transaction.validate shielded outputs', () => {
+  // shieldedOutputs is a header-backed read-only getter, so populate via the
+  // ShieldedOutputsHeader rather than assigning the property.
+  const fakeShielded = {
+    mode: 1,
+    commitment: Buffer.alloc(33),
+    rangeProof: Buffer.alloc(10),
+    tokenData: 0,
+    script: Buffer.alloc(25),
+    ephemeralPubkey: Buffer.alloc(33),
+    value: 1n,
+    serialize: () => [Buffer.alloc(1)],
+    serializeSighash: () => [Buffer.alloc(1)],
+  };
+  const txWithShielded = (count: number): Transaction => {
+    const tx = new Transaction([], [], { version: DEFAULT_TX_VERSION });
+    tx.headers.push(
+      new ShieldedOutputsHeader(
+        Array.from({ length: count }, () => ({ ...fakeShielded })) as unknown as ShieldedOutput[]
+      )
+    );
+    return tx;
+  };
+
+  it('should accept MAX_SHIELDED_OUTPUTS shielded outputs', () => {
+    expect(() => txWithShielded(MAX_SHIELDED_OUTPUTS).validate()).not.toThrow();
+  });
+
+  it('should reject more than MAX_SHIELDED_OUTPUTS shielded outputs', () => {
+    expect(() => txWithShielded(MAX_SHIELDED_OUTPUTS + 1).validate()).toThrow(
+      MaximumNumberOutputsError
+    );
+  });
 });

--- a/__tests__/new/hathorwallet.test.ts
+++ b/__tests__/new/hathorwallet.test.ts
@@ -932,6 +932,337 @@ test('getTxHistory', async () => {
   ]);
 });
 
+describe('getShieldedUnblindingForTx', () => {
+  // SEPARATED model: build a tx with transparent outputs in `outputs[]` and the
+  // full on-chain-ordered shielded list in `shielded_outputs[]`. Owned slots
+  // carry the owned-marker fields (value/token/blindingFactor[/assetBlindingFactor])
+  // written IN PLACE; non-owned slots have `value === undefined`. The on-chain
+  // absolute index of `shielded_outputs[s]` is `outputs.length + s`.
+  const makeTx = (
+    txId: string,
+    transparent: Array<{ value: bigint; token: string }>,
+    shielded: Array<{
+      commitment: string;
+      value?: bigint;
+      token?: string;
+      blindingFactor?: string;
+      assetBlindingFactor?: string;
+    }>
+  ): IHistoryTx =>
+    ({
+      tx_id: txId,
+      timestamp: 1,
+      version: 1,
+      weight: 1,
+      nonce: 0,
+      height: 0,
+      parents: [],
+      inputs: [],
+      outputs: transparent.map(t => ({
+        value: t.value,
+        token_data: 0,
+        token: t.token,
+        spent_by: null,
+        script: '',
+        decoded: { type: 'P2PKH', address: 'addr1', timelock: null },
+      })),
+      // The FULL on-chain-ordered shielded list. Owned slots carry the
+      // owned-marker fields; non-owned slots leave value/token/blinding
+      // undefined.
+      shielded_outputs: shielded.map(s => ({
+        mode: s.assetBlindingFactor ? 2 : 1,
+        commitment: s.commitment,
+        range_proof: '',
+        script: '',
+        token_data: 0,
+        ephemeral_pubkey: '',
+        decoded: { type: 'P2PKH', address: 'addrShielded', timelock: null },
+        spent_by: null,
+        // owned-marker fields (undefined when not owned)
+        value: s.value,
+        token: s.token,
+        blindingFactor: s.blindingFactor,
+        assetBlindingFactor: s.assetBlindingFactor,
+      })),
+    }) as unknown as IHistoryTx;
+
+  test('returns one entry per wallet-owned shielded output (index = T + s)', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+
+    // 1 transparent output (T=1) → shielded slots map to on-chain indices 1,2,3.
+    const tx = makeTx(
+      'tx1',
+      [{ value: 100n, token: '00' }],
+      [
+        // owned (decoded) AmountShielded — on-chain index = T(1) + 0 = 1
+        { commitment: 'aa', value: 250n, token: '00', blindingFactor: 'cafe' },
+        // not decoded — wallet doesn't own. value === undefined → skipped.
+        { commitment: 'bb' },
+        // owned FullShielded — on-chain index = T(1) + 2 = 3
+        {
+          commitment: 'cc',
+          value: 999n,
+          token: '0102',
+          blindingFactor: 'beef',
+          assetBlindingFactor: 'dead',
+        },
+      ]
+    );
+    jest.spyOn(storage, 'getTx').mockResolvedValue(tx);
+
+    const result = await hWallet.getShieldedUnblindingForTx('tx1');
+
+    expect(result.outputs).toEqual([
+      { index: 1, value: 250n, token: '00', vbf: 'cafe' },
+      { index: 3, value: 999n, token: '0102', vbf: 'beef', abf: 'dead' },
+    ]);
+    expect(result.inputs).toEqual([]);
+  });
+
+  test('returns empty when tx not found or has no decoded shielded outputs', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+
+    jest.spyOn(storage, 'getTx').mockResolvedValueOnce(null);
+    await expect(hWallet.getShieldedUnblindingForTx('missing')).resolves.toEqual({
+      outputs: [],
+      inputs: [],
+    });
+
+    const transparentOnly = makeTx('tx2', [{ value: 5n, token: '00' }], []);
+    jest.spyOn(storage, 'getTx').mockResolvedValueOnce(transparentOnly);
+    await expect(hWallet.getShieldedUnblindingForTx('tx2')).resolves.toEqual({
+      outputs: [],
+      inputs: [],
+    });
+  });
+
+  test('owned slot at a non-prefix shielded position resolves to index T + s', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+
+    // Two transparent outputs (T=2), then two shielded slots — the wallet owns
+    // only the SECOND shielded slot (s=1). Its on-chain index must be the
+    // arithmetic T(2) + s(1) = 3, with NO reliance on a stored onChainIndex.
+    const tx = makeTx(
+      'tx3',
+      [
+        { value: 1n, token: '00' },
+        { value: 2n, token: '00' },
+      ],
+      [
+        { commitment: 'foreign' }, // not owned (value undefined)
+        { commitment: 'mine', value: 50n, token: '00', blindingFactor: 'fade' },
+      ]
+    );
+    jest.spyOn(storage, 'getTx').mockResolvedValue(tx);
+
+    const result = await hWallet.getShieldedUnblindingForTx('tx3');
+    expect(result.outputs).toEqual([{ index: 3, value: 50n, token: '00', vbf: 'fade' }]);
+    expect(result.inputs).toEqual([]);
+  });
+
+  test('returns inputs the wallet owned the parent output for', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+
+    // Parent tx has 1 transparent output (T=1) + 1 shielded the wallet owns;
+    // that shielded slot's on-chain index is T(1) + 0 = 1.
+    const parent = makeTx(
+      'parentA',
+      [{ value: 10n, token: '00' }],
+      [
+        {
+          commitment: 'parent-shielded-cm',
+          value: 777n,
+          token: '00',
+          blindingFactor: 'parentVbf',
+          assetBlindingFactor: 'parentAbf',
+        },
+      ]
+    );
+
+    // Spending tx: input #0 is a shielded reference to parentA[1] (the
+    // wallet-owned output), input #1 is a shielded reference to a tx the wallet
+    // doesn't have (no parent → skipped silently).
+    const spending = {
+      ...makeTx('spendA', [], [{ commitment: 'self-cm' }]),
+      inputs: [
+        { type: 'shielded', tx_id: 'parentA', index: 1, commitment: 'parent-shielded-cm' },
+        { type: 'shielded', tx_id: 'foreign', index: 2, commitment: 'foreign-cm' },
+        // Transparent input — ignored, doesn't need unblinding.
+        {
+          type: 'transparent',
+          tx_id: 'parentA',
+          index: 0,
+          value: 10n,
+          token: '00',
+          token_data: 0,
+          script: '',
+          decoded: { type: 'P2PKH', address: 'addr1', timelock: null },
+        },
+      ],
+    };
+
+    jest.spyOn(storage, 'getTx').mockImplementation(async (id: string) => {
+      if (id === 'spendA') return spending as unknown as IHistoryTx;
+      if (id === 'parentA') return parent;
+      return null;
+    });
+
+    const result = await hWallet.getShieldedUnblindingForTx('spendA');
+    // Owned-parent input is included with the input position in the current tx
+    // (`index: 0`). The foreign-parent input is silently skipped — the wallet
+    // has no opening for it.
+    expect(result.inputs).toEqual([
+      { index: 0, value: 777n, token: '00', vbf: 'parentVbf', abf: 'parentAbf' },
+    ]);
+  });
+});
+
+describe('onNewTx shielded handling (SEPARATED model)', () => {
+  const TX_ID = 'ab'.repeat(32); // 64-char hex tx_id
+
+  // A bare wire shielded output (commitment-only, value-less) as the fullnode
+  // re-delivers it after the wallet already decoded the slot once.
+  const bareWireShielded = () => ({
+    mode: 1,
+    commitment: 'aa',
+    range_proof: 'bb',
+    script: 'cc',
+    token_data: 0,
+    ephemeral_pubkey: 'dd',
+    decoded: { type: 'P2PKH', address: 'addrShielded', timelock: null },
+    spent_by: null,
+  });
+
+  // The wire form of a re-delivered tx: transparent output(s) in outputs[],
+  // bare value-less shielded entries in shielded_outputs[].
+  const reDeliveredWire = () => ({
+    tx_id: TX_ID,
+    version: 1,
+    weight: 1,
+    timestamp: 1,
+    is_voided: false,
+    nonce: 0,
+    inputs: [],
+    outputs: [
+      {
+        value: 100n,
+        token_data: 0,
+        token: '00',
+        script: '',
+        spent_by: null,
+        decoded: { type: 'P2PKH', address: 'addr1', timelock: null },
+      },
+    ],
+    shielded_outputs: [bareWireShielded()],
+    parents: [],
+  });
+
+  test('per-slot merge preserves decoded shielded data across a bare re-delivery', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+    hWallet.state = HathorWallet.READY;
+    hWallet.pinCode = null;
+    hWallet.emit = () => {};
+    hWallet.scanAddressesToLoad = jest.fn().mockResolvedValue(undefined);
+
+    // The processing branches must not clobber our merged data; stub them.
+    jest.spyOn(storage, 'processNewTx').mockResolvedValue(undefined);
+    jest.spyOn(storage, 'processHistory').mockResolvedValue(undefined);
+    jest.spyOn(storageUtils, 'processMetadataChanged').mockResolvedValue(undefined);
+
+    // Storage already holds the DECODED tx — owned-marker fields are written in
+    // place on shielded_outputs[0] (value/token/blinding present).
+    const decodedStored = reDeliveredWire();
+    decodedStored.shielded_outputs[0] = {
+      ...bareWireShielded(),
+      value: 250n,
+      token: '00',
+      blindingFactor: 'cafe',
+      decoded: { type: 'P2PKH', address: 'addrShielded', timelock: null },
+    };
+    await storage.addTx(decodedStored as unknown as IHistoryTx);
+
+    // A bare WS re-delivery arrives: shielded_outputs[] present but value-less.
+    await hWallet.onNewTx({ type: 'wallet:address_history', history: reDeliveredWire() });
+
+    const persisted = await storage.getTx(TX_ID);
+    // The decoded owned-marker fields survived the re-delivery (per-slot merge).
+    expect(persisted.shielded_outputs[0].value).toBe(250n);
+    expect(persisted.shielded_outputs[0].token).toBe('00');
+    expect(persisted.shielded_outputs[0].blindingFactor).toBe('cafe');
+    // Transparent balance is untouched.
+    expect(persisted.outputs[0].value).toBe(100n);
+  });
+
+  test('needsRetry does NOT run processHistory for a tx the wallet owns no shielded output of', async () => {
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+    hWallet.state = HathorWallet.READY;
+    // Crypto provider + pinCode present so the safety-net branch is reachable.
+    hWallet.pinCode = '1234';
+    storage.shieldedCryptoProvider = {} as never;
+    hWallet.emit = () => {};
+    hWallet.scanAddressesToLoad = jest.fn().mockResolvedValue(undefined);
+
+    const processHistorySpy = jest.spyOn(storage, 'processHistory').mockResolvedValue(undefined);
+    jest.spyOn(storage, 'processNewTx').mockResolvedValue(undefined);
+    jest.spyOn(storageUtils, 'processMetadataChanged').mockResolvedValue(undefined);
+    // The stored undecoded shielded slot's address is FOREIGN — not ours.
+    jest.spyOn(storage, 'isAddressMine').mockResolvedValue(false);
+
+    // Storage holds a tx with a value-less shielded slot whose decoded.address
+    // is not one of the wallet's addresses (fully non-owned shielded tx).
+    const foreignTx = {
+      ...reDeliveredWire(),
+      tx_id: 'cd'.repeat(32),
+    };
+    await storage.addTx(foreignTx as unknown as IHistoryTx);
+
+    // An unrelated new tx arrives (no shielded data).
+    const unrelated = {
+      tx_id: 'ef'.repeat(32),
+      version: 1,
+      weight: 1,
+      timestamp: 2,
+      is_voided: false,
+      nonce: 0,
+      inputs: [],
+      outputs: [
+        {
+          value: 5n,
+          token_data: 0,
+          token: '00',
+          script: '',
+          spent_by: null,
+          decoded: { type: 'P2PKH', address: 'addr1', timelock: null },
+        },
+      ],
+      parents: [],
+    };
+    await hWallet.onNewTx({ type: 'wallet:address_history', history: unrelated });
+
+    // isNewTx path calls processNewTx, but the safety-net must NOT trigger a
+    // processHistory because the only shielded tx in storage is fully foreign.
+    expect(processHistorySpy).not.toHaveBeenCalled();
+  });
+});
+
 test('isHardwareWallet', async () => {
   const store = new MemoryStore();
   const storage = new Storage(store);
@@ -1604,5 +1935,133 @@ describe('hasTxOutsideFirstAddress', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe('getAddressInfo shielded accounting (SEPARATED model)', () => {
+  // SEPARATED model: owned shielded outputs are decoded in place onto
+  // tx.shielded_outputs[] (value/token written after decryption) with
+  // decoded.address = the shielded-spend P2PKH. getAddressInfo mirrors the
+  // transparent accounting over shielded_outputs so a shielded receive/spend on
+  // the queried address is reflected in the per-address totals.
+  //
+  // A shielded slot is wallet-OWNED only when so.value !== undefined; a slot is
+  // spent when so.spent_by is non-null; a slot is locked when its decoded
+  // timelock is in the future (height/reward lock stays off here since the
+  // store's bestBlockHeight is 0 and storage.version is undefined).
+  test('sums received/sent/locked/available over owned shielded outputs only', async () => {
+    const ownedAddress = 'addrOwned';
+    const token = '00';
+    const futureTimelock = Math.floor(Date.now() / 1000) + 3600;
+
+    // A history tx whose shielded_outputs[] cover every accounting branch for
+    // the queried (ownedAddress, token):
+    //   A: owned, unspent, unlocked  -> received + available
+    //   B: owned, spent              -> received + sent (and nothing else)
+    //   C: owned, locked (timelock)  -> received + locked (not available)
+    //   D: non-owned (value=undef)   -> excluded from every total
+    //   E: owned but wrong token     -> excluded (token filter)
+    //   F: owned but wrong address   -> excluded (address filter)
+    const tx = {
+      tx_id: 'shieldedTx',
+      timestamp: 1,
+      version: 1,
+      weight: 1,
+      nonce: 0,
+      height: 0,
+      is_voided: false,
+      parents: [],
+      inputs: [],
+      outputs: [],
+      shielded_outputs: [
+        // A: owned, unspent, unlocked
+        {
+          mode: 1,
+          commitment: 'aa',
+          spent_by: null,
+          token,
+          value: 250n,
+          blindingFactor: 'cafe',
+          decoded: { type: 'P2PKH', address: ownedAddress, timelock: null },
+        },
+        // B: owned, spent
+        {
+          mode: 1,
+          commitment: 'bb',
+          spent_by: 'spendTx',
+          token,
+          value: 100n,
+          blindingFactor: 'beef',
+          decoded: { type: 'P2PKH', address: ownedAddress, timelock: null },
+        },
+        // C: owned, time-locked
+        {
+          mode: 1,
+          commitment: 'cc',
+          spent_by: null,
+          token,
+          value: 70n,
+          blindingFactor: 'face',
+          decoded: { type: 'P2PKH', address: ownedAddress, timelock: futureTimelock },
+        },
+        // D: non-owned (value undefined) -> skipped before any total
+        {
+          mode: 1,
+          commitment: 'dd',
+          spent_by: null,
+          decoded: { type: 'P2PKH', address: ownedAddress, timelock: null },
+        },
+        // E: owned but a different token -> token filter excludes it
+        {
+          mode: 1,
+          commitment: 'ee',
+          spent_by: null,
+          token: '0102',
+          value: 500n,
+          blindingFactor: 'dead',
+          decoded: { type: 'P2PKH', address: ownedAddress, timelock: null },
+        },
+        // F: owned but a different address -> address filter excludes it
+        {
+          mode: 1,
+          commitment: 'ff',
+          spent_by: null,
+          token,
+          value: 999n,
+          blindingFactor: 'feed',
+          decoded: { type: 'P2PKH', address: 'addrOther', timelock: null },
+        },
+      ],
+    } as unknown as IHistoryTx;
+
+    const store = new MemoryStore();
+    const storage = new Storage(store);
+    async function* txHistoryMock() {
+      yield tx;
+    }
+    jest.spyOn(storage, 'txHistory').mockImplementation(txHistoryMock);
+    jest.spyOn(storage, 'isAddressMine').mockResolvedValue(true);
+    jest
+      .spyOn(storage, 'getAddressInfo')
+      .mockResolvedValue({ bip32AddressIndex: 7 } as unknown as ReturnType<
+        typeof storage.getAddressInfo
+      >);
+
+    const hWallet = new FakeHathorWallet();
+    hWallet.storage = storage;
+
+    const info = await hWallet.getAddressInfo(ownedAddress, { token });
+
+    // Hand-computed expectations over the owned, matching-token slots A/B/C:
+    //   received  = 250 + 100 + 70 = 420
+    //   sent      = 100             (only the spent slot B)
+    //   locked    = 70              (only the time-locked slot C)
+    //   available = 250             (only the unspent, unlocked slot A)
+    expect(info.total_amount_received).toBe(420n);
+    expect(info.total_amount_sent).toBe(100n);
+    expect(info.total_amount_locked).toBe(70n);
+    expect(info.total_amount_available).toBe(250n);
+    expect(info.token).toBe(token);
+    expect(info.index).toBe(7);
   });
 });

--- a/__tests__/new/sendTransaction.test.ts
+++ b/__tests__/new/sendTransaction.test.ts
@@ -5,20 +5,27 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { HDPrivateKey } from 'bitcore-lib';
-import { TOKEN_AUTHORITY_MASK, NATIVE_TOKEN_UID } from '../../src/constants';
+import { HDPrivateKey, PrivateKey } from 'bitcore-lib';
+import {
+  FEE_PER_AMOUNT_SHIELDED_OUTPUT,
+  FEE_PER_FULL_SHIELDED_OUTPUT,
+  NATIVE_TOKEN_UID,
+  TOKEN_AUTHORITY_MASK,
+} from '../../src/constants';
+import Network from '../../src/models/network';
 import SendTransaction, {
   isDataOutput,
   checkUnspentInput,
+  convertHtrChangeIfRequested,
   prepareSendTokensData,
 } from '../../src/new/sendTransaction';
+import { ShieldedOutputMode } from '../../src/shielded/types';
 import { MemoryStore, Storage } from '../../src/storage';
 import { WalletType } from '../../src/types';
+import { encodeShieldedAddress } from '../../src/utils/shieldedAddress';
 import transaction from '../../src/utils/transaction';
 import { OutputType } from '../../src/wallet/types';
 import { mockGetToken } from '../__mock_helpers__/get-token.mock';
-import { encodeShieldedAddress } from '../../src/utils/shieldedAddress';
-import Network from '../../src/models/network';
 
 test('prepareTxData rejects a shielded address in a transparent output', async () => {
   const store = new MemoryStore();
@@ -541,5 +548,206 @@ describe('releaseUtxos', () => {
     await sendTx.releaseUtxos(); // should not throw
 
     expect(utxoSelectSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('convertHtrChangeIfRequested', () => {
+  // Build a fresh real shielded testnet address per test so the helper
+  // can extract scanPubkey + spend P2PKH the same way the production
+  // `sendManyOutputsSendTransaction` does. Reusing the same network
+  // across tests is fine — the helper doesn't cache anything.
+  const testnetNetwork = new Network('testnet');
+
+  // Real EC pubkeys (compressed, 33 bytes) so the helper's
+  // `getSpendAddress()` call can derive a valid P2PKH instead of
+  // throwing on a malformed point. We don't need deterministic keys
+  // here — only that they parse.
+  const buildShieldedAddress = (): string => {
+    const scanPubkey = new PrivateKey().toPublicKey().toBuffer();
+    const spendPubkey = new PrivateKey().toPublicKey().toBuffer();
+    return encodeShieldedAddress(scanPubkey, spendPubkey, testnetNetwork);
+  };
+
+  const buildHtrChangeOutput = (value: bigint) => ({
+    type: 'p2pkh' as const,
+    address: 'transparent-change-address',
+    value,
+    token: NATIVE_TOKEN_UID,
+    authorities: 0n,
+    timelock: null,
+    isChange: true,
+  });
+
+  const buildShieldedDef = (mode: ShieldedOutputMode) => ({
+    type: OutputType.P2PKH as OutputType.P2PKH,
+    address: 'spend-P2PKH-of-recipient',
+    value: 10n,
+    token: '01',
+    scanPubkey: 'aa'.repeat(33),
+    shieldedMode: mode,
+  });
+
+  const mockWallet = (shieldedAddress: string) =>
+    ({
+      getCurrentAddress: jest.fn().mockResolvedValue({
+        address: shieldedAddress,
+        index: 0,
+        addressPath: 'm/0',
+      }),
+    }) as unknown as import('../../src/new/wallet').default;
+
+  test('H.1 — converts transparent HTR change to FS', async () => {
+    const partialHtrTxData = {
+      inputs: [],
+      outputs: [buildHtrChangeOutput(100n)],
+    };
+    const defs = [
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+    ];
+
+    const result = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      defs,
+      ShieldedOutputMode.FULLY_SHIELDED,
+      mockWallet(buildShieldedAddress()),
+      testnetNetwork
+    );
+
+    expect(result.addedFee).toBe(FEE_PER_FULL_SHIELDED_OUTPUT);
+    // Transparent change removed.
+    expect(partialHtrTxData.outputs).toHaveLength(0);
+    // Shielded HTR change appended.
+    expect(defs).toHaveLength(3);
+    const htrChange = defs[2];
+    expect(htrChange.token).toBe(NATIVE_TOKEN_UID);
+    expect(htrChange.shieldedMode).toBe(ShieldedOutputMode.FULLY_SHIELDED);
+    expect(htrChange.value).toBe(100n - FEE_PER_FULL_SHIELDED_OUTPUT);
+    // scanPubkey is hex-encoded 33 bytes (66 hex chars).
+    expect(htrChange.scanPubkey).toMatch(/^[0-9a-f]{66}$/);
+  });
+
+  test('H.2 — converts transparent HTR change to AS', async () => {
+    const partialHtrTxData = {
+      inputs: [],
+      outputs: [buildHtrChangeOutput(100n)],
+    };
+    const defs = [
+      buildShieldedDef(ShieldedOutputMode.AMOUNT_SHIELDED),
+      buildShieldedDef(ShieldedOutputMode.AMOUNT_SHIELDED),
+    ];
+
+    const result = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      defs,
+      ShieldedOutputMode.AMOUNT_SHIELDED,
+      mockWallet(buildShieldedAddress()),
+      testnetNetwork
+    );
+
+    expect(result.addedFee).toBe(FEE_PER_AMOUNT_SHIELDED_OUTPUT);
+    expect(partialHtrTxData.outputs).toHaveLength(0);
+    expect(defs).toHaveLength(3);
+    expect(defs[2].shieldedMode).toBe(ShieldedOutputMode.AMOUNT_SHIELDED);
+    expect(defs[2].value).toBe(100n - FEE_PER_AMOUNT_SHIELDED_OUTPUT);
+  });
+
+  test('H.3 — no-op when mode is null', async () => {
+    const partialHtrTxData = {
+      inputs: [],
+      outputs: [buildHtrChangeOutput(100n)],
+    };
+    const defs = [
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+    ];
+
+    const result = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      defs,
+      null,
+      mockWallet(buildShieldedAddress()),
+      testnetNetwork
+    );
+
+    expect(result.addedFee).toBe(0n);
+    expect(partialHtrTxData.outputs).toHaveLength(1);
+    expect(defs).toHaveLength(2);
+  });
+
+  test('H.4 — no-op when change value <= additionalFee', async () => {
+    // Edge: change exactly equals the FEE → conversion would zero-out
+    // the resulting shielded value, which is strictly worse than
+    // keeping the transparent change (we'd be silently destroying
+    // funds via the fee).
+    const partialHtrTxData = {
+      inputs: [],
+      outputs: [buildHtrChangeOutput(FEE_PER_FULL_SHIELDED_OUTPUT)],
+    };
+    const defs = [
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+    ];
+
+    const result = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      defs,
+      ShieldedOutputMode.FULLY_SHIELDED,
+      mockWallet(buildShieldedAddress()),
+      testnetNetwork
+    );
+
+    expect(result.addedFee).toBe(0n);
+    expect(partialHtrTxData.outputs).toHaveLength(1);
+    expect(defs).toHaveLength(2);
+  });
+
+  test('H.5 — no-op when no HTR change output present', async () => {
+    // All HTR was consumed exactly by the fee — `prepareSendTokensData`
+    // would have emitted no `isChange: true` HTR entry, so there's
+    // nothing for us to convert.
+    const partialHtrTxData = {
+      inputs: [],
+      outputs: [],
+    };
+    const defs = [
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+      buildShieldedDef(ShieldedOutputMode.FULLY_SHIELDED),
+    ];
+
+    const result = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      defs,
+      ShieldedOutputMode.FULLY_SHIELDED,
+      mockWallet(buildShieldedAddress()),
+      testnetNetwork
+    );
+
+    expect(result.addedFee).toBe(0n);
+    expect(defs).toHaveLength(2);
+  });
+
+  test('H.6 — no-op when shieldedOutputDefs is empty (defensive)', async () => {
+    // A pure-transparent tx that somehow received `changeShieldedMode`
+    // should NOT have its HTR change converted — the resulting tx
+    // would have exactly one shielded output, violating the `>= 2`
+    // invariant enforced later in prepareTxData.
+    const partialHtrTxData = {
+      inputs: [],
+      outputs: [buildHtrChangeOutput(100n)],
+    };
+    const defs: ReturnType<typeof buildShieldedDef>[] = [];
+
+    const result = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      defs,
+      ShieldedOutputMode.FULLY_SHIELDED,
+      mockWallet(buildShieldedAddress()),
+      testnetNetwork
+    );
+
+    expect(result.addedFee).toBe(0n);
+    expect(partialHtrTxData.outputs).toHaveLength(1);
+    expect(defs).toHaveLength(0);
   });
 });

--- a/__tests__/schemas.test.ts
+++ b/__tests__/schemas.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { addressHistorySchema } from '../src/api/schemas/wallet';
+import { IHistoryInputSchema } from '../src/schemas';
+import transactionUtils from '../src/utils/transaction';
+import { IHistoryTx } from '../src/types';
+
+/**
+ * Regression coverage for the `thin_wallet/address_history` response schema.
+ *
+ * The SEPARATED-model rework added a `type` discriminator to history inputs to
+ * mark shielded spends. The alpha fullnode also stamps `type: "transparent"` on
+ * ordinary transparent inputs — so a schema that only accepts the literal
+ * "shielded" (or absent) rejects every transparent input, which throws while
+ * loading wallet history and bricks every wallet start. These tests pin the
+ * accepted shapes so the schema can never regress to fail-closed on a plain
+ * transparent input again.
+ */
+describe('addressHistorySchema — history input `type` discriminator', () => {
+  // A real genesis funding tx as returned by the alpha fullnode: a single
+  // transparent input carrying `type: "transparent"`, two transparent outputs.
+  const transparentInput = {
+    value: 100000000000n,
+    token_data: 0,
+    script: 'dqkUZmZbJ/fbxMjAidL2hsFwx01m8LWIrA==',
+    decoded: { type: 'P2PKH', address: 'WY1URKUnqCTyiixW1Dw29vmeG99hNN4EW6', timelock: null },
+    token: '00',
+    type: 'transparent',
+    tx_id: '00000334a21fbb58b4db8d7ff282d018e03e2977abd3004cf378fb1d677c3967',
+    index: 0,
+  };
+
+  const transparentOutput = {
+    value: 99999999000n,
+    token_data: 0,
+    script: 'dqkUC0ZxRSSEE4r0LK+clnbZUaB1IyyIrA==',
+    decoded: { type: 'P2PKH', address: 'WPhehTyNHTPz954CskfuSgLEfuKXbXeK3f', timelock: null },
+    token: '00',
+    spent_by: null,
+  };
+
+  const makeHistoryResponse = (input: Record<string, unknown>) => ({
+    success: true,
+    history: [
+      {
+        tx_id: '7a274493f738aa59572ea1a0fdce0d765dd8a28ca47d5c73b2f68c6ce76134cf',
+        version: 1,
+        weight: 1.0,
+        timestamp: 1781753958,
+        is_voided: false,
+        inputs: [input],
+        outputs: [transparentOutput],
+        parents: [
+          '54165cef1fd4cf2240d702b8383c307c822c16ca407f78014bdefa189a7571c2',
+          '039906854ce6309b3180945f2a23deb9edff369753f7082e19053f5ac11bfbae',
+        ],
+        tokens: [],
+      },
+    ],
+    has_more: false,
+    first_hash: null,
+    first_address: null,
+  });
+
+  it('accepts an explicit transparent input (`type: "transparent"`)', () => {
+    const result = addressHistorySchema.safeParse(makeHistoryResponse(transparentInput));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a transparent input that omits `type` (older fullnodes)', () => {
+    const { type: _type, ...noType } = transparentInput;
+    const result = addressHistorySchema.safeParse(makeHistoryResponse(noType));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a shielded input (`type: "shielded"`)', () => {
+    const shieldedInput = {
+      tx_id: '00000334a21fbb58b4db8d7ff282d018e03e2977abd3004cf378fb1d677c3967',
+      index: 0,
+      type: 'shielded',
+      commitment: '02abcdef',
+    };
+    const result = addressHistorySchema.safeParse(makeHistoryResponse(shieldedInput));
+    expect(result.success).toBe(true);
+  });
+
+  it('IHistoryInputSchema accepts both transparent and shielded discriminators', () => {
+    expect(IHistoryInputSchema.safeParse(transparentInput).success).toBe(true);
+    expect(
+      IHistoryInputSchema.safeParse({ tx_id: transparentInput.tx_id, index: 0, type: 'shielded' })
+        .success
+    ).toBe(true);
+  });
+});
+
+/**
+ * Coverage for the SEPARATED-model wire.
+ *
+ * The fullnode delivers shielded outputs in a dedicated top-level
+ * `shielded_outputs[]` array on every path (HTTP `/transaction` and
+ * `address_history` + WS), so `outputs[]` is transparent-only and
+ * `normalizeShieldedOutputs` is a hex-only pass — no inline `type: 'shielded'`
+ * entry in `outputs[]` to accept or relocate. These tests pin that invariant:
+ * the schema accepts the separated shape, rejects an inline shielded entry in
+ * `outputs[]`, and normalize converts the confidential fields in place.
+ */
+describe('addressHistorySchema — separated shielded_outputs[]', () => {
+  // A separated shielded output as emitted by the fullnode: hex
+  // commitment, base64 range_proof/script, hex ephemeral_pubkey, address-only
+  // decoded, `mode` present. `range_proof` is base64 "abcd" to assert hex conversion.
+  const shieldedOutput = {
+    mode: 1,
+    commitment: '09fbb71fb77f29184e414aa0ebda936eac97738b749247c6597be233697f1efc6c',
+    range_proof: 'YWJjZA==', // base64("abcd") -> hex "61626364"
+    script: 'dqkUF7S4s7xJDTbP3RtOd8pqL961GpaIrA==',
+    ephemeral_pubkey: '02f924f2c619c63bfebb3657a6d464fd7358bace065d804a8e3c37a9c8c996a05b',
+    token_data: 0,
+    decoded: { address: 'WQqNv68SWbgULkMXfNtwM7gdRGcgUa5oab' },
+    spent_by: null,
+    token: '00',
+  };
+
+  // Plain number `value` (not bigint) so the JSON clone in the normalize test
+  // works; bigIntCoercibleSchema coerces it.
+  const transparentOutput = {
+    value: 60,
+    token_data: 0,
+    script: 'dqkU+m9UioQSJyfKgU/p334z9ecz24KIrA==',
+    decoded: { type: 'P2PKH', address: 'WmWDBFDRs4s4j6rXded6HLEvCMo51LkbXA', timelock: null },
+    token: '00',
+    spent_by: null,
+  };
+
+  const historyTx = {
+    tx_id: '2949aeadd060f6ffbbcb40c88fe60166a0585d5a8e27e49d220c1b54cf16ad81',
+    version: 1,
+    weight: 1.0,
+    timestamp: 1781756639,
+    is_voided: false,
+    inputs: [],
+    outputs: [transparentOutput],
+    shielded_outputs: [shieldedOutput],
+    parents: [],
+    tokens: [],
+  };
+
+  it('accepts a tx with transparent outputs[] and a separated shielded_outputs[]', () => {
+    const result = addressHistorySchema.safeParse({
+      success: true,
+      history: [historyTx],
+      has_more: false,
+      first_hash: null,
+      first_address: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an inline shielded entry (no `value`) in outputs[] — outputs[] is transparent-only', () => {
+    const badTx = {
+      ...historyTx,
+      outputs: [transparentOutput, { type: 'shielded', commitment: 'ab'.repeat(33) }],
+      shielded_outputs: [],
+    };
+    const result = addressHistorySchema.safeParse({
+      success: true,
+      history: [badTx],
+      has_more: false,
+      first_hash: null,
+      first_address: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('normalizeShieldedOutputs converts shielded_outputs[] confidential fields in place (no relocation)', () => {
+    // Clone so the shared fixture is not mutated in place.
+    const tx = JSON.parse(JSON.stringify(historyTx)) as unknown as IHistoryTx;
+    transactionUtils.normalizeShieldedOutputs(tx);
+
+    // outputs[] is untouched (transparent-only); the shielded entry stays put.
+    expect(tx.outputs).toHaveLength(1);
+    expect((tx.outputs[0] as { value?: unknown }).value).toBeDefined();
+    expect(tx.shielded_outputs).toHaveLength(1);
+
+    const so = tx.shielded_outputs![0];
+    // commitment was already hex -> unchanged; range_proof base64 -> hex.
+    expect(so.commitment).toBe(shieldedOutput.commitment);
+    expect(so.range_proof).toBe('61626364');
+    expect(so.range_proof).toMatch(/^[0-9a-f]+$/);
+    expect(so.spent_by).toBeNull();
+  });
+});

--- a/__tests__/template/transaction/executor.test.ts
+++ b/__tests__/template/transaction/executor.test.ts
@@ -965,3 +965,55 @@ describe('execFeeInstruction', () => {
     expect(ctx.fees.get(token2)).toBe(200n);
   });
 });
+
+describe('shielded inputs are rejected in templates (SEPARATED model)', () => {
+  it('execRawInputInstruction rejects an input whose index lands in the shielded range', async () => {
+    // Parent has 1 transparent output (T=1) and 1 shielded output. The on-chain
+    // absolute index of the shielded slot is T + 0 = 1, which is >= outputs.length.
+    const interpreter = {
+      getTx: jest.fn().mockResolvedValue({
+        outputs: [{ value: 10n, token, token_data: 1 }],
+        shielded_outputs: [
+          {
+            mode: 1,
+            commitment: 'aa',
+            range_proof: '',
+            script: '',
+            token_data: 0,
+            ephemeral_pubkey: '',
+            decoded: { type: 'P2PKH', address, timelock: null },
+          },
+        ],
+      }),
+    };
+    const ctx = new TxTemplateContext(getDefaultLogger(), DEBUG);
+    const ins = RawInputInstruction.parse({ type: 'input/raw', index: 1, txId });
+
+    await expect(execRawInputInstruction(interpreter, ctx, ins)).rejects.toThrow(
+      'Shielded inputs are not supported in transaction templates'
+    );
+  });
+
+  it('addBalanceFromUtxo throws a clear error for a shielded slot index', () => {
+    const ctx = new TxTemplateContext(getDefaultLogger(), DEBUG);
+    const tx = {
+      outputs: [{ value: 10n, token, token_data: 1, decoded: { address } }],
+      shielded_outputs: [
+        {
+          mode: 1,
+          commitment: 'aa',
+          range_proof: '',
+          script: '',
+          token_data: 0,
+          ephemeral_pubkey: '',
+          decoded: { type: 'P2PKH', address, timelock: null },
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+    // index 1 == outputs.length + 0 → shielded slot
+    expect(() => ctx.balance.addBalanceFromUtxo(tx, 1)).toThrow(
+      'Shielded inputs are not supported in transaction templates'
+    );
+  });
+});

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -147,6 +147,9 @@ test('getSignatureForTx signing nano contract when we are not the caller', async
     addressIndex: 10,
     signature: expect.anything(),
     pubkey: xpriv.derive(10).publicKey.toDER(),
+    // Legacy (P2PKH) input → addressType undefined; shielded-spend inputs carry
+    // 'shielded-spend' so getSignatures can render the spend-chain path.
+    addressType: undefined,
   });
 
   const hashdata = tx.getDataToSignHash();
@@ -920,4 +923,54 @@ describe('prepareTransaction threads weight constants from storage', () => {
     // otherwise the test couldn't distinguish the two paths.
     expect(tx.weight).not.toBeCloseTo(tx.calculateWeight(), 1);
   });
+});
+
+test('getSignatureForTx uses spend key chain for shielded-spend addresses', async () => {
+  const legacyXpriv = new HDPrivateKey();
+  const spendXpriv = new HDPrivateKey();
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+
+  jest.spyOn(storage, 'getMainXPrivKey').mockResolvedValue(legacyXpriv.xprivkey);
+  jest
+    .spyOn(storage, 'getSpendXPrivKey')
+    .mockResolvedValue(spendXpriv.deriveNonCompliantChild(0).xprivkey);
+
+  // Use a non-zero index to verify the derivation path actually uses bip32AddressIndex
+  // (index 0 can pass even if the production path ignores the index).
+  const shieldedAddr = 'shielded-spend-addr';
+  const addressIndex = 3;
+  jest.spyOn(storage, 'getAddressInfo').mockImplementation(async addr => {
+    if (addr === shieldedAddr) {
+      return {
+        base58: addr,
+        bip32AddressIndex: addressIndex,
+        addressType: 'shielded-spend' as const,
+      };
+    }
+    return null;
+  });
+
+  // The spent output is transparent (positionally at index 0); resolveSpentOutput
+  // returns it as `{ kind: 'transparent', output }`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function* getSpentMock(inputs: any) {
+    yield {
+      index: 0,
+      input: inputs[0],
+      tx: { outputs: [{ decoded: { address: shieldedAddr } }] },
+    };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  jest.spyOn(storage, 'getSpentTxs').mockImplementation(getSpentMock as any);
+
+  const input = new Input('cafe'.repeat(8), 0);
+  const tx = new Transaction([input], []);
+
+  const sigData = await transaction.getSignatureForTx(tx, storage, '123');
+
+  expect(sigData.inputSignatures).toHaveLength(1);
+  expect(sigData.inputSignatures[0].addressIndex).toBe(addressIndex);
+  // getSpendXPrivKey should have been called (not just getMainXPrivKey)
+  expect(storage.getSpendXPrivKey).toHaveBeenCalledWith('123');
 });

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -207,6 +207,7 @@ describe('normalizeShieldedOutputs', () => {
       [makeTransparentOutput(1n, 'A')],
       [
         {
+          mode: ShieldedOutputMode.AMOUNT_SHIELDED,
           commitment: 'ab'.repeat(33),
           range_proof: '0102ff',
           script: 'aa',
@@ -215,10 +216,14 @@ describe('normalizeShieldedOutputs', () => {
         },
       ]
     );
-    const before = JSON.stringify(tx.shielded_outputs);
     transactionUtils.normalizeShieldedOutputs(tx);
     expect(tx.outputs).toHaveLength(1);
-    expect(JSON.stringify(tx.shielded_outputs)).toBe(before);
+    // `mode` from the wire is preserved untouched.
+    expect(tx.shielded_outputs![0].mode).toBe(ShieldedOutputMode.AMOUNT_SHIELDED);
+    // A second pass is a no-op (true idempotency: f(f(x)) === f(x)).
+    const afterFirst = JSON.stringify(tx.shielded_outputs);
+    transactionUtils.normalizeShieldedOutputs(tx);
+    expect(JSON.stringify(tx.shielded_outputs)).toBe(afterFirst);
   });
 
   it('preserves owned-marker fields while converting an owned shielded entry', () => {
@@ -284,6 +289,43 @@ describe('normalizeShieldedOutputs', () => {
     transactionUtils.normalizeShieldedOutputs(tx);
     expect(tx.shielded_outputs![0].asset_commitment).toBe('aa');
     expect(tx.shielded_outputs![0].surjection_proof).toBe('bb');
+  });
+
+  it('preserves the wire `mode` on every entry untouched (fullnode always sends it)', () => {
+    // The fullnode always emits `mode`; normalizeShieldedOutputs is a
+    // hex-only pass and must leave `mode` verbatim on both FullShielded and
+    // AmountShielded entries (it neither derives nor overwrites it).
+    const b64 = (byte: number) => Buffer.from([byte]).toString('base64');
+    const tx = makeTx(
+      [makeTransparentOutput(1n, 'A')],
+      [
+        {
+          mode: ShieldedOutputMode.FULLY_SHIELDED,
+          commitment: 'ab'.repeat(33),
+          range_proof: b64(0x01),
+          script: b64(0x02),
+          ephemeral_pubkey: b64(0x03),
+          asset_commitment: b64(0xaa),
+          surjection_proof: b64(0xbb),
+          decoded: {},
+          spent_by: null,
+        },
+        {
+          mode: ShieldedOutputMode.AMOUNT_SHIELDED,
+          commitment: 'cd'.repeat(33),
+          range_proof: b64(0x04),
+          script: b64(0x05),
+          ephemeral_pubkey: b64(0x06),
+          token_data: 0,
+          decoded: {},
+          spent_by: null,
+        },
+      ]
+    );
+
+    transactionUtils.normalizeShieldedOutputs(tx);
+    expect(tx.shielded_outputs![0].mode).toBe(ShieldedOutputMode.FULLY_SHIELDED);
+    expect(tx.shielded_outputs![1].mode).toBe(ShieldedOutputMode.AMOUNT_SHIELDED);
   });
 });
 

--- a/src/api/schemas/txApi.ts
+++ b/src/api/schemas/txApi.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import { bigIntCoercibleSchema } from '../../utils/bigint';
-import { IHistoryNanoContractContextSchema } from '../../schemas';
+import { IHistoryNanoContractContextSchema, shieldedOutputWireShape } from '../../schemas';
 
 const p2pkhDecodedScriptSchema = z.object({
   type: z.literal('P2PKH'),
@@ -38,7 +38,7 @@ export const decodedSchema = z.discriminatedUnion('type', [
   unknownDecodedScriptSchema,
 ]);
 
-export const fullnodeTxApiInputSchema = z.object({
+const fullnodeTxApiTransparentInputSchema = z.object({
   value: bigIntCoercibleSchema,
   token_data: z.number(),
   script: z.string(),
@@ -48,6 +48,22 @@ export const fullnodeTxApiInputSchema = z.object({
   token: z.string().nullish(),
 });
 
+// Shielded inputs expose only a commitment + range proof on the wire; the
+// amount, token and spender are hidden. Additional fields may be added by the
+// fullnode over time, so we passthrough unknown keys instead of rejecting.
+const fullnodeTxApiShieldedInputSchema = z
+  .object({
+    type: z.literal('shielded'),
+    commitment: z.string(),
+    range_proof: z.string(),
+  })
+  .passthrough();
+
+export const fullnodeTxApiInputSchema = z.union([
+  fullnodeTxApiShieldedInputSchema,
+  fullnodeTxApiTransparentInputSchema,
+]);
+
 export const fullnodeTxApiOutputSchema = z.object({
   value: bigIntCoercibleSchema,
   token_data: z.number(),
@@ -56,6 +72,33 @@ export const fullnodeTxApiOutputSchema = z.object({
   token: z.string().nullish(),
   spent_by: z.string().nullable().default(null),
 });
+
+// Shielded outputs hide their value behind a Pedersen commitment, so the
+// `decoded` block carries only address-side fields (no `value` /
+// `token_data` like transparent outputs). Matches `IShieldedOutputDecoded`
+// in src/shielded/types.ts and what `_shielded_output_to_json` in
+// hathor-core's base_transaction.py emits.
+const shieldedDecodedSchema = z
+  .object({
+    type: z.string().optional(),
+    address: z.string().optional(),
+    timelock: z.number().nullish(),
+  })
+  .passthrough();
+
+// Shielded outputs as emitted by the fullnode's tx API. Mirrors
+// `IShieldedOutput` (src/shielded/types.ts) plus the optional FullShielded
+// extensions and the `spent_by` flag that the fullnode populates the same
+// way it does for transparent outputs (see hathor-core
+// `_shielded_output_to_json` in base_transaction.py and
+// `meta.get_output_spent_by`). `.passthrough()` keeps any new
+// forward-compat fields the fullnode might add without rejecting the tx.
+export const fullnodeTxApiShieldedOutputSchema = z
+  .object({
+    ...shieldedOutputWireShape,
+    decoded: shieldedDecodedSchema,
+  })
+  .passthrough();
 
 export const fullnodeTxApiTokenSchema = z.object({
   uid: z.string(),
@@ -80,6 +123,8 @@ export const fullnodeTxApiTxSchema = z.object({
   nc_blueprint_id: z.string().nullish(),
   inputs: fullnodeTxApiInputSchema.array(),
   outputs: fullnodeTxApiOutputSchema.array(),
+  shielded_inputs: fullnodeTxApiShieldedInputSchema.array().nullish(),
+  shielded_outputs: fullnodeTxApiShieldedOutputSchema.array().nullish(),
   tokens: fullnodeTxApiTokenSchema.array(),
   token_name: z.string().nullish(),
   token_symbol: z.string().nullish(),

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -60,6 +60,7 @@ import {
 import { stopGLLBackgroundTask } from './sync/gll';
 import * as enums from './models/enum';
 import { Fee } from './utils/fee';
+import * as shielded from './shielded';
 
 export {
   PartialTx,
@@ -124,6 +125,7 @@ export {
   WalletTxTemplateInterpreter,
   stopGLLBackgroundTask,
   enums,
+  shielded,
 };
 
 // Re-export all types from every module.

--- a/src/models/partial_tx.ts
+++ b/src/models/partial_tx.ts
@@ -480,6 +480,12 @@ export class PartialTx {
               return resolve(false);
             }
 
+            // Partial transactions are a transparent-only flow; reject an input
+            // whose index lands in the shielded range with a clear error rather
+            // than silently resolving false (which would look like a mismatch).
+            if (transactionUtils.isShieldedOutputIndex(data.tx, input.index)) {
+              return reject(new Error('Shielded inputs are not supported in partial transactions'));
+            }
             if (data.tx.outputs.length <= input.index) {
               return resolve(false);
             }

--- a/src/new/sendTransaction.ts
+++ b/src/new/sendTransaction.ts
@@ -8,9 +8,17 @@
 import EventEmitter from 'events';
 import { shuffle } from 'lodash';
 import txApi from '../api/txApi';
-import { NATIVE_TOKEN_UID, SELECT_OUTPUTS_TIMEOUT } from '../constants';
+import {
+  NATIVE_TOKEN_UID,
+  MAX_SHIELDED_OUTPUTS,
+  SELECT_OUTPUTS_TIMEOUT,
+  ZERO_TWEAK,
+  FEE_PER_AMOUNT_SHIELDED_OUTPUT,
+  FEE_PER_FULL_SHIELDED_OUTPUT,
+} from '../constants';
 import { ErrorMessages } from '../errorMessages';
 import { SendTxError, WalletError } from '../errors';
+import Address from '../models/address';
 import { getAddressType } from '../utils/address';
 import CreateTokenTransaction from '../models/create_token_transaction';
 import { Fee } from '../utils/fee';
@@ -26,6 +34,8 @@ import {
   OutputValueType,
   WalletType,
 } from '../types';
+import { IDataShieldedOutput, InputGeneratorInfo, ShieldedOutputMode } from '../shielded/types';
+import { createShieldedOutputs } from '../shielded/creation';
 import helpers from '../utils/helpers';
 import { addCreatedTokenFromTx } from '../utils/storage';
 import tokens from '../utils/tokens';
@@ -65,7 +75,20 @@ export interface ISendTokenOutput {
   timelock?: number | null;
 }
 
-export type ISendOutput = ISendDataOutput | ISendTokenOutput;
+export interface ISendShieldedOutput {
+  type: OutputType.P2PKH | OutputType.P2SH;
+  address: string;
+  value: OutputValueType;
+  token: string;
+  scanPubkey: string; // hex, 33 bytes compressed EC scan pubkey for ECDH
+  shieldedMode: ShieldedOutputMode;
+}
+
+export function isShieldedOutput(output: ISendOutput): output is ISendShieldedOutput {
+  return 'shieldedMode' in output;
+}
+
+export type ISendOutput = ISendDataOutput | ISendTokenOutput | ISendShieldedOutput;
 
 /**
  * This is transaction mining class responsible for:
@@ -96,6 +119,19 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
 
   changeAddress: string | null;
 
+  /**
+   * If set, the HTR fee-change output that `prepareSendTokensData` would
+   * have emitted as transparent is rewritten as a shielded HTR output in
+   * the given mode (FullShielded or AmountShielded). Defaults to `null`,
+   * which preserves the long-standing transparent-change behavior.
+   *
+   * Used by callers that also pass shielded recipient outputs and want
+   * the HTR change for the per-shielded-output fee to match the same
+   * privacy mode the user selected — otherwise the transparent HTR
+   * change would correlate the sender with an otherwise-private send.
+   */
+  changeShieldedMode: ShieldedOutputMode | null;
+
   pin: string | null;
 
   fullTxData: IDataTx | null;
@@ -113,6 +149,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
    * @param {ISendInput[]} [options.inputs=[]] tx inputs
    * @param {ISendOutput[]} [options.outputs=[]] tx outputs
    * @param {string|null} [options.changeAddress=null] Address to use if we need to create a change output
+   * @param {ShieldedOutputMode|null} [options.changeShieldedMode=null] If set, the HTR fee-change is emitted shielded in this mode instead of transparent
    * @param {string|null} [options.pin=null] Wallet pin
    * @param {IStorage|null} [options.network=null] Network object
    */
@@ -123,6 +160,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
     outputs = [],
     inputs = [],
     changeAddress = null,
+    changeShieldedMode = null,
     pin = null,
   }: {
     wallet?: HathorWallet | null;
@@ -131,6 +169,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
     inputs?: ISendInput[];
     outputs?: ISendOutput[];
     changeAddress?: string | null;
+    changeShieldedMode?: ShieldedOutputMode | null;
     pin?: string | null;
   } = {}) {
     super();
@@ -145,6 +184,7 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
     this.outputs = outputs;
     this.inputs = inputs;
     this.changeAddress = changeAddress;
+    this.changeShieldedMode = changeShieldedMode;
     this.pin = pin;
     this.fullTxData = null;
   }
@@ -174,6 +214,11 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
     // Map of token uid to the chooseInputs value of this token
     const tokenMap = new Map<string, boolean>();
 
+    // Collect shielded output definitions separately
+    const shieldedOutputDefs: ISendShieldedOutput[] = [];
+    // Track phantom outputs for removal after UTXO selection and shuffle
+    const phantomOutputs = new Set<IDataOutput>();
+
     for (const output of this.outputs) {
       if (isDataOutput(output)) {
         tokenMap.set(HTR_UID, true);
@@ -187,11 +232,34 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
           authorities: 0n,
           token: output.token,
         });
+      } else if (isShieldedOutput(output)) {
+        // Shielded output: store definition and add a phantom transparent output
+        // so UTXO selection accounts for this value
+        shieldedOutputDefs.push(output);
+        tokenMap.set(output.token, true);
+
+        // Phantom output for UTXO selection (removed after shuffle).
+        // output.address is already the spend-derived P2PKH (resolved in sendManyOutputsSendTransaction).
+        const phantom: IDataOutput = {
+          address: output.address,
+          value: output.value,
+          timelock: null,
+          authorities: 0n,
+          token: output.token,
+          type: getAddressType(output.address, network),
+        };
+        phantomOutputs.add(phantom);
+        txData.outputs.push(phantom);
       } else {
         // We set chooseInputs true as default and may be overwritten by the inputs.
         // chooseInputs should be true if no inputs are given
         tokenMap.set(output.token, true);
 
+        // getAddressType throws for a 71-byte shielded address: it has no
+        // transparent output script form, so it must fail loudly here rather
+        // than be silently rewritten to its spend-derived P2PKH. To pay a
+        // shielded address, callers pass a shielded output definition
+        // (shieldedMode), which is handled by the isShieldedOutput branch above.
         txData.outputs.push({
           address: output.address,
           value: output.value,
@@ -207,15 +275,52 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
 
     for (const input of this.inputs) {
       const inputTx = await this.storage.getTx(input.txId);
-      if (inputTx === null || !inputTx.outputs[input.index]) {
+      // SEPARATED-model resolve. Positional inputTx.outputs[input.index] would
+      // return the wrong output (or undefined) for any input whose absolute
+      // on-chain index lands in the shielded range (idx >= outputs.length),
+      // causing this send pipeline to attach wrong value/token/address to the
+      // input and the fullnode to reject the signed tx.
+      const resolved =
+        inputTx !== null ? transactionUtils.resolveSpentOutput(inputTx, input.index) : undefined;
+      if (inputTx === null || !resolved) {
         const err = new SendTxError(ErrorMessages.INVALID_INPUT);
         err.errorData = { txId: input.txId, index: input.index };
         throw err;
       }
-      const spentOut = inputTx.outputs[input.index];
-      if (!tokenMap.has(spentOut.token)) {
+
+      // Resolve value/token/address/authorities by kind. For a shielded spend
+      // the public token/value live in the owned-marker fields written in
+      // place on the slot; fall back to the stored UTXO when the parent tx
+      // entry has not been decoded (e.g. spent UTXO already pruned).
+      let spentValue: OutputValueType;
+      let spentToken: string;
+      let spentAddress: string;
+      let spentAuthorities: bigint;
+      if (resolved.kind === 'shielded') {
+        const so = resolved.output;
+        const utxo = await this.storage.getUtxo({ txId: input.txId, index: input.index });
+        if (so.value === undefined && !utxo) {
+          // Non-owned / undecoded shielded slot with no stored UTXO — the
+          // wallet cannot spend it (no value/blinding to sign with).
+          const err = new SendTxError(ErrorMessages.INVALID_INPUT);
+          err.errorData = { txId: input.txId, index: input.index };
+          throw err;
+        }
+        spentValue = so.value ?? utxo!.value;
+        spentToken = so.token ?? utxo!.token;
+        spentAddress = so.decoded?.address ?? utxo!.address;
+        spentAuthorities = utxo ? utxo.authorities ?? 0n : 0n;
+      } else {
+        const spentOut = resolved.output;
+        spentValue = spentOut.value;
+        spentToken = spentOut.token;
+        spentAddress = spentOut.decoded.address!;
+        spentAuthorities = transactionUtils.authoritiesFromOutput(spentOut);
+      }
+
+      if (!tokenMap.has(spentToken)) {
         // the inputs should be used to pay fees, otherwise it's an invalid input and it will raise an error after the fee is calculated
-        if (HTR_UID === spentOut.token) {
+        if (HTR_UID === spentToken) {
           requiresFees.push({ txId: input.txId, index: input.index });
         } else {
           // The input select is from a token that is not in the outputs
@@ -224,14 +329,14 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
           throw err;
         }
       }
-      tokenMap.set(spentOut.token, false);
+      tokenMap.set(spentToken, false);
       txData.inputs.push({
         txId: input.txId,
         index: input.index,
-        value: spentOut.value,
-        token: spentOut.token,
-        address: spentOut.decoded.address!,
-        authorities: transactionUtils.authoritiesFromOutput(spentOut),
+        value: spentValue,
+        token: spentToken,
+        address: spentAddress,
+        authorities: spentAuthorities,
       });
     }
 
@@ -269,13 +374,25 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
       throw err;
     }
 
-    const headers: Header[] = [];
-    if (fee > 0) {
-      headers.push(new FeeHeader([{ tokenIndex: 0, amount: fee }]));
-      // if the token map doesn't have HTR, it means that the user didn't provide any HTR input or output, so we need to choose inputs for HTR to pay fees
-      if (!tokenMapHasHTR) {
-        shouldChooseHTRInputs = true;
+    // Calculate shielded output fee
+    let shieldedFee = 0n;
+    for (const def of shieldedOutputDefs) {
+      if (def.shieldedMode === ShieldedOutputMode.FULLY_SHIELDED) {
+        shieldedFee += FEE_PER_FULL_SHIELDED_OUTPUT;
+      } else {
+        shieldedFee += FEE_PER_AMOUNT_SHIELDED_OUTPUT;
       }
+    }
+
+    let totalFee = fee + shieldedFee;
+
+    // Decide whether to auto-pick HTR inputs based on the original
+    // totalFee (the value `prepareSendTokensData` is about to use for
+    // selection). The post-conversion fee bump done below is funded
+    // entirely from the would-be transparent change, so inputs picked
+    // here remain sufficient.
+    if (totalFee > 0n && !tokenMapHasHTR) {
+      shouldChooseHTRInputs = true;
     }
 
     const options: IUtxoSelectionOptions = {
@@ -294,8 +411,33 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
         outputs: partialOutputs,
       },
       options,
-      fee
+      totalFee
     );
+
+    // If the caller opted in to shielded HTR change, rewrite the
+    // transparent change emitted above as a shielded HTR output. The
+    // helper mutates both `partialHtrTxData.outputs` (removing the
+    // transparent change) and `shieldedOutputDefs` (appending the
+    // shielded replacement), and returns the extra shielded-output
+    // fee we now owe — funded by reducing the change by the same
+    // amount, so inputs already picked are still sufficient.
+    const { addedFee } = await convertHtrChangeIfRequested(
+      partialHtrTxData,
+      shieldedOutputDefs,
+      this.changeShieldedMode,
+      this.wallet,
+      network
+    );
+    totalFee += addedFee;
+
+    // FeeHeader is pushed AFTER the conversion so it carries the final
+    // total. The header gates on `totalFee > 0`; that's still
+    // monotonically increasing through the conversion (addedFee >= 0n)
+    // so the gate's outcome can't flip from true to false.
+    const headers: Header[] = [];
+    if (totalFee > 0n) {
+      headers.push(new FeeHeader([{ tokenIndex: 0, amount: totalFee }]));
+    }
 
     const shouldShuffleOutputs =
       partialTxData.outputs.length > 0 || partialHtrTxData.outputs.length > 0;
@@ -306,13 +448,209 @@ export default class SendTransaction extends EventEmitter implements ISendTransa
       outputs = shuffle([...partialOutputs, ...partialHtrTxData.outputs]);
     }
 
+    // Remove phantom outputs (shielded) from the final outputs list.
+    // This relies on reference equality — Set.has() matches the same object instances
+    // created above. The spread operators and shuffle preserve object references.
+    if (phantomOutputs.size > 0) {
+      outputs = outputs.filter(out => !phantomOutputs.has(out));
+    }
+
+    // Walk every input (user-supplied + HTR-picked) once, regardless of
+    // whether we're building shielded outputs. We need these both for:
+    //   (a) surjection-proof domain construction (shielded-outputs path), and
+    //   (b) excess-blinding-factor computation (full-unshield path).
+    // Collecting once keeps the two paths in sync on input ordering.
+    const allInputs = [...partialInputs, ...partialHtrTxData.inputs];
+    const inputGenerators: InputGeneratorInfo[] = [];
+    const blindedInputsArr: Array<{
+      value: bigint;
+      valueBlindingFactor: Buffer;
+      generatorBlindingFactor: Buffer;
+    }> = [];
+    // Transparent non-authority inputs collected separately. Needed only for the
+    // excess-blinding-factor calc on full-unshield txs where the wallet holds a
+    // mix of transparent + shielded UTXOs of the same token: the fullnode's
+    // balance verifier sums ALL inputs (transparent + shielded) against all
+    // outputs, so computeBalancingBlindingFactor must see the transparent
+    // inputs too or it returns a bf that doesn't satisfy the equation (the
+    // fullnode then panics when it tries to build the excess commitment).
+    const transparentInputEntries: Array<{
+      value: bigint;
+      valueBlindingFactor: Buffer;
+      generatorBlindingFactor: Buffer;
+    }> = [];
+
+    for (const inp of allInputs) {
+      const utxo = await this.storage.getUtxo({
+        txId: inp.txId,
+        index: inp.index,
+      });
+
+      // Build generator info for surjection proof domain
+      if (inp.token) {
+        const genInfo: InputGeneratorInfo = { tokenUid: inp.token as string };
+        // For FullShielded inputs, pass the asset blinding factor so the
+        // surjection proof domain uses the blinded generator (asset_commitment)
+        // matching what the fullnode verifies against.
+        if (utxo?.shielded && utxo.assetBlindingFactor) {
+          genInfo.assetBlindingFactor = Buffer.from(utxo.assetBlindingFactor, 'hex');
+        }
+        inputGenerators.push(genInfo);
+      }
+
+      // Extract blinding factors from shielded inputs for the homomorphic balance equation.
+      if (utxo?.shielded) {
+        if (!utxo.blindingFactor) {
+          throw new SendTxError(
+            `Shielded input ${inp.txId}:${inp.index} is missing blindingFactor — ` +
+              'cannot satisfy the homomorphic balance equation.'
+          );
+        }
+        blindedInputsArr.push({
+          value: utxo.value,
+          valueBlindingFactor: Buffer.from(utxo.blindingFactor, 'hex'),
+          generatorBlindingFactor: utxo.assetBlindingFactor
+            ? Buffer.from(utxo.assetBlindingFactor, 'hex')
+            : ZERO_TWEAK,
+        });
+      } else if (utxo && (utxo.authorities ?? 0n) === 0n && utxo.value > 0n) {
+        transparentInputEntries.push({
+          value: utxo.value,
+          valueBlindingFactor: ZERO_TWEAK,
+          generatorBlindingFactor: ZERO_TWEAK,
+        });
+      }
+    }
+
+    // Create shielded outputs with cryptographic commitments and proofs
+    let shieldedOutputs: IDataShieldedOutput[] = [];
+    if (shieldedOutputDefs.length > 0) {
+      const cryptoProvider = this.storage.shieldedCryptoProvider;
+      if (!cryptoProvider) {
+        throw new SendTxError(
+          'Shielded crypto provider is not set. Cannot create shielded outputs.'
+        );
+      }
+
+      // Validate shielded output count before expensive crypto work
+      if (shieldedOutputDefs.length === 1) {
+        throw new SendTxError(
+          'At least 2 shielded outputs are required to prevent trivial commitment matching.'
+        );
+      }
+      if (shieldedOutputDefs.length > MAX_SHIELDED_OUTPUTS) {
+        throw new SendTxError(
+          `Cannot create more than ${MAX_SHIELDED_OUTPUTS} shielded outputs per transaction ` +
+            `(requested ${shieldedOutputDefs.length}).`
+        );
+      }
+
+      shieldedOutputs = await createShieldedOutputs(
+        shieldedOutputDefs,
+        cryptoProvider,
+        network,
+        inputGenerators,
+        blindedInputsArr
+      );
+    }
+
+    // Full-unshield detection: tx has shielded inputs but no shielded outputs.
+    // The fullnode rejects such a tx unless it carries an UnshieldBalanceHeader
+    // with excess = sum(r_in) − sum(r_out). Compute excess using the existing
+    // computeBalancingBlindingFactor primitive: pass value=0,
+    // generatorBlindingFactor=ZERO, ALL inputs (shielded with their real
+    // blinding factors + transparent with valueBlindingFactor=0) as `inputs`,
+    // and every output + transparent fee entry as `otherOutputs` with
+    // (valueBlindingFactor=0, generatorBlindingFactor=0). The function expects
+    // sum of input values to equal sum of other-output values plus the
+    // last-output value, so transparent inputs MUST be included when the
+    // wallet pulls from a mixed transparent+shielded pool — otherwise the
+    // function returns a bf that doesn't satisfy the equation and the
+    // fullnode panics trying to build the excess commitment at verify time.
+    //
+    // Mutually exclusive with shielded outputs (hathor-core enforces this at
+    // verify time). We gate on `shieldedOutputs.length === 0` to skip this
+    // branch on the shielded/partial-unshield path.
+    let excessBlindingFactor: Buffer | undefined;
+    if (shieldedOutputs.length === 0 && blindedInputsArr.length > 0) {
+      const cryptoProvider = this.storage.shieldedCryptoProvider;
+      if (!cryptoProvider) {
+        throw new SendTxError(
+          'Shielded crypto provider is not set. Cannot compute excess blinding ' +
+            'factor for a full-unshield transaction.'
+        );
+      }
+
+      // All transparent outputs contribute (value, valueBlindingFactor=0,
+      // generatorBlindingFactor=0). Include the HTR fee amount as a transparent
+      // output entry — the scalar must cover the full output side the verifier
+      // sees.
+      const transparentOutputEntries: Array<{
+        value: bigint;
+        valueBlindingFactor: Buffer;
+        generatorBlindingFactor: Buffer;
+      }> = [];
+      for (const out of outputs) {
+        transparentOutputEntries.push({
+          value: out.value,
+          valueBlindingFactor: ZERO_TWEAK,
+          generatorBlindingFactor: ZERO_TWEAK,
+        });
+      }
+      if (totalFee > 0n) {
+        transparentOutputEntries.push({
+          value: totalFee,
+          valueBlindingFactor: ZERO_TWEAK,
+          generatorBlindingFactor: ZERO_TWEAK,
+        });
+      }
+
+      const excess = await cryptoProvider.computeBalancingBlindingFactor(
+        0n,
+        ZERO_TWEAK,
+        [...blindedInputsArr, ...transparentInputEntries],
+        transparentOutputEntries
+      );
+      excessBlindingFactor = excess;
+    }
+
+    // Privacy guard: a non-HTR token MUST appear in `tokens[]` only when
+    // at least one output in the FINAL tx references it via `token_data`
+    // — i.e. a transparent (including downstream-added change) or
+    // AmountShielded output. FullShielded outputs commit the token UID
+    // under `asset_commitment` instead; listing the token publicly in
+    // `tokens[]` would defeat that privacy guarantee. Inputs don't carry
+    // `token_data` in the wire format, so they don't pull a token in.
+    //
+    // Computed AFTER `outputs` is finalized (phantoms removed, change
+    // outputs added by prepareSendManyTokensData included) — populating
+    // earlier from `this.outputs` alone misses transparent change and
+    // breaks balance verification when the same token has both FS user
+    // outputs and a transparent change.
+    const tokensWithVisibleOutput = new Set<string>();
+    for (const out of outputs) {
+      const tokenUid = (out as { token?: string }).token;
+      if (!tokenUid || tokenUid === HTR_UID) continue;
+      if ((out.authorities ?? 0n) !== 0n) continue;
+      tokensWithVisibleOutput.add(tokenUid);
+    }
+    for (const so of shieldedOutputs) {
+      if (so.shieldedMode !== ShieldedOutputMode.FULLY_SHIELDED) {
+        tokensWithVisibleOutput.add(so.token);
+      }
+    }
+
     // This new IDataTx should be complete with the requested funds
     this.fullTxData = {
       outputs,
       inputs: [...partialInputs, ...partialHtrTxData.inputs],
-      // We already removed HTR from the tokenMap
-      tokens: Array.from(tokenMap.keys()),
+      // We already removed HTR from the tokenMap. Filter out any token
+      // whose only references are FullShielded outputs (see the privacy
+      // guard above).
+      tokens: Array.from(tokenMap.keys()).filter(t => tokensWithVisibleOutput.has(t)),
       headers,
+      ...(shieldedOutputs.length > 0 ? { shieldedOutputs } : {}),
+      ...(excessBlindingFactor ? { excessBlindingFactor } : {}),
     };
 
     return this.fullTxData;
@@ -735,6 +1073,81 @@ export async function prepareSendTokensData(
   }
 }
 
+/**
+ * If `mode` is set and `prepareSendTokensData` emitted a transparent
+ * HTR change output, rewrite that change as a shielded HTR output in
+ * `shieldedOutputDefs`. Mutates both `partialHtrTxData.outputs` (to
+ * remove the transparent change) and `shieldedOutputDefs` (to append
+ * the shielded one). Returns the additional shielded-output fee that
+ * the caller must add to `totalFee`, or `0n` when no conversion was
+ * performed.
+ *
+ * No-ops in any of these cases:
+ *   - `mode` is null/undefined (caller did not opt in).
+ *   - `wallet` is null (no shielded address derivation available).
+ *   - `shieldedOutputDefs` is empty (a pure-transparent tx has no
+ *     shielded fee context; converting the change here would silently
+ *     break the `>= 2 shielded outputs` invariant downstream).
+ *   - No HTR change output exists in `partialHtrTxData.outputs` (the
+ *     selected HTR UTXO covered the fee exactly).
+ *   - The transparent change value is `<= additionalFee` — converting
+ *     would zero-out or negate the change. Keeping the transparent
+ *     change is the safe, value-preserving choice.
+ */
+export async function convertHtrChangeIfRequested(
+  partialHtrTxData: Pick<IDataTx, 'inputs' | 'outputs'>,
+  shieldedOutputDefs: ISendShieldedOutput[],
+  mode: ShieldedOutputMode | null,
+  wallet: HathorWallet | null,
+  network: ReturnType<IStorage['config']['getNetwork']>
+): Promise<{ addedFee: bigint }> {
+  if (!mode) return { addedFee: 0n };
+  if (!wallet) return { addedFee: 0n };
+  if (shieldedOutputDefs.length === 0) return { addedFee: 0n };
+
+  const additionalFee =
+    mode === ShieldedOutputMode.FULLY_SHIELDED
+      ? FEE_PER_FULL_SHIELDED_OUTPUT
+      : FEE_PER_AMOUNT_SHIELDED_OUTPUT;
+
+  const HTR_UID = NATIVE_TOKEN_UID;
+  const changeIdx = partialHtrTxData.outputs.findIndex(o => {
+    const withToken = o as IDataOutputWithToken;
+    return withToken.token === HTR_UID && withToken.isChange === true;
+  });
+  if (changeIdx === -1) return { addedFee: 0n };
+
+  const transparentChange = partialHtrTxData.outputs[changeIdx];
+  if (transparentChange.value <= additionalFee) {
+    // Conversion would produce a zero or negative shielded value —
+    // keep the transparent change so we don't silently drop funds.
+    return { addedFee: 0n };
+  }
+
+  const { address: shieldedAddress } = await wallet.getCurrentAddress({}, { legacy: false });
+  const addressObj = new Address(shieldedAddress, { network });
+  if (!addressObj.isShielded()) {
+    throw new SendTxError('Wallet did not return a shielded address for HTR change conversion.');
+  }
+  const spendAddress = addressObj.getSpendAddress();
+
+  // Remove the transparent change output before appending the shielded
+  // replacement so any later iteration over `partialHtrTxData.outputs`
+  // sees the post-conversion shape.
+  partialHtrTxData.outputs.splice(changeIdx, 1);
+
+  shieldedOutputDefs.push({
+    type: OutputType.P2PKH,
+    address: spendAddress.base58,
+    value: transparentChange.value - additionalFee,
+    token: HTR_UID,
+    scanPubkey: addressObj.getScanPubkey().toString('hex'),
+    shieldedMode: mode,
+  });
+
+  return { addedFee: additionalFee };
+}
+
 async function getOutputTypeFromWallet(storage: IStorage): Promise<'p2pkh' | 'p2sh'> {
   const walletType = await storage.getWalletType();
   if (walletType === WalletType.P2PKH) {
@@ -897,15 +1310,28 @@ export async function checkUnspentInput(
   if (tx.is_voided) {
     return { success: false, message: `Transaction [${input.txId}] is voided` };
   }
-  if (tx.outputs.length - 1 < input.index) {
+  // SEPARATED-model resolve so explicit shielded inputs validate against the
+  // correct entry, not whatever happens to sit positionally at
+  // `tx.outputs[input.index]` (which is out of bounds for any shielded slot).
+  const resolved = transactionUtils.resolveSpentOutput(tx, input.index);
+  if (!resolved) {
     return {
       success: false,
       message: `Transaction [${input.txId}] does not have this output [index=${input.index}]`,
     };
   }
 
-  const txout = tx.outputs[input.index];
-  if (transactionUtils.isAuthorityOutput(txout)) {
+  // Normalize the fields the checks below read off the resolved output. For a
+  // shielded slot the public token/value live in the owned-marker fields
+  // written in place when the wallet decrypted it; `token_data` may be absent
+  // so authority detection only applies to transparent outputs.
+  const isAuthority =
+    resolved.kind === 'transparent' && transactionUtils.isAuthorityOutput(resolved.output);
+  const outputAddress = resolved.output.decoded?.address;
+  const outputToken = resolved.output.token;
+  const outputSpentBy = resolved.output.spent_by;
+
+  if (isAuthority) {
     /**
      * XXX: We are NOT enabling authority outputs for now.
      */
@@ -915,14 +1341,14 @@ export async function checkUnspentInput(
     };
   }
 
-  if (txout.decoded.address) {
-    if (txout.decoded.address !== input.address) {
+  if (outputAddress) {
+    if (outputAddress !== input.address) {
       return {
         success: false,
         message: `Output [${input.index}] of transaction [${input.txId}] does not have the same address as the provided input`,
       };
     }
-    if (!(await storage.isAddressMine(txout.decoded.address))) {
+    if (!(await storage.isAddressMine(outputAddress))) {
       return {
         success: false,
         message: `Output [${input.index}] of transaction [${input.txId}] is not from the wallet`,
@@ -936,14 +1362,14 @@ export async function checkUnspentInput(
     };
   }
 
-  if (txout.token !== input.token || input.token !== selectedToken) {
+  if (outputToken !== input.token || input.token !== selectedToken) {
     return {
       success: false,
       message: `Output [${input.index}] of transaction [${input.txId}] is not from selected token [${selectedToken}]`,
     };
   }
 
-  if (txout.spent_by) {
+  if (outputSpentBy) {
     return {
       success: false,
       message: `Output [${input.index}] of transaction [${input.txId}] is already spent`,

--- a/src/new/types.ts
+++ b/src/new/types.ts
@@ -104,6 +104,13 @@ export interface UtxoOptions {
   amount_bigger_than?: bigint;
   max_amount?: bigint;
   only_available_utxos?: boolean;
+  /**
+   * Whether to include shielded UTXOs. Defaults to `false` (transparent-only):
+   * `getUtxos` feeds consolidation, which spends its results as TRANSPARENT
+   * inputs, so a shielded UTXO must never leak into that listing. Pass `true`
+   * to explicitly include shielded UTXOs.
+   */
+  shielded?: boolean;
 }
 
 /**
@@ -348,6 +355,23 @@ export interface ProposedOutput {
 }
 
 /**
+ * The unblinding data the wallet holds for a single shielded output/input it
+ * owns: the cleartext `value`/`token` plus the value blinding factor (`vbf`)
+ * and, for FullShielded slots, the asset blinding factor (`abf`).
+ */
+export interface ShieldedOpening {
+  value: bigint;
+  token: string;
+  vbf: string;
+  abf?: string;
+}
+
+/** A {@link ShieldedOpening} tagged with the on-chain absolute slot index. */
+export interface ShieldedOpeningEntry extends ShieldedOpening {
+  index: number;
+}
+
+/**
  * Proposed input for a transaction
  * @property txId Transaction ID of the input
  * @property index Index of the output being spent
@@ -442,6 +466,19 @@ export interface GetTxHistoryFullnodeFacadeReturnType {
   ncMethod?: string;
   ncCaller?: Address; // Address type
   firstBlock?: string;
+  /**
+   * Tx-level headers (FeeHeader, etc.) carried through unchanged from
+   * the on-chain payload so callers can compute network fees without
+   * a second `getTx` round-trip.
+   */
+  headers?: unknown[];
+  /**
+   * Shielded output entries from `tx.shielded_outputs[]`. Each entry's
+   * `mode` (1 = AmountShielded, 2 = FullShielded) is the only field
+   * the privacy-fee accumulator needs; others are passed through for
+   * future use.
+   */
+  shielded_outputs?: { mode?: number }[];
 }
 
 /**

--- a/src/new/types.ts
+++ b/src/new/types.ts
@@ -14,6 +14,7 @@ import {
   OutputValueType,
   TokenVersion,
 } from '../types';
+import { ShieldedOutputMode } from '../shielded/types';
 import { NanoContractAction } from '../nano_contracts/types';
 import WalletConnection from './connection';
 import Address from '../models/address';
@@ -342,16 +343,18 @@ export interface UtxoDetails {
 
 /**
  * Proposed output for a transaction
- * @property address Destination address for the output
+ * @property address Destination address for the output. Must be a shielded address when shielded mode is set.
  * @property value Value of the output
  * @property timelock Optional timelock for the output
  * @property token Token UID for the output
+ * @property shielded Optional shielded output mode (AMOUNT_SHIELDED or FULLY_SHIELDED)
  */
 export interface ProposedOutput {
   address: string;
   value: OutputValueType;
   timelock?: number;
   token: string;
+  shielded?: ShieldedOutputMode;
 }
 
 /**
@@ -395,12 +398,19 @@ export interface SendTransactionFullnodeOptions {
  * @property changeAddress Address for change output
  * @property startMiningTx Boolean to trigger start mining (default true)
  * @property pinCode Pin to decrypt xpriv information
+ * @property changeShieldedMode If set, the HTR fee-change output (when
+ *   one would otherwise be created as transparent) is rewritten as a
+ *   shielded HTR output in the given mode. Mirrors the user-selected
+ *   privacy mode of the transaction so HTR change doesn't leak the
+ *   sender alongside an otherwise-private send. Undefined keeps the
+ *   default transparent change.
  */
 export interface SendManyOutputsOptions {
   inputs?: ProposedInput[];
   changeAddress?: string | null;
   startMiningTx?: boolean;
   pinCode?: string | null;
+  changeShieldedMode?: ShieldedOutputMode;
 }
 
 /**

--- a/src/new/wallet.ts
+++ b/src/new/wallet.ts
@@ -111,7 +111,13 @@ import GLL from '../sync/gll';
 import { TransactionTemplate, WalletTxTemplateInterpreter } from '../template/transaction';
 import Address from '../models/address';
 import type { IShieldedCryptoProvider } from '../shielded/types';
-import { ConnectionState, FullNodeVersionData, IHathorWallet, Utxo } from '../wallet/types';
+import {
+  ConnectionState,
+  FullNodeVersionData,
+  IHathorWallet,
+  OutputType,
+  Utxo,
+} from '../wallet/types';
 import Transaction from '../models/transaction';
 import {
   CreateNFTOptions,
@@ -737,8 +743,14 @@ class HathorWallet extends EventEmitter {
     const p2shSignatures = signatures.sort().map(sig => P2SHSignature.deserialize(sig));
 
     for await (const { tx: spentTx, input, index } of this.storage.getSpentTxs(tx.inputs)) {
-      const spentUtxo = spentTx.outputs[input.index];
-      const storageAddress = await this.storage.getAddressInfo(spentUtxo.decoded.address!);
+      // SEPARATED-model resolve so the P2SH signing path picks the correct
+      // address info when the spent output lives in shielded_outputs[] (its
+      // array position is not its on-chain index).
+      const resolved = transactionUtils.resolveSpentOutput(spentTx, input.index);
+      if (!resolved?.output.decoded?.address) {
+        continue;
+      }
+      const storageAddress = await this.storage.getAddressInfo(resolved.output.decoded.address);
       if (storageAddress === null) {
         // The transaction is on our history but this input is not ours
         continue;
@@ -1945,6 +1957,7 @@ class HathorWallet extends EventEmitter {
       changeAddress: null,
       startMiningTx: true,
       pinCode: null,
+      changeShieldedMode: null,
       ...options,
     };
 
@@ -1952,12 +1965,43 @@ class HathorWallet extends EventEmitter {
     if (!pin) {
       throw new Error(ERROR_MESSAGE_PIN_REQUIRED);
     }
-    const { inputs, changeAddress } = newOptions;
+    const { inputs, changeAddress, changeShieldedMode } = newOptions;
+
+    // Map ProposedOutput[] to ISendOutput[], handling shielded outputs
+    const network = this.storage.config.getNetwork();
+    const sendOutputs = outputs.map(o => {
+      if (o.shielded) {
+        const addressObj = new Address(o.address, { network });
+        if (!addressObj.isShielded()) {
+          throw new Error('Shielded output requires a shielded address');
+        }
+        // Extract scan pubkey from shielded address for ECDH.
+        // Use the spend-derived P2PKH as the on-chain address.
+        const spendAddress = addressObj.getSpendAddress();
+        return {
+          type: OutputType.P2PKH as OutputType.P2PKH,
+          address: spendAddress.base58,
+          value: o.value,
+          token: o.token,
+          scanPubkey: addressObj.getScanPubkey().toString('hex'),
+          shieldedMode: o.shielded,
+          ...(o.timelock != null ? { timelock: o.timelock } : {}),
+        };
+      }
+      return {
+        address: o.address,
+        value: o.value,
+        token: o.token,
+        ...(o.timelock ? { timelock: o.timelock } : {}),
+      };
+    });
+
     return new SendTransaction({
       wallet: this,
-      outputs,
+      outputs: sendOutputs,
       inputs,
       changeAddress,
+      changeShieldedMode,
       pin,
     });
   }
@@ -3090,13 +3134,24 @@ class HathorWallet extends EventEmitter {
     const walletInputs: IWalletInputInfo[] = [];
 
     for await (const { tx: spentTx, input, index } of this.storage.getSpentTxs(tx.inputs)) {
-      const addressInfo = await this.storage.getAddressInfo(
-        spentTx.outputs[input.index].decoded.address!
-      );
+      // SEPARATED-model resolve so a caller using this API to fetch signing
+      // info (e.g. external signers, the partial-tx flow) gets the address of
+      // the actual spent output, not a positional mismatch when the parent's
+      // shielded outputs shift the array.
+      const resolved = transactionUtils.resolveSpentOutput(spentTx, input.index);
+      if (!resolved?.output.decoded?.address) {
+        continue;
+      }
+      const addressInfo = await this.storage.getAddressInfo(resolved.output.decoded.address);
       if (addressInfo === null) {
         continue;
       }
-      const addressPath = await this.getAddressPathForIndex(addressInfo.bip32AddressIndex);
+      // A shielded-spend input's key lives on the spend chain (m/44'/280'/2'),
+      // not the legacy P2PKH chain — select the right path so it matches the key
+      // that actually signs the input (see getSignatureForTx).
+      const addressPath = await this.getAddressPathForIndex(addressInfo.bip32AddressIndex, {
+        legacy: addressInfo.addressType !== 'shielded-spend',
+      });
       walletInputs.push({
         inputIndex: index,
         addressIndex: addressInfo.bip32AddressIndex,
@@ -3134,7 +3189,11 @@ class HathorWallet extends EventEmitter {
         ...sigData,
         pubkey: sigData.pubkey.toString('hex'),
         signature: sigData.signature.toString('hex'),
-        addressPath: await this.getAddressPathForIndex(sigData.addressIndex),
+        // Render the path that matches the key that signed: a 'shielded-spend'
+        // input was signed with the spend chain, not the legacy P2PKH chain.
+        addressPath: await this.getAddressPathForIndex(sigData.addressIndex, {
+          legacy: sigData.addressType !== 'shielded-spend',
+        }),
       });
     }
     return sigInfoArray;

--- a/src/new/wallet.ts
+++ b/src/new/wallet.ts
@@ -30,6 +30,7 @@ import {
   ON_CHAIN_BLUEPRINTS_VERSION,
   P2PKH_ACCT_PATH,
   P2SH_ACCT_PATH,
+  SHIELDED_SPEND_ACCT_PATH,
   GAP_LIMIT,
 } from '../constants';
 import tokenUtils from '../utils/tokens';
@@ -76,6 +77,7 @@ import {
   WalletState,
   WalletType,
   WalletAddressMode,
+  IAddressChainOptions,
 } from '../types';
 import transactionUtils from '../utils/transaction';
 import Queue from '../models/queue';
@@ -90,7 +92,12 @@ import {
 } from '../utils/storage';
 import txApi from '../api/txApi';
 import { MemoryStore, Storage } from '../storage';
-import { deriveAddressP2PKH, deriveAddressP2SH, getAddressFromPubkey } from '../utils/address';
+import {
+  deriveAddressP2PKH,
+  deriveAddressP2SH,
+  deriveShieldedAddressFromStorage,
+  getAddressFromPubkey,
+} from '../utils/address';
 import NanoContractTransactionBuilder from '../nano_contracts/builder';
 import { prepareNanoSendTransaction, setNanoHeaderCallerFromWallet } from '../nano_contracts/utils';
 import OnChainBlueprint, { Code, CodeKind } from '../nano_contracts/on_chain_blueprint';
@@ -103,6 +110,7 @@ import { IHistoryTxSchema } from '../schemas';
 import GLL from '../sync/gll';
 import { TransactionTemplate, WalletTxTemplateInterpreter } from '../template/transaction';
 import Address from '../models/address';
+import type { IShieldedCryptoProvider } from '../shielded/types';
 import { ConnectionState, FullNodeVersionData, IHathorWallet, Utxo } from '../wallet/types';
 import Transaction from '../models/transaction';
 import {
@@ -126,6 +134,8 @@ import {
   ISignature,
   IWalletInputInfo,
   ProposedOutput,
+  ShieldedOpening,
+  ShieldedOpeningEntry,
   SendManyOutputsOptions,
   UtxoDetails,
   UtxoOptions,
@@ -644,7 +654,12 @@ class HathorWallet extends EventEmitter {
             }
           }
           const addressesToLoad = await scanPolicyStartAddresses(this.storage);
-          await this.syncHistory(addressesToLoad.nextIndex, addressesToLoad.count);
+          await this.syncHistory(
+            addressesToLoad.nextIndex,
+            addressesToLoad.count,
+            false,
+            this.pinCode ?? undefined
+          );
         } else {
           if (this.beforeReloadCallback) {
             this.beforeReloadCallback();
@@ -758,15 +773,20 @@ class HathorWallet extends EventEmitter {
    * @returns Address object with the count of txs for this address
    * @memberof HathorWallet
    * */
-  async *getAllAddresses(): AsyncGenerator<{
+  async *getAllAddresses(opts?: IAddressChainOptions): AsyncGenerator<{
     address: string;
     index: number;
     transactions: number;
   }> {
     // We add the count of transactions
     // in order to replicate the same return as the new
-    // wallet service facade
-    for await (const address of this.storage.getAllAddresses()) {
+    // wallet service facade.
+    //
+    // `opts.legacy` defaults to `true`; pass `legacy: false` to
+    // enumerate the shielded receive chain instead. The storage
+    // surface filters out the internal `shielded-spend` entries on
+    // either branch, so callers always get the user-facing shape.
+    for await (const address of this.storage.getAllAddresses(opts)) {
       yield {
         address: address.base58,
         index: address.bip32AddressIndex,
@@ -810,15 +830,27 @@ class HathorWallet extends EventEmitter {
    * @memberof HathorWallet
    * @inner
    */
-  async getAddressAtIndex(index: number): Promise<string> {
-    let address = await this.storage.getAddressAtIndex(index);
+  async getAddressAtIndex(index: number, opts?: IAddressChainOptions): Promise<string> {
+    let address = await this.storage.getAddressAtIndex(index, opts);
 
     if (address === null) {
+      if (opts?.legacy === false) {
+        // Shielded address not yet derived at this index — derive and save
+        const result = await deriveShieldedAddressFromStorage(index, this.storage);
+        if (!result) {
+          throw new Error('Shielded keys not available');
+        }
+        await this.storage.saveAddress(result.shieldedAddress);
+        await this.storage.saveAddress(result.spendAddress);
+        return result.shieldedAddress.base58;
+      }
+      // Legacy address derivation
       if ((await this.storage.getWalletType()) === 'p2pkh') {
         address = await deriveAddressP2PKH(index, this.storage);
       } else {
         address = await deriveAddressP2SH(index, this.storage);
       }
+      await this.storage.saveAddress(address);
     }
     return address.base58;
   }
@@ -832,7 +864,13 @@ class HathorWallet extends EventEmitter {
    * @memberof HathorWallet
    * @inner
    */
-  async getAddressPathForIndex(index: number): Promise<string> {
+  async getAddressPathForIndex(index: number, opts?: IAddressChainOptions): Promise<string> {
+    if (opts?.legacy === false) {
+      // Shielded addresses are formed by scanPubkey (account 1') + spendPubkey (account 2').
+      // We return the spend path since it's used for on-chain scripts and signing.
+      return `${SHIELDED_SPEND_ACCT_PATH}/0/${index}`;
+    }
+
     const walletType = await this.storage.getWalletType();
     if (walletType === WalletType.MULTISIG) {
       // P2SH
@@ -852,14 +890,18 @@ class HathorWallet extends EventEmitter {
    * @memberof HathorWallet
    * @inner
    */
-  async getCurrentAddress({ markAsUsed = false } = {}): Promise<{
+  async getCurrentAddress(
+    // eslint-disable-next-line default-param-last
+    { markAsUsed = false } = {},
+    opts?: IAddressChainOptions
+  ): Promise<{
     address: string;
     index: number | null;
     addressPath: string;
   }> {
-    const address = await this.storage.getCurrentAddress(markAsUsed);
+    const address = await this.storage.getCurrentAddress(markAsUsed, opts);
     const index = await this.getAddressIndex(address);
-    const addressPath = await this.getAddressPathForIndex(index!);
+    const addressPath = await this.getAddressPathForIndex(index!, opts);
 
     return { address, index, addressPath };
   }
@@ -867,10 +909,12 @@ class HathorWallet extends EventEmitter {
   /**
    * Get the next address after the current available
    */
-  async getNextAddress(): Promise<{ address: string; index: number | null; addressPath: string }> {
+  async getNextAddress(
+    opts?: IAddressChainOptions
+  ): Promise<{ address: string; index: number | null; addressPath: string }> {
     // First we mark the current address as used, then return the next
-    await this.getCurrentAddress({ markAsUsed: true });
-    return this.getCurrentAddress();
+    await this.getCurrentAddress({ markAsUsed: true }, opts);
+    return this.getCurrentAddress({}, opts);
   }
 
   /**
@@ -989,7 +1033,7 @@ class HathorWallet extends EventEmitter {
         break;
       }
       const txbalance = await this.getTxBalance(tx);
-      const txHistory = {
+      const txHistory: GetTxHistoryFullnodeFacadeReturnType = {
         txId: tx.tx_id,
         timestamp: tx.timestamp,
         voided: tx.is_voided,
@@ -1000,6 +1044,15 @@ class HathorWallet extends EventEmitter {
         ncCaller: (tx.nc_address &&
           new Address(tx.nc_address, { network: this.getNetworkObject() })) as Address,
         firstBlock: tx.first_block as string | undefined,
+        // Pass-through fields needed by display layers that compute
+        // fees per-tx (network fee from FeeHeader entries, privacy
+        // fee from per-shielded-output mode). Cheap to copy and lets
+        // the consumer skip a second round-trip via `getTx`. Both are
+        // optional on `IHistoryTx`; spread-conditionally so the
+        // returned shape doesn't carry explicit `undefined` keys when
+        // the upstream payload didn't include them.
+        ...(tx.headers ? { headers: tx.headers } : {}),
+        ...(tx.shielded_outputs ? { shielded_outputs: tx.shielded_outputs } : {}),
       };
       if (tx.version === ON_CHAIN_BLUEPRINTS_VERSION) {
         txHistory.ncCaller = (tx.nc_pubkey &&
@@ -1036,6 +1089,99 @@ class HathorWallet extends EventEmitter {
    */
   async getTx(id: string): Promise<IHistoryTx | null> {
     return this.storage.getTx(id);
+  }
+
+  /**
+   * Get the unblinding factors for shielded outputs in a transaction.
+   *
+   * Returns one entry per shielded output **the wallet owns** (received +
+   * change). Outputs the wallet generated for other recipients are not in
+   * scope — even though the wallet knows their blinding factors at signing
+   * time, disclosing them would leak the recipient's amount/token to a third
+   * party. The same is true of any shielded output decoded with a different
+   * wallet's scan key.
+   *
+   * Each entry carries the on-chain absolute output index the explorer / a
+   * fullnode uses to identify the output (`len(transparent_outputs) +
+   * shielded_index`). The viewer can recompute the Pedersen commitment from
+   * `{value, token, vbf, abf?}` and confirm it matches the on-chain
+   * commitment at that index.
+   *
+   * SEPARATED model: shielded outputs live in `tx.shielded_outputs[]` (the
+   * full on-chain-ordered list); the wallet writes the owned-marker fields
+   * (`value`/`token`/`blindingFactor`/`assetBlindingFactor`) IN PLACE on the
+   * slots it decrypts. The single ownership gate is `value !== undefined`;
+   * the on-chain absolute index of `shielded_outputs[s]` is
+   * `tx.outputs.length + s`.
+   */
+  async getShieldedUnblindingForTx(
+    txId: string
+  ): Promise<{ outputs: ShieldedOpeningEntry[]; inputs: ShieldedOpeningEntry[] }> {
+    const tx = await this.storage.getTx(txId);
+    if (!tx) return { outputs: [], inputs: [] };
+
+    const ownedOutputsOf = (target: IHistoryTx): Map<number, ShieldedOpening> => {
+      // Build a lookup keyed by on-chain absolute output index for shielded
+      // outputs the wallet owns (decoded). Same shape used by both the outputs
+      // path (this tx's shielded_outputs) and the inputs path (each input's
+      // parent tx's shielded_outputs). The single ownership gate is the
+      // top-level `value !== undefined`: slots the fullnode delivered but the
+      // wallet couldn't decode never get the owned-marker fields written, so
+      // they are excluded here. `blindingFactor` must also be present to
+      // produce a usable opening.
+      const transparentCount = (target.outputs ?? []).length;
+      const out = new Map<number, ShieldedOpening>();
+      const shielded = target.shielded_outputs ?? [];
+      for (let s = 0; s < shielded.length; s += 1) {
+        const output = shielded[s];
+        if (output.value === undefined) continue;
+        if (!output.blindingFactor || output.token === undefined) continue;
+        const absIdx = transparentCount + s;
+        out.set(absIdx, {
+          value: output.value,
+          token: output.token,
+          vbf: output.blindingFactor,
+          ...(output.assetBlindingFactor ? { abf: output.assetBlindingFactor } : {}),
+        });
+      }
+      return out;
+    };
+
+    const outputsResult: ShieldedOpeningEntry[] = [];
+    for (const [absIdx, opening] of ownedOutputsOf(tx).entries()) {
+      outputsResult.push({ index: absIdx, ...opening });
+    }
+
+    // Inputs: a shielded input references a previous shielded output by
+    // `tx_id` + `index` (the parent's on-chain absolute index). If the wallet
+    // owned that previous output (its parent tx is in history with the
+    // owned-marker fields written on the slot), the same opening unblinds the
+    // input. Inputs whose parent the wallet doesn't own stay opaque — the
+    // wallet has no business disclosing someone else's blinding factors.
+    const inputsResult: ShieldedOpeningEntry[] = [];
+    const parentTxCache = new Map<string, Map<number, ShieldedOpening>>();
+    for (const [inputIdx, input] of (tx.inputs ?? []).entries()) {
+      // We don't gate on `input.type === 'shielded'`: the sender-local insert
+      // path builds the IHistoryTx without setting `type` on inputs that spend
+      // shielded parents. Instead attempt the parent-opening lookup on every
+      // input — only inputs whose parent tx has a decoded shielded entry at the
+      // referenced absolute index produce a hit, which is exactly the ownership
+      // gate we want. Transparent inputs naturally miss (parents have no
+      // shielded entry at that absolute index) and fall through.
+      const { tx_id: parentTxId, index: parentOutputIndex } = input;
+      if (!parentTxId || parentOutputIndex === undefined) continue;
+      let parentOwned = parentTxCache.get(parentTxId);
+      if (parentOwned === undefined) {
+        const parent = await this.storage.getTx(parentTxId);
+        parentOwned = parent ? ownedOutputsOf(parent) : new Map();
+        parentTxCache.set(parentTxId, parentOwned);
+      }
+      const opening = parentOwned.get(parentOutputIndex);
+      if (!opening) continue;
+      inputsResult.push({ index: inputIdx, ...opening });
+    }
+
+    return { outputs: outputsResult, inputs: inputsResult };
   }
 
   /**
@@ -1093,6 +1239,11 @@ class HathorWallet extends EventEmitter {
       index,
     };
 
+    // Height-lock inputs are constant across the whole scan; read them once
+    // instead of per-output.
+    const nowHeight = await this.storage.getCurrentHeight();
+    const rewardLock = this.storage.version?.reward_spend_min_blocks;
+
     // Iterate through transactions
     for await (const tx of this.storage.txHistory()) {
       // Voided transactions should be ignored
@@ -1100,35 +1251,54 @@ class HathorWallet extends EventEmitter {
         continue;
       }
 
-      // Iterate through outputs
-      for (const output of tx.outputs) {
-        const is_address_valid = output.decoded && output.decoded.address === address;
-        const is_token_valid = token === output.token;
-        const is_authority = transactionUtils.isAuthorityOutput(output);
-        if (!is_address_valid || !is_token_valid || is_authority) {
-          continue;
-        }
+      // Shared per-output accounting for this address+token. hathor-core
+      // stamps `spent_by` and `decoded` on BOTH transparent and
+      // shielded outputs, so the two output kinds feed identical totals — only
+      // the field plumbing differs at the two call sites below.
+      const accrue = (
+        value: bigint,
+        decodedAddress: string | undefined,
+        outputToken: string,
+        spentBy: string | null | undefined,
+        lockable: Parameters<typeof transactionUtils.isOutputLocked>[0]
+      ): void => {
+        if (decodedAddress !== address || token !== outputToken) return;
+        const is_spent = (spentBy ?? null) !== null;
+        const is_locked =
+          transactionUtils.isOutputLocked(lockable) ||
+          transactionUtils.isHeightLocked(tx.height, nowHeight, rewardLock);
 
-        const is_spent = output.spent_by !== null;
-        const is_time_locked = transactionUtils.isOutputLocked(output);
-        // XXX: we currently do not check heightlock on the helper, checking here for compatibility
-        const nowHeight = await this.storage.getCurrentHeight();
-        const rewardLock = this.storage.version?.reward_spend_min_blocks;
-        const is_height_locked = transactionUtils.isHeightLocked(tx.height, nowHeight, rewardLock);
-        const is_locked = is_time_locked || is_height_locked;
-
-        addressInfo.total_amount_received += output.value;
-
+        addressInfo.total_amount_received += value;
         if (is_spent) {
-          addressInfo.total_amount_sent += output.value;
-          continue;
+          addressInfo.total_amount_sent += value;
+          return;
         }
-
         if (is_locked) {
-          addressInfo.total_amount_locked += output.value;
+          addressInfo.total_amount_locked += value;
         } else {
-          addressInfo.total_amount_available += output.value;
+          addressInfo.total_amount_available += value;
         }
+      };
+
+      // Transparent outputs — authority outputs never count toward value totals.
+      for (const output of tx.outputs) {
+        if (transactionUtils.isAuthorityOutput(output)) continue;
+        accrue(output.value, output.decoded?.address, output.token, output.spent_by, output);
+      }
+
+      // SEPARATED model: owned shielded outputs live in tx.shielded_outputs[]
+      // (value/token written in place after decryption), with decoded.address =
+      // the shielded-spend P2PKH. Only wallet-owned slots (value !== undefined)
+      // carry an opening; the rest are skipped.
+      for (const so of tx.shielded_outputs ?? []) {
+        if (so.value === undefined) continue; // not owned / not yet decrypted
+        accrue(
+          so.value,
+          so.decoded?.address,
+          so.token ?? NATIVE_TOKEN_UID,
+          so.spent_by ?? null,
+          so
+        );
       }
     }
 
@@ -1152,6 +1322,10 @@ class HathorWallet extends EventEmitter {
       amount_bigger_than: options.amount_bigger_than,
       max_amount: options.max_amount,
       only_available_utxos: options.only_available_utxos,
+      // Transparent-only by default: getUtxos feeds consolidateUtxos, which
+      // spends its results as TRANSPARENT inputs — a shielded UTXO leaking in
+      // would be mis-spent. Callers wanting shielded UTXOs opt in explicitly.
+      shielded: options.shielded ?? false,
     };
     const utxoDetails: UtxoDetails = {
       total_amount_available: 0n,
@@ -1429,7 +1603,7 @@ class HathorWallet extends EventEmitter {
       });
     }
 
-    await this.storage.processHistory();
+    await this.storage.processHistory(this.pinCode ?? undefined);
   }
 
   /**
@@ -1442,7 +1616,12 @@ class HathorWallet extends EventEmitter {
     // check address scanning policy and load more addresses if needed
     const loadMoreAddresses = await checkScanningPolicy(this.storage);
     if (loadMoreAddresses !== null) {
-      await this.syncHistory(loadMoreAddresses.nextIndex, loadMoreAddresses.count, processHistory);
+      await this.syncHistory(
+        loadMoreAddresses.nextIndex,
+        loadMoreAddresses.count,
+        processHistory,
+        this.pinCode ?? undefined
+      );
     }
   }
 
@@ -1476,10 +1655,25 @@ class HathorWallet extends EventEmitter {
   /**
    * Enqueue the call for onNewTx with the given data.
    *
+   * The `.catch` is load-bearing — without it, one rejection inside
+   * onNewTx (or any of its downstream awaits: `addTx`, `processNewTx`,
+   * the shielded decryption loop, `processHistory`, etc.) would leave
+   * `newTxPromise` in a rejected state, and every subsequent
+   * `.then(() => onNewTx(...))` would propagate the rejection without
+   * invoking the handler. The wallet would silently stop processing
+   * websocket events for the rest of the session. Logging the error and
+   * swallowing the rejection preserves the queue contract for follow-up
+   * messages while keeping the underlying failure visible.
+   *
    * @param wsData WebSocket message data containing transaction history
    */
   enqueueOnNewTx(wsData: WalletWebSocketData): void {
-    this.newTxPromise = this.newTxPromise.then(() => this.onNewTx(wsData));
+    this.newTxPromise = this.newTxPromise
+      .then(() => this.onNewTx(wsData))
+      .catch(err => {
+        const txId = wsData?.history?.tx_id ?? '<unknown>';
+        this.logger.error(`enqueueOnNewTx: onNewTx failed for tx ${txId}: ${err?.stack ?? err}`);
+      });
   }
 
   /**
@@ -1494,6 +1688,27 @@ class HathorWallet extends EventEmitter {
       return;
     }
     const newTx = parseResult.data;
+
+    // Normalize: convert the shielded outputs' base64 confidential fields to hex
+    // (the fullnode delivers them already separated in shielded_outputs[]).
+    transactionUtils.normalizeShieldedOutputs(newTx);
+
+    // SECURITY: the wire never legitimately carries decoded shielded values —
+    // the fullnode hides them behind commitments. Any value/token/blinding on an
+    // incoming WS payload is therefore UNTRUSTED: a malicious or compromised
+    // data source could pre-fill them to forge a credit that bypasses the ECDH
+    // rewind (processNewTx's `alreadyDecoded` gate would skip verification). See
+    // crypto_failures J.40–J.43. Strip the owned-marker fields here so ownership
+    // is re-established ONLY from our own rewind or the per-slot merge from our
+    // own storage (below). commitment / range_proof / ephemeral_pubkey / script /
+    // decoded.address are kept — they're public and required to rewind.
+    for (const so of newTx.shielded_outputs ?? []) {
+      so.value = undefined;
+      so.token = undefined;
+      so.blindingFactor = undefined;
+      so.assetBlindingFactor = undefined;
+    }
+
     // Later we will compare the storageTx and the received tx.
     // To avoid reference issues we clone the current storageTx.
     const storageTx = cloneDeep(await this.storage.getTx(newTx.tx_id));
@@ -1501,35 +1716,161 @@ class HathorWallet extends EventEmitter {
 
     newTx.processingStatus = TxHistoryProcessingStatus.PROCESSING;
 
+    // On re-delivery, the wire form typically strips previously-decoded data:
+    //   - shielded INPUTS lose value/token/token_data (the UTXO was deleted on
+    //     first receipt, so the fullnode just sends the bare reference);
+    //   - shielded OUTPUTS come back as bare wire entries in shielded_outputs[]
+    //     (commitment/range_proof only, no `value`/`token`/blinding) — the
+    //     whole array is PRESENT but value-less.
+    //
+    // The `addTx` below unconditionally persists `newTx`, so we must merge the
+    // decoded fields from the previously-stored tx INTO newTx before that save.
+    // A whole-array `if (!newTx.shielded_outputs)` guard is INSUFFICIENT: a bare
+    // WS re-delivery has the array present-but-value-less and would clobber the
+    // decoded data. We merge PER-SLOT instead, keyed by on-chain position.
+    if (!isNewTx && storageTx) {
+      // Merge shielded input enrichment (value/token/etc.) from storage.
+      for (let i = 0; i < newTx.inputs.length; i += 1) {
+        const input = newTx.inputs[i];
+        if (input.decoded?.address && input.token !== undefined) continue;
+        const storedInput = storageTx.inputs?.find(
+          si => si.tx_id === input.tx_id && si.index === input.index
+        );
+        if (storedInput?.decoded?.address && storedInput.token !== undefined) {
+          input.decoded = storedInput.decoded;
+          input.value = storedInput.value;
+          input.token = storedInput.token;
+          input.token_data = storedInput.token_data ?? 0;
+        }
+      }
+      // Restore shielded slots dropped by a metadata-only re-delivery. The
+      // fullnode can re-send a known tx WITHOUT its shielded_outputs (or with
+      // fewer slots) — a bare metadata ping. The unconditional addTx below would
+      // then overwrite the decoded array with nothing, eroding the balance to
+      // undefined on every such update (A.3/A.4). Re-base on the stored array so
+      // the per-slot merge can preserve every decoded slot; values copied here
+      // come from our own storage, so they are trusted (unlike wire-provided
+      // values, which were stripped above).
+      const storedShielded = storageTx.shielded_outputs ?? [];
+      if (storedShielded.length > (newTx.shielded_outputs?.length ?? 0)) {
+        newTx.shielded_outputs = cloneDeep(storedShielded);
+      }
+      // PER-SLOT merge of shielded_outputs[]: for each slot whose incoming
+      // value is undefined (non-owned or bare re-delivery), copy the
+      // owned-marker + decoded fields the wallet already decrypted on a prior
+      // receipt. This preserves balance + unblinding data across re-deliveries.
+      const newShielded = newTx.shielded_outputs ?? [];
+      for (let s = 0; s < newShielded.length; s += 1) {
+        const stored = storedShielded[s];
+        if (!stored) continue;
+        if (newShielded[s].value === undefined && stored.value !== undefined) {
+          newShielded[s].value = stored.value;
+          newShielded[s].token = stored.token;
+          newShielded[s].decoded = stored.decoded;
+          newShielded[s].blindingFactor = stored.blindingFactor;
+          newShielded[s].assetBlindingFactor = stored.assetBlindingFactor;
+        }
+      }
+    }
+
     await this.storage.addTx(newTx);
     await this.scanAddressesToLoad();
+
+    // Detect when an "update" event for a known tx is actually delivering
+    // shielded outputs that weren't decoded on the first receipt. The fullnode
+    // sometimes sends a tx in two stages — first a bare announcement, then a
+    // follow-up carrying the full shielded data. Without this branch the second
+    // message would route to processMetadataChanged (which doesn't decrypt) and
+    // the per-tx delta would forever read as -input until the next full reload.
+    // Gate on the SEPARATED decoded marker `value !== undefined`.
+    const storedHasDecodedShielded = (storageTx?.shielded_outputs ?? []).some(
+      so => so.value !== undefined
+    );
+    const newHasUndecodedShielded = (newTx.shielded_outputs ?? []).some(
+      so => so.value === undefined
+    );
+    const shieldedNewlyAvailable = !isNewTx && newHasUndecodedShielded && !storedHasDecodedShielded;
 
     // set state to processing and save current state.
     const previousState = this.state;
     this.state = HathorWallet.PROCESSING;
+    let didProcessHistory = false;
     if (isNewTx) {
       // Process this single transaction.
       // Handling new metadatas and deleting utxos that are not available anymore
-      await this.storage.processNewTx(newTx);
-    } else if (storageTx.is_voided !== newTx.is_voided) {
-      // This is a voided transaction update event.
-      // voided transactions require a full history reprocess.
-      await this.storage.processHistory();
+      await this.storage.processNewTx(newTx, this.pinCode ?? undefined);
+    } else if (storageTx.is_voided !== newTx.is_voided || shieldedNewlyAvailable) {
+      // Voided change OR shielded data only now arriving — both require a full
+      // history reprocess to avoid double-counting from the prior partial
+      // processNewTx.
+      await this.storage.processHistory(this.pinCode ?? undefined);
+      didProcessHistory = true;
     } else if (!newTx.is_voided) {
       // Process other types of metadata updates.
       await processMetadataChanged(this.storage, newTx);
     }
+
+    // Safety net: if any stored tx has an OWNED-but-undecoded shielded slot,
+    // decryption silently failed at some point (e.g. the recipient address
+    // wasn't in the wallet cache when processNewTx's decryption loop ran).
+    // Retry decryption with current wallet state — the same recovery path a
+    // reload takes.
+    //
+    // Two gates, both required:
+    //   (a) DECODED gate: at least one slot the wallet OWNS is still undecoded
+    //       (`value === undefined`) — a tx the wallet owns NO output of must
+    //       NOT trigger processHistory on every unrelated onNewTx event.
+    //   (b) OWNERSHIP gate: the undecoded slot's `decoded.address` is one of
+    //       the wallet's addresses. Without this, fully-non-owned shielded txs
+    //       (every slot value-less but foreign) would retry forever.
+    // Only runs when crypto provider + pinCode are available, and skips if we
+    // already reran processHistory above.
+    if (!didProcessHistory && this.storage.shieldedCryptoProvider && this.pinCode) {
+      let needsRetry = false;
+      // eslint-disable-next-line no-restricted-syntax
+      for await (const storedTx of this.storage.txHistory()) {
+        const shielded = storedTx.shielded_outputs ?? [];
+        if (shielded.length === 0) continue;
+        for (const so of shielded) {
+          // Already decoded — nothing to retry for this slot.
+          if (so.value !== undefined) continue;
+          // Ownership gate: only retry for slots the wallet owns but hasn't
+          // decoded yet. A value-less slot whose decoded.address is foreign (or
+          // absent) is not ours and must be skipped.
+          const addr = so.decoded?.address;
+          if (!addr) continue;
+          // eslint-disable-next-line no-await-in-loop
+          if (await this.storage.isAddressMine(addr)) {
+            needsRetry = true;
+            break;
+          }
+        }
+        if (needsRetry) break;
+      }
+      if (needsRetry) {
+        await this.storage.processHistory(this.pinCode);
+      }
+    }
     // restore previous state
     this.state = previousState;
 
-    newTx.processingStatus = TxHistoryProcessingStatus.FINISHED;
-    // Save the transaction in the storage
-    await this.storage.addTx(newTx);
+    // Trust storage as the source of truth for the final save. The processing
+    // branches above (processNewTx / processHistory / processMetadataChanged)
+    // have persisted the authoritative post-decryption state — including the
+    // owned-marker fields written in place onto shielded_outputs[], enriched
+    // shielded inputs, saved UTXOs, and updated address/token metadata. The
+    // `newTx` object in scope still carries the (merged) wire form. Re-read the
+    // persisted tx, update only the processingStatus flag, and save that. Works
+    // for any input/output mix (transparent / AmountShielded / FullShielded).
+    const persisted = await this.storage.getTx(newTx.tx_id);
+    const txToSave = persisted ?? newTx;
+    txToSave.processingStatus = TxHistoryProcessingStatus.FINISHED;
+    await this.storage.addTx(txToSave);
 
     if (isNewTx) {
-      this.emit('new-tx', newTx);
+      this.emit('new-tx', txToSave);
     } else {
-      this.emit('update-tx', newTx);
+      this.emit('update-tx', txToSave);
     }
   }
 
@@ -1710,6 +2051,20 @@ class HathorWallet extends EventEmitter {
         throw new Error('This should never happen');
       }
       await this.storage.saveAccessData(accessData);
+    } else if (pinCode && password) {
+      // Existing wallet — migrate forward if the persisted record predates
+      // shielded support. `migrateShieldedAccessData` is idempotent and a
+      // no-op for xpub-only wallets (nothing to derive from). We only persist
+      // when fields were actually written.
+      const migrated = walletUtils.migrateShieldedAccessData(accessData, {
+        pin: pinCode,
+        password,
+        passphrase: this.passphrase,
+        networkName: this.conn.getCurrentNetwork(),
+      });
+      if (migrated) {
+        await this.storage.saveAccessData(accessData);
+      }
     }
 
     this.clearSensitiveData();
@@ -1723,6 +2078,13 @@ class HathorWallet extends EventEmitter {
     if (info.network.indexOf(this.conn.getCurrentNetwork()) >= 0) {
       this.storage.setApiVersion(info);
       await this.storage.saveNativeToken();
+
+      // Note: shielded crypto provider is not auto-detected. Clients that need
+      // shielded support MUST install the appropriate crypto package
+      // (@hathor/ct-crypto-node for Node, @hathor/ct-crypto-wasm for browser
+      // verifier-only) and register the provider explicitly via
+      // `wallet.setShieldedCryptoProvider(...)` before starting the wallet.
+
       this.conn.start();
     } else {
       this.setState(HathorWallet.CLOSED);
@@ -2644,6 +3006,16 @@ class HathorWallet extends EventEmitter {
         addresses.add(io.decoded.address);
       }
     }
+    // SEPARATED model: a shielded output the wallet owns lives in
+    // tx.shielded_outputs[], not tx.outputs[]; its decoded.address is the
+    // wallet's on-chain spend-derived P2PKH. Without this a shielded-only
+    // receive returns an empty/incomplete address set. decoded.address is
+    // on-wire so this works regardless of decryption state.
+    for (const so of tx.shielded_outputs ?? []) {
+      if (so.decoded?.address && (await this.isAddressMine(so.decoded.address))) {
+        addresses.add(so.decoded.address);
+      }
+    }
 
     return addresses;
   }
@@ -2963,14 +3335,42 @@ class HathorWallet extends EventEmitter {
       throw new Error(`Failed to get transaction ${txId}: ${fullTx.message}`);
     }
 
+    // Shielded outputs are never delivered inline in outputs[] (they arrive in
+    // the dedicated shielded_outputs[] field), so every wire output here is
+    // transparent and can be hydrated. Shielded inputs, however, may arrive bare
+    // (commitment only) and lack the token_data hydrateWithTokenUid needs, so
+    // those are skipped.
     fullTx.tx.outputs = fullTx.tx.outputs.map(output =>
       hydrateWithTokenUid(output, fullTx.tx.tokens)
     );
-    fullTx.tx.inputs = fullTx.tx.inputs.map(input => hydrateWithTokenUid(input, fullTx.tx.tokens));
+    // Inputs can include a bare shielded input (no transparent token_data) — skip
+    // it; getTxBalance recovers its value/token from the parent shielded output.
+    fullTx.tx.inputs = fullTx.tx.inputs.map(input =>
+      transactionUtils.isShieldedInputEntry(input as { type?: string })
+        ? input
+        : hydrateWithTokenUid(input as { token_data: number }, fullTx.tx.tokens)
+    ) as typeof fullTx.tx.inputs;
+
+    // Prefer the locally-decoded tx for the balance. A fresh fullnode fetch
+    // carries shielded_outputs WITHOUT their decrypted value/token (the wallet's
+    // ECDH-recovered plaintext lives only in local storage), so getTxBalance
+    // over the wire copy credits 0 for owned shielded outputs and could even
+    // throw "no balance" for a shielded-only receive. Fall back to the
+    // (normalized) wire copy only when the tx isn't in our local history.
+    const localTx = await this.storage.getTx(txId);
+    let balanceTx: IHistoryTx;
+    if (localTx) {
+      balanceTx = localTx;
+    } else {
+      // Normalize the shielded outputs' base64 confidential fields to hex
+      // (getTxBalance reads off the separated shielded_outputs[] array).
+      transactionUtils.normalizeShieldedOutputs(fullTx.tx as unknown as IHistoryTx);
+      balanceTx = fullTx.tx as unknown as IHistoryTx;
+    }
 
     // Get the balance of each token in the transaction that belongs to this wallet
     // sample output: { 'A': 100, 'B': 10 }, where 'A' and 'B' are token UIDs
-    const tokenBalances = await this.getTxBalance(fullTx.tx as unknown as IHistoryTx);
+    const tokenBalances = await this.getTxBalance(balanceTx);
     const { length: hasBalance } = Object.keys(tokenBalances);
     if (!hasBalance) {
       throw new Error(`Transaction ${txId} does not have any balance for this wallet`);
@@ -3310,6 +3710,16 @@ class HathorWallet extends EventEmitter {
   }
 
   /**
+   * Set the shielded crypto provider for confidential transaction support.
+   * Use this for explicit injection (e.g., mobile apps using UniFFI bindings).
+   *
+   * @param provider The shielded crypto provider, or undefined to disable
+   */
+  setShieldedCryptoProvider(provider?: IShieldedCryptoProvider): void {
+    this.storage.setShieldedCryptoProvider(provider);
+  }
+
+  /**
    * Set the history sync mode.
    *
    * @param mode The history sync mode to use
@@ -3328,7 +3738,8 @@ class HathorWallet extends EventEmitter {
   async syncHistory(
     startIndex: number,
     count: number,
-    shouldProcessHistory: boolean = false
+    shouldProcessHistory?: boolean,
+    pinCode?: string
   ): Promise<void> {
     if (!(await getSupportedSyncMode(this.storage)).includes(this.historySyncMode)) {
       throw new Error('Trying to use an unsupported sync method for this wallet.');
@@ -3352,7 +3763,7 @@ class HathorWallet extends EventEmitter {
     // This will add the task to the GLL queue and return a promise that
     // resolves when the task finishes executing
     await GLL.add(async () => {
-      await syncMethod(startIndex, count, this.storage, this.conn, shouldProcessHistory);
+      await syncMethod(startIndex, count, this.storage, this.conn, shouldProcessHistory, pinCode);
     });
   }
 
@@ -3362,9 +3773,18 @@ class HathorWallet extends EventEmitter {
   async reloadStorage(): Promise<void> {
     await this.conn.onReload();
 
-    // unsub all addresses
+    // unsub all addresses. getAllAddresses() yields the legacy chain; shielded
+    // receives are subscribed by their on-chain spend-derived P2PKH (the 71-byte
+    // shielded address itself is never subscribed — the fullnode indexes by
+    // on-chain script), so also unsubscribe each shielded record's paired spend
+    // P2PKH (ctMappingAddress). Without this, shielded subscriptions leak on reload.
     for await (const address of this.storage.getAllAddresses()) {
       this.conn.unsubscribeAddress(address.base58);
+    }
+    for await (const address of this.storage.getAllAddresses({ legacy: false })) {
+      if (address.ctMappingAddress) {
+        this.conn.unsubscribeAddress(address.ctMappingAddress);
+      }
     }
     const accessData = await this.storage.getAccessData();
     if (accessData != null) {
@@ -3374,7 +3794,12 @@ class HathorWallet extends EventEmitter {
       await this.storage.saveAccessData(accessData);
     }
     const addressesToLoad = await scanPolicyStartAddresses(this.storage);
-    await this.syncHistory(addressesToLoad.nextIndex, addressesToLoad.count);
+    await this.syncHistory(
+      addressesToLoad.nextIndex,
+      addressesToLoad.count,
+      false,
+      this.pinCode ?? undefined
+    );
   }
 
   /**

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -21,6 +21,10 @@ import {
   TxHistoryProcessingStatus,
 } from './types';
 import { bigIntCoercibleSchema, ZodSchema } from './utils/bigint';
+// Type-only: the enum's runtime value lives in the native @hathor/ct-crypto-provider
+// package; importing it as a value would pull that native module into every consumer
+// of this schema module. We only need it to type the `mode` wire field.
+import type { ShieldedOutputMode } from './shielded/types';
 
 /**
  * TxId schema
@@ -74,17 +78,33 @@ export const IHistoryOutputDecodedSchema: ZodSchema<IHistoryOutputDecoded> = z
 
 export const IHistoryInputSchema: ZodSchema<IHistoryInput> = z
   .object({
-    value: bigIntCoercibleSchema,
-    token_data: z.number(),
-    script: z.string(),
-    decoded: IHistoryOutputDecodedSchema,
-    token: z.string(),
+    // These fields may be absent for shielded inputs (spent output value/token hidden)
+    value: bigIntCoercibleSchema.optional(),
+    token_data: z.number().optional(),
+    script: z.string().optional(),
+    decoded: IHistoryOutputDecodedSchema.optional(),
+    token: z.string().optional(),
+    // Always present:
     tx_id: txIdSchema,
     index: z.number(),
+    // Marks a shielded spend when set to 'shielded'. The alpha fullnode also
+    // stamps 'transparent' on ordinary inputs (older nodes omit the field).
+    // Accept any string and never fail-closed on this external discriminator:
+    // the wallet's only semantic use is `=== 'shielded'` (see
+    // utils/transaction.ts:isShieldedInputEntry). A strict literal here rejects
+    // every transparent input and bricks wallet-history loading.
+    type: z.string().optional(),
+    commitment: z.string().optional(),
   })
-  .passthrough();
+  .passthrough() as ZodSchema<IHistoryInput>;
 
-export const IHistoryOutputSchema: ZodSchema<IHistoryOutput> = z
+// SEPARATED model: `outputs[]` is transparent-only. The fullnode
+// delivers shielded outputs in a dedicated top-level `shielded_outputs[]` array
+// on every path — HTTP `/transaction` (to_json) and `address_history` + the WS
+// real-time path (to_json_extended) — so a transparent-only output schema
+// validates the raw wire directly; there are no inline `type: 'shielded'`
+// entries in `outputs[]` to accommodate.
+const transparentHistoryOutputSchema = z
   .object({
     value: bigIntCoercibleSchema,
     token_data: z.number(),
@@ -95,6 +115,9 @@ export const IHistoryOutputSchema: ZodSchema<IHistoryOutput> = z
     selected_as_input: z.boolean().optional(),
   })
   .passthrough();
+
+export const IHistoryOutputSchema: ZodSchema<IHistoryOutput> =
+  transparentHistoryOutputSchema as unknown as ZodSchema<IHistoryOutput>;
 
 export const IHistoryNanoContractBaseAction = z.object({
   token_uid: z.string(),
@@ -142,6 +165,48 @@ export const IHistoryNanoContractContextSchema = z
   })
   .passthrough();
 
+// The wire fields shared by a shielded output on BOTH the fullnode tx API
+// (`fullnodeTxApiShieldedOutputSchema`, api/schemas/txApi.ts) and the wallet
+// history (`IHistoryShieldedOutputSchema` below). Only the `decoded` sub-schema
+// and the history-only owned-marker fields differ between the two, so each
+// composes this base via `z.object({ ...shieldedOutputWireShape, ... })`.
+//
+// `mode` is REQUIRED: the fullnode always sets it on the wire, so readers
+// classify directly from it. `token_data` defaults to 0 (native-token slot)
+// because FullShielded outputs hide the token UID behind `asset_commitment`
+// and may omit the field.
+export const shieldedOutputWireShape = {
+  // Wire value is a raw number (1=AmountShielded, 2=FullShielded); type it as
+  // ShieldedOutputMode without pulling the native provider's runtime enum in.
+  mode: z.number() as unknown as z.ZodType<ShieldedOutputMode>,
+  commitment: z.string(),
+  range_proof: z.string(),
+  script: z.string(),
+  token_data: z.number().optional().default(0),
+  ephemeral_pubkey: z.string(),
+  asset_commitment: z.string().optional(),
+  surjection_proof: z.string().optional(),
+  spent_by: z.string().nullable().optional(),
+};
+
+// SEPARATED model: history shape of one entry in `tx.shielded_outputs[]`.
+// Mirrors `IHistoryShieldedOutput` (src/types.ts): the shared wire fields plus
+// the OPTIONAL owned-marker fields written in place when the wallet decrypts an
+// output it owns. `value !== undefined` is the single ownership/decoded gate.
+const IHistoryShieldedOutputSchema = z
+  .object({
+    ...shieldedOutputWireShape,
+    decoded: IHistoryOutputDecodedSchema,
+    // ── owned-marker fields (SEPARATED model) ──
+    // Written in place when the wallet decrypts an output it owns. A slot with
+    // `value === undefined` is non-owned (or not yet decrypted).
+    value: bigIntCoercibleSchema.optional(),
+    token: z.string().optional(),
+    blindingFactor: z.string().optional(),
+    assetBlindingFactor: z.string().optional(),
+  })
+  .passthrough();
+
 export const IHistoryTxSchema: ZodSchema<IHistoryTx> = z
   .object({
     tx_id: txIdSchema,
@@ -158,6 +223,7 @@ export const IHistoryTxSchema: ZodSchema<IHistoryTx> = z
     token_symbol: z.string().optional(),
     tokens: z.string().array().optional(),
     height: z.number().optional(),
+    shielded_outputs: IHistoryShieldedOutputSchema.array().optional(),
     processingStatus: z.nativeEnum(TxHistoryProcessingStatus).optional(),
     nc_id: z.string().optional(),
     nc_blueprint_id: z.string().optional(),

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -50,12 +50,10 @@ export interface IShieldedOutputProofs {
 }
 
 export interface IShieldedOutput extends IShieldedOutputProofs {
-  // Optional because hathor-core nodes pre-`_shielded_output_to_json`
-  // mode-field addition still send shielded outputs without `mode`.
-  // Readers must fall back to detecting FullShielded via the presence
-  // of `asset_commitment` (the same pattern already used in the
-  // explorer's `TxData.isFullShielded`).
-  mode?: ShieldedOutputMode;
+  // First byte of every shielded output on the wire (see
+  // ShieldedOutput.serialize/deserialize): the fullnode always sets it
+  // (1=AmountShielded, 2=FullShielded), so readers classify directly from it.
+  mode: ShieldedOutputMode;
   script: string; // hex, output script (P2PKH/P2SH)
   // FullShielded outputs may omit `token_data` (the token UID is hidden
   // behind `asset_commitment`, so the field has no meaningful value).

--- a/src/storage/memory_store.ts
+++ b/src/storage/memory_store.ts
@@ -513,6 +513,26 @@ export class MemoryStore implements IStore {
         yield tx;
         continue;
       }
+      // SEPARATED model: an owned shielded output lives in shielded_outputs[],
+      // not outputs[]. Without this loop a shielded-only receive (the wallet
+      // owns no transparent output of the tx) never appears in tokenHistory /
+      // getTxHistory (G.30/G.31). Owned slots carry value !== undefined and the
+      // decoded token after decryption; non-owned slots are value-less and skipped.
+      for (const so of tx.shielded_outputs ?? []) {
+        if (
+          so.value !== undefined &&
+          so.decoded?.address &&
+          this.addresses.has(so.decoded.address) &&
+          (so.token ?? NATIVE_TOKEN_UID) === tokenUid
+        ) {
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        yield tx;
+        continue;
+      }
     }
   }
 

--- a/src/sync/stream.ts
+++ b/src/sync/stream.ts
@@ -21,7 +21,7 @@ import Network from '../models/network';
 import Queue from '../models/queue';
 import { IHistoryTxSchema } from '../schemas';
 import { prepareP2SHChangeNodes, buildP2SHRedeemScriptAtIndex } from '../utils/scripts';
-import { redeemScriptToP2SHAddress } from '../utils/address';
+import { redeemScriptToP2SHAddress, deriveShieldedAddressFromStorage } from '../utils/address';
 /* eslint max-classes-per-file: ["error", 2] */
 
 const QUEUE_GRACEFUL_SHUTDOWN_LIMIT = 10000;
@@ -298,7 +298,8 @@ export async function xpubStreamSyncHistory(
   _count: number,
   storage: IStorage,
   connection: FullNodeConnection,
-  shouldProcessHistory: boolean = false
+  shouldProcessHistory?: boolean,
+  pinCode?: string
 ) {
   let firstIndex = startIndex;
   const scanPolicyData = await storage.getScanningPolicyData();
@@ -315,7 +316,7 @@ export async function xpubStreamSyncHistory(
     connection,
     HistorySyncMode.XPUB_STREAM_WS
   );
-  await streamSyncHistory(manager, shouldProcessHistory);
+  await streamSyncHistory(manager, shouldProcessHistory, pinCode);
 }
 
 export async function manualStreamSyncHistory(
@@ -323,7 +324,8 @@ export async function manualStreamSyncHistory(
   _count: number,
   storage: IStorage,
   connection: FullNodeConnection,
-  shouldProcessHistory: boolean = false
+  shouldProcessHistory?: boolean,
+  pinCode?: string
 ) {
   let firstIndex = startIndex;
   const scanPolicyData = await storage.getScanningPolicyData();
@@ -340,7 +342,7 @@ export async function manualStreamSyncHistory(
     connection,
     HistorySyncMode.MANUAL_STREAM_WS
   );
-  await streamSyncHistory(manager, shouldProcessHistory);
+  await streamSyncHistory(manager, shouldProcessHistory, pinCode);
 }
 
 /**
@@ -629,6 +631,28 @@ export class StreamManager extends AbortController {
         if (!alreadyExists) {
           await this.storage.saveAddress(addr);
         }
+        // Generate shielded address pair at the same index (if keys are available).
+        // Wrapped in try/catch so derivation failures don't crash the queue.
+        try {
+          const shieldedResult = await deriveShieldedAddressFromStorage(
+            addr.bip32AddressIndex,
+            this.storage
+          );
+          if (shieldedResult) {
+            if (!(await this.storage.isAddressMine(shieldedResult.shieldedAddress.base58))) {
+              await this.storage.saveAddress(shieldedResult.shieldedAddress);
+            }
+            if (!(await this.storage.isAddressMine(shieldedResult.spendAddress.base58))) {
+              await this.storage.saveAddress(shieldedResult.spendAddress);
+            }
+          }
+        } catch (e) {
+          this.logger.error(
+            'Failed to derive shielded address at index',
+            addr.bip32AddressIndex,
+            e
+          );
+        }
       } else if (isStreamItemVertex(item)) {
         await this.storage.addTx(item.vertex);
       }
@@ -820,7 +844,8 @@ function buildListener(manager: StreamManager, resolve: () => void) {
  */
 export async function streamSyncHistory(
   manager: StreamManager,
-  shouldProcessHistory: boolean
+  shouldProcessHistory?: boolean,
+  pinCode?: string
 ): Promise<void> {
   try {
     await manager.setupStream();
@@ -875,7 +900,7 @@ export async function streamSyncHistory(
     await manager.shutdown();
 
     if (manager.foundAnyTx && shouldProcessHistory) {
-      await manager.storage.processHistory();
+      await manager.storage.processHistory(pinCode);
     }
   } finally {
     // shutdown() (which clears the interval) is skipped when sendStartMessage throws; clean() is idempotent.

--- a/src/template/transaction/context.ts
+++ b/src/template/transaction/context.ts
@@ -128,6 +128,11 @@ export class TxBalance {
    * @param index - The output index
    */
   addBalanceFromUtxo(tx: IHistoryTx, index: number) {
+    // Templates are a transparent-only flow; reject an index that lands in the
+    // shielded range with a clear message rather than a misleading bounds error.
+    if (transactionUtils.isShieldedOutputIndex(tx, index)) {
+      throw new Error('Shielded inputs are not supported in transaction templates');
+    }
     if (tx.outputs.length <= index) {
       throw new Error('Index does not exist on tx outputs');
     }

--- a/src/template/transaction/executor.ts
+++ b/src/template/transaction/executor.ts
@@ -45,6 +45,7 @@ import {
 } from '../../constants';
 import { createOutputScriptFromAddress } from '../../utils/address';
 import { JSONBigInt } from '../../utils/bigint';
+import transactionUtils from '../../utils/transaction';
 import ScriptData from '../../models/script_data';
 import {
   getOracleScript,
@@ -146,6 +147,11 @@ export async function execRawInputInstruction(
 
   // Find the original transaction from the input
   const origTx = await interpreter.getTx(txId);
+  // Templates are a transparent-only flow; reject a shielded input index with a
+  // clear message instead of a confusing `undefined` destructure below.
+  if (transactionUtils.isShieldedOutputIndex(origTx, index)) {
+    throw new Error('Shielded inputs are not supported in transaction templates');
+  }
   // Cache the tokenVersion via addToken
   const { token } = origTx.outputs[index];
   await ctx.cacheTokenDetails(interpreter, token);

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,10 @@ export interface IInputSignature {
   addressIndex: number;
   signature: Buffer;
   pubkey: Buffer;
+  // Address type of the signed input, so consumers can render the matching
+  // derivation path. 'shielded-spend' inputs are signed with the spend chain
+  // (m/44'/280'/2'); undefined/legacy use the P2PKH/P2SH chain.
+  addressType?: AddressType | 'shielded-spend';
 }
 
 export enum HistorySyncMode {
@@ -348,8 +352,9 @@ export interface IHistoryInput {
   // `/transaction?id=…` responses; the wallet's sender-local insert
   // (`txUtils.convertTransactionToHistoryTx`) also stamps it so
   // self-sent shielded spends carry the discriminator before any
-  // WebSocket re-delivery. Absent on transparent inputs.
-  type?: 'shielded';
+  // WebSocket re-delivery. The alpha fullnode stamps 'transparent' on
+  // ordinary inputs; older nodes omit the field entirely.
+  type?: 'shielded' | 'transparent';
   // Shielded inputs carry their own commitment on the wire; surfaced
   // here so the explorer's unblinding verifier (and any future
   // re-derive flows) can read it without round-tripping the full tx.

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -52,6 +52,28 @@ export function getAddressType(address: string, network: Network): 'p2pkh' | 'p2
 }
 
 /**
+ * Resolve an address to the form usable as a transparent output script.
+ *
+ * Shielded addresses have no direct output script (on-chain they use the
+ * spend-derived P2PKH), so this returns the spend address base58 for a shielded
+ * input and the address unchanged otherwise. Use it before `getAddressType` /
+ * output building wherever a caller-supplied address may be shielded — e.g. a
+ * shielded change address in token creation (otherwise getAddressType throws).
+ * Mirrors the conversion the send pipeline applies to explicit shielded outputs.
+ *
+ * @param {string} address base58 address (may be shielded)
+ * @param {Network} network
+ * @returns {string} spend-derived P2PKH base58 if shielded, else `address`
+ */
+export function resolveOutputScriptAddress(address: string, network: Network): string {
+  const addressObj = new Address(address, { network });
+  if (addressObj.getType() === 'shielded') {
+    return addressObj.getSpendAddress().base58;
+  }
+  return address;
+}
+
+/**
  * Convert a bitcore PublicKey to a base58 P2PKH address string.
  */
 export function publicKeyToP2PKH(

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -44,7 +44,7 @@ export const JSONBigInt = {
     } catch (e) {
       if (
         e instanceof SyntaxError &&
-        (e.message === `Cannot convert ${context.source} to a BigInt` ||
+        (e.message === `Cannot convert ${context?.source} to a BigInt` ||
           e.message === `invalid BigInt syntax`)
       ) {
         // When this error happens, it means the number cannot be converted to a BigInt,

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1137,10 +1137,39 @@ export async function processNewTx(
   }
 
   for (const input of tx.inputs) {
+    // Enrich a bare shielded input from the parent tx's decoded shielded output
+    // so the balance debit below treats it like a transparent input. The
+    // realtime path enriches shielded inputs before processing (sender-local
+    // insert / onNewTx per-slot merge), but the reload path (processHistory)
+    // feeds bare {tx_id, index, type:'shielded'} inputs straight from
+    // address_history. Without this, a spent wallet-owned shielded UTXO is never
+    // debited from the balance counter on reload, so reload over-counts it vs
+    // realtime (the spent-output value lingers in `getBalance`). Gated on
+    // `value === undefined` so an already-enriched (realtime) input is debited
+    // exactly once. processHistory walks txs oldest-first, so the parent's
+    // shielded output is already decoded + persisted when we resolve it here.
+    if (input.value === undefined && transactionUtils.isShieldedInputEntry(input)) {
+      const parentTx = await storage.getTx(input.tx_id);
+      const resolved = parentTx
+        ? transactionUtils.resolveSpentOutput(parentTx, input.index)
+        : undefined;
+      if (resolved?.kind === 'shielded' && resolved.output.value !== undefined) {
+        const so = resolved.output;
+        if (so.decoded?.address && (await storage.isAddressMine(so.decoded.address))) {
+          input.value = so.value;
+          // owned + decoded (value gate above) ⇒ token is set; no HTR-mislabel fallback.
+          input.token = so.token!;
+          input.token_data = so.token_data ?? 0;
+          input.decoded = so.decoded;
+        }
+      }
+    }
+
     // Inputs spending shielded outputs carry no transparent fields
-    // (value/token/decoded are hidden in commitments). Their balance
-    // handling lands with the receive pipeline in the next PR; here we
-    // only need the type-level guard so transparent processing narrows.
+    // (value/token/decoded are hidden in commitments) until enriched above.
+    // Anything still bare here is a shielded input we don't own (or whose parent
+    // tx isn't ours) — skip it; the type-level guard also narrows the union for
+    // the transparent processing below.
     if (
       input.value === undefined ||
       input.token === undefined ||

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -29,7 +29,7 @@ import {
   TokenVersion,
   UtxoSelectionAlgorithm,
 } from '../types';
-import { getAddressType } from './address';
+import { getAddressType, resolveOutputScriptAddress } from './address';
 import {
   InsufficientFundsError,
   SendTxError,
@@ -492,7 +492,14 @@ const tokens = {
 
       // get output change
       if (foundAmount > requiredAmount) {
-        const cAddress = await storage.getChangeAddress({ changeAddress });
+        // A shielded change address has no direct output script; resolve it to
+        // its spend-derived P2PKH (same as explicit shielded outputs in the send
+        // pipeline). Without this, getAddressType throws for a shielded
+        // changeAddress and token creation with a shielded change fails (K.2).
+        const cAddress = resolveOutputScriptAddress(
+          await storage.getChangeAddress({ changeAddress }),
+          storage.config.getNetwork()
+        );
 
         // place at the beginning of the array to keep the order of the outputs
         outputs.unshift({

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -139,21 +139,41 @@ const transaction = {
   },
 
   /**
-   * Normalize a transaction's shielded outputs: convert any base64-encoded
-   * confidential fields (commitment / range_proof / script / ephemeral_pubkey /
-   * asset_commitment / surjection_proof) to hex in place. Mutates the tx.
+   * True when `index` is the on-chain absolute index of a SHIELDED output of
+   * `tx` — i.e. it falls in the shielded range `[outputs.length, outputs.length
+   * + shieldedCount)`. In the SEPARATED model transparent outputs occupy
+   * `outputs[0..N)` and shielded outputs occupy the slots immediately after.
+   * Transparent-only flows (partial txs, tx templates) use this to reject a
+   * shielded input index with a clear message instead of a misleading bounds
+   * error or an undefined output read.
+   */
+  isShieldedOutputIndex(
+    tx: { outputs: unknown[]; shielded_outputs?: unknown[] | null },
+    index: number
+  ): boolean {
+    const shieldedCount = tx.shielded_outputs?.length ?? 0;
+    return index >= tx.outputs.length && index < tx.outputs.length + shieldedCount;
+  },
+
+  /**
+   * Hex-encode the confidential wire fields of a transaction's shielded outputs,
+   * in place. The fullnode delivers shielded outputs SEPARATED in a
+   * dedicated `shielded_outputs[]` array on BOTH the HTTP `/transaction`
+   * (to_json) and the `address_history` + WS real-time (to_json_extended) paths,
+   * so `outputs[]` is always transparent-only — no inline relocation needed —
+   * and `mode` is always present on the wire.
    *
-   * The fullnode delivers shielded outputs in a dedicated `shielded_outputs[]`
-   * field (the separated model). Over the websocket real-time path their buffer
-   * fields arrive base64-encoded; without this conversion `Buffer.from(value,
-   * 'hex')` downstream parses them as garbage — making the native rewind throw
-   * "asset commitment verification failed" and the per-tx balance read as
-   * -input with no credit for the decoded shielded outputs.
+   * Converts every shielded output's base64 confidential fields (commitment /
+   * range_proof / script / ephemeral_pubkey / asset_commitment /
+   * surjection_proof) to hex; without this `Buffer.from(value, 'hex')`
+   * downstream parses them as garbage — making the native rewind throw "asset
+   * commitment verification failed" and the per-tx balance read as -input with
+   * no credit for the decoded shielded outputs.
    *
-   * Idempotent: an already-hex field is left unchanged (ensureHex no-ops on it).
-   * The owned-marker fields (value / token / blindingFactor / assetBlindingFactor)
-   * are NOT on the wire — they are populated post-decryption on the slots the
-   * wallet owns — so this neither reads nor invents them.
+   * Idempotent: ensureHex no-ops on already-hex fields. The owned-marker fields
+   * (value / token / blindingFactor / assetBlindingFactor) are NOT on the wire —
+   * they are populated post-decryption on the slots the wallet owns — so this
+   * neither reads nor invents them.
    */
   normalizeShieldedOutputs(tx: IHistoryTx): void {
     if (!tx.shielded_outputs) {
@@ -161,6 +181,7 @@ const transaction = {
       return;
     }
 
+    // Hex-encode the confidential wire fields of every shielded output.
     for (const so of tx.shielded_outputs) {
       // eslint-disable-next-line no-param-reassign
       so.commitment = ensureHex(so.commitment);
@@ -339,6 +360,10 @@ const transaction = {
         addressIndex: addressInfo.bip32AddressIndex,
         signature: this.getSignature(dataToSignHash, derivedKey.privateKey),
         pubkey: derivedKey.publicKey.toDER(),
+        // Carry the address type so callers (getSignatures) can render the
+        // matching derivation path: a 'shielded-spend' input was signed with the
+        // spend chain (m/44'/280'/2'), not the legacy P2PKH chain.
+        addressType: addressInfo.addressType,
       });
     }
 
@@ -1131,7 +1156,10 @@ const transaction = {
           script: shieldedEntry.script ?? '',
           decoded: shieldedEntry.decoded ?? {},
           token_data: shieldedEntry.token_data ?? 0,
-          token: shieldedEntry.token ?? NATIVE_TOKEN_UID,
+          // Owned + decoded (gated by `value !== undefined` above): decryption
+          // always recovers the token, so no NATIVE_TOKEN_UID fallback — which
+          // would mislabel a custom token as HTR (matches the credit path).
+          token: shieldedEntry.token!,
           value: shieldedEntry.value,
         });
         continue;
@@ -1538,22 +1566,18 @@ const transaction = {
 
     // SEPARATED model: `outputs[]` is transparent-only — hydrate each with its
     // token. Shielded outputs arrive in a dedicated `shielded_outputs[]` field
-    // (passthrough — not in the zod schema); convert their base64 buffer fields
-    // to hex so downstream decryption (Buffer.from(value, 'hex')) parses them.
+    // (passthrough — not in the zod schema); they are shallow-copied here and
+    // hex-normalized in one pass via normalizeShieldedOutputs(histTx) below.
     const outputs: IHistoryOutput[] = tx.outputs.map(
       o => this.hydrateIOWithToken(o, tx.tokens) as IHistoryOutput
     );
 
     const separateShielded = (tx as { shielded_outputs?: IHistoryShieldedOutput[] })
       .shielded_outputs;
+    // Shallow-copy each slot so the hex normalization below mutates our copies,
+    // not the caller's txResponse objects.
     const shieldedOutputs: IHistoryShieldedOutput[] = (separateShielded ?? []).map(so => ({
       ...so,
-      commitment: ensureHex(so.commitment),
-      range_proof: ensureHex(so.range_proof),
-      script: ensureHex(so.script),
-      ephemeral_pubkey: ensureHex(so.ephemeral_pubkey),
-      asset_commitment: so.asset_commitment ? ensureHex(so.asset_commitment) : undefined,
-      surjection_proof: so.surjection_proof ? ensureHex(so.surjection_proof) : undefined,
     }));
 
     const histTx: IHistoryTx = {
@@ -1582,6 +1606,10 @@ const transaction = {
     if (tx.nc_address) histTx.nc_address = tx.nc_address;
     if (tx.nc_context) histTx.nc_context = tx.nc_context;
     if (tx.nc_pubkey) histTx.nc_pubkey = tx.nc_pubkey;
+
+    // Hex-encode the confidential wire fields (commitment/range_proof/script/…)
+    // in one pass — the same normalization used by the realtime/ws path.
+    this.normalizeShieldedOutputs(histTx);
 
     return histTx;
   },

--- a/src/utils/utxo.ts
+++ b/src/utils/utxo.ts
@@ -99,6 +99,12 @@ export async function bestUtxoSelection(
   let utxosAmount = 0n;
   let selectedUtxo: IUtxo | null = null;
 
+  // Select any UTXO (transparent or shielded) up to the requested amount.
+  // hathor-core accepts shielded inputs in transparent-output-only txs
+  // (see `is_shielded()` gating in verification_service.py); ownership is
+  // enforced via the P2PKH signature on the spend-derived key for shielded
+  // outputs, and the fullnode skips the HTR surplus/deficit check for
+  // shielded txs (commit 75831f9a).
   const options: IUtxoFilterOptions = {
     token,
     authorities: 0n,

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -13,6 +13,7 @@ import {
   IHistoryTx,
   IDataTx,
   WalletAddressMode,
+  IAddressChainOptions,
 } from '../types';
 import Transaction from '../models/transaction';
 import CreateTokenTransaction from '../models/create_token_transaction';
@@ -359,12 +360,15 @@ export interface IHathorWallet {
     options: { token?: string; changeAddress?: string }
   ): Promise<Transaction>;
   stop(params?: IStopWalletParams): void;
-  getAddressAtIndex(index: number): Promise<string>;
+  getAddressAtIndex(index: number, opts?: IAddressChainOptions): Promise<string>;
   getAddressIndex(address: string): Promise<number | null>;
-  getCurrentAddress(options?: {
-    markAsUsed: boolean;
-  }): AddressInfoObject | Promise<AddressInfoObject>; // FIXME: Should have a single return type
-  getNextAddress(): AddressInfoObject | Promise<AddressInfoObject>; // FIXME: Should have a single return type;
+  getCurrentAddress(
+    options?: {
+      markAsUsed: boolean;
+    },
+    opts?: IAddressChainOptions
+  ): AddressInfoObject | Promise<AddressInfoObject>; // FIXME: Should have a single return type
+  getNextAddress(opts?: IAddressChainOptions): AddressInfoObject | Promise<AddressInfoObject>; // FIXME: Should have a single return type;
   getAddressPrivKey(pinCode: string, addressIndex: number): Promise<bitcore.PrivateKey>;
   signMessageWithAddress(message: string, index: number, pinCode: string): Promise<string>;
   prepareCreateNewToken(
@@ -724,6 +728,8 @@ export interface FullNodeOutput {
   decoded: FullNodeDecodedOutput;
   token?: string | null;
   spent_by?: string | null;
+  // Shielded entries appended by fullnode's to_json_extended() have type='shielded'
+  type?: string;
 }
 
 export interface FullNodeTx {


### PR DESCRIPTION
## Summary

Wires PRs 1–5 into the wallet's transaction-building and lifecycle paths. The integration slice: **receive** (`onNewTx` → `normalizeShieldedOutputs` → `processShieldedOutputs` → `saveAddress`) and **send** (`sendManyOutputs` → `buildShieldedOutputs` → `balanceBlindingFactors` → `attachHeader`) become end-to-end usable. **PR 6 of 7** in the decomposition of [PR #1059](https://github.com/HathorNetwork/hathor-wallet-lib/pull/1059).

```
master ─ PR1 ─ PR2 ─ PR3 ─ PR4 ─ PR5 ─ PR6 ◀ PR7
```

Base: `shielded/pr-5-storage-layer`.

Suggested **two reviewers**: one for wallet lifecycle + WS event ordering, one for send-side blinding factor arithmetic.

## Acceptance Criteria

- `wallet.start()` auto-loads the shielded crypto provider when `@hathor/ct-crypto-node` is installed; absence leaves the slot undefined and every downstream branch short-circuits.
- `wallet.start()` migrates pre-shielded access-data records to shielded when given both pinCode and password; xpub-only / xpriv-imported wallets bypass the migration.
- WS-driven receive (`onNewTx`) normalizes both shielded wire-shape variants (a) inline-in-outputs and (b) separated, then decrypts wallet-owned shielded outputs.
- A rejected `newTxPromise` no longer poisons the WS event chain — subsequent events continue to be processed (chain-resilience fix).
- `getShieldedUnblindingForTx` is available so audit/explorer tools can verify a shielded tx with browser-side primitives.
- `setPinCode` is available for runtime pin configuration.
- `sendManyOutputs` accepts shielded outputs (`ProposedOutput.shielded`) and a `changeShieldedMode` option so HTR fee-change can be emitted shielded, matching the recipient's privacy mode.
- The send pipeline builds shielded outputs with correct blinding-factor balancing (uses PR 2's `createShieldedOutputs`).
- The send pipeline attaches `ShieldedOutputsHeader` or `UnshieldBalanceHeader` correctly — the two are mutually exclusive.
- The send pipeline applies the correct per-output shielded fee (`FEE_PER_AMOUNT_SHIELDED_OUTPUT` or `FEE_PER_FULL_SHIELDED_OUTPUT`).
- Shielded addresses passed to the send pipeline are validated via `addressObj.isShielded()` and routed to the shielded mapping.
- `StreamManager` (xpub stream) derives the shielded + spend-address pair alongside each legacy address during initial load.
- The generic UTXO filter excludes shielded UTXOs by default; callers explicitly request shielded via `IUtxoFilterOptions.shielded`.
- `bigint.ts` JSON revival works on Hermes/RN engines (mobile compat fix).
- Zod schemas accept the relaxed shielded shapes — `IHistoryOutputSchema` union (transparent / AmountShielded / FullShielded), `IHistoryInputSchema` with optional transparent fields for `type='shielded'` inputs.
- Library barrel (`lib.ts`) exports the shielded namespace + `IHistoryShieldedOutput`, `IShieldedCryptoProvider`, `IDecryptedShieldedOutput` so consumers can wire up shielded support.
- Transparent-only wallets see byte-identical behavior to master for build, send, receive, balance, and history.

## What's in this PR

**Wallet lifecycle (`src/new/wallet.ts` — heaviest single change):**
- Auto-detect shielded crypto provider in `start()` (try/catch-wrapped `require` of `@hathor/ct-crypto-node` — absent dep leaves `storage.shieldedCryptoProvider` undefined).
- `migrateShieldedAccessData` call site (gated on `pinCode && password`, line ~2069).
- `normalizeShieldedOutputs` in `onNewTx` to fold both wire-shape variants into the same internal shape.
- Shielded receive path (`shieldedNewlyAvailable` branch + safety-net retry loop).
- `.catch()` on `newTxPromise` (chain-resilience fix — a rejected promise no longer poisons later events).
- `sendManyOutputsSendTransaction` shielded-output mapping (`ProposedOutput` → `ISendOutput` carrying `scanPubkey` / `shieldedMode` / spend-derived address).
- `getShieldedUnblindingForTx` (per-tx unblinding query for browser-side audit).
- `setPinCode` setter.

**Send pipeline (`src/new/sendTransaction.ts`):**
- `ISendShieldedOutput` type + phantom-output tracking.
- Blinding-factor balancing (N-1 random + 1 computed via `computeBalancingBlindingFactor`).
- Surjection-proof domain construction for FullShielded.
- Shielded fee calc (`FEE_PER_AMOUNT_SHIELDED_OUTPUT` / `FEE_PER_FULL_SHIELDED_OUTPUT` per output).
- `addressObj.isShielded()` guard at output entry.
- `changeShieldedMode` option — HTR fee-change can be emitted shielded so the change output's privacy mode matches the recipient's instead of leaking a transparent correlation.

**Type / schema layer:**
- `src/new/types.ts` — `ProposedOutput.shielded?`, `SendManyOutputsOptions.changeShieldedMode?`.
- `src/schemas.ts` — `IHistoryOutputSchema` becomes a Zod union of `TransparentOutputSchema` (byte-identical to master) + `AmountShieldedOutputSchema` + `FullShieldedOutputSchema`; `IHistoryInputSchema` relaxed (transparent fields optional, adds `type='shielded'` + `commitment` optional).
- `src/api/schemas/txApi.ts` — shielded output fields relaxed to optional (matches what fullnodes pre-mode-field-change still send).
- `src/wallet/types.ts` — `ISendOutput` updates for the shielded variant.

**Sync / utilities:**
- `src/sync/stream.ts` — `StreamManager` derives the shielded + spend-address pair alongside each legacy address during initial load.
- `src/utils/utxo.ts` — skip shielded UTXOs in the legacy filter (callers that want shielded request them explicitly via `IUtxoFilterOptions.shielded`).
- `src/utils/bigint.ts` — Hermes/RN-compat fix in `JSON.parse` reviver.
- `src/lib.ts` — re-export the shielded module namespace + `IHistoryShieldedOutput` / `IShieldedCryptoProvider` / `IDecryptedShieldedOutput` so consumers can type their wiring code.

**Tests:**
- `__tests__/new/{hathorwallet,sendTransaction}.test.ts` — `getShieldedUnblindingForTx`, `onNewTx` shielded path, phantom outputs, balancing factor.
- `__tests__/models/transaction.test.ts` — weight calc threading, spend-key signature routing.
- `__tests__/utils/transaction.test.ts` — `normalizeShieldedOutputs` cases.

## Plan deviations

- The shielded helpers in `src/utils/transaction.ts`, the `Transaction` model's `shieldedOutputs` field, and the `HathorWalletServiceWallet getBalance` / `walletServiceStorageProxy` shielded-skip changes landed in PR 5 (required for that PR's build to stay green — the `IHistoryInput` optional-fields ripple).
- `src/shielded/provider.ts` is intentionally **not** re-synced from feat: it carries the friendly missing-addon error wrapping from PR 2, which is load-bearing for the deliberate "ct-crypto-node not a wallet-lib dependency" posture.

## Behavior preservation

- `start()` shielded provider auto-load is `try/catch`-wrapped; absence of `@hathor/ct-crypto-node` leaves `storage.shieldedCryptoProvider` undefined, and every downstream branch is then short-circuited.
- `migrateShieldedAccessData` call site is gated on `pinCode && password` AND on `accessData.words` being present in the helper itself. xpub-only and xpriv-imported wallets bypass it entirely.
- `onNewTx` shielded path is gated on `tx.shielded_outputs?.length > 0` and `shieldedCryptoProvider`. Transparent-only txs flow through `normalizeShieldedOutputs` which fast-returns when no `type==='shielded'` entries exist.
- `sendManyOutputsSendTransaction` only routes through shielded mapping when `o.shielded` is truthy. The transparent-output mapping is byte-identical to master.
- `IHistoryOutputSchema` union: `TransparentOutputSchema` is byte-identical to master's `IHistoryOutputSchema`. Any input master accepted, this schema accepts.
- `.catch()` on `newTxPromise`: pure defensive code, changes nothing when no rejection occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for shielded outputs, including SEPARATED-model handling, wallet-owned unblinding helpers, and optional conversion of HTR transparent change into shielded outputs.
  * Exposed shielded utilities, shielded crypto provider configuration, and address-chain options for enumerating shielded chains.

* **Bug Fixes**
  * Fixed shielded receive/spend address ordering and improved resolution for wallet-owned shielded change and spend-derived addresses.
  * Hardened transaction/template flows to reject unsupported shielded inputs.

* **Tests**
  * Expanded regression coverage for shielded storage iteration, change-address resolution, send preparation, and schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->