### PR TITLE
fix(nano): resolve current blueprint id for upgraded contracts

### DIFF
--- a/__tests__/integration/configuration/blueprints/upgrade_test_v1.py
+++ b/__tests__/integration/configuration/blueprints/upgrade_test_v1.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) Hathor Labs and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from hathor import (
+    Address,
+    Blueprint,
+    BlueprintId,
+    Context,
+    export,
+    public,
+)
+
+
+@export
+class UpgradeTestV1(Blueprint):
+    """Initial version of an upgradable blueprint used in upgrade tests.
+
+    `set_value` accepts an Address. After upgrading to v2, the same method
+    accepts a CallerId — exercising the wallet-lib path that resolves a
+    contract's *current* blueprint id (state) rather than its *creation*
+    blueprint id (tx).
+    """
+
+    counter: int
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        self.counter = 0
+
+    @public
+    def set_value(self, ctx: Context, addr: Address) -> None:
+        self.counter += 1
+
+    @public
+    def upgrade_to(self, ctx: Context, new_blueprint_id: BlueprintId) -> None:
+        self.syscall.change_blueprint(new_blueprint_id)

--- a/__tests__/integration/configuration/blueprints/upgrade_test_v2.py
+++ b/__tests__/integration/configuration/blueprints/upgrade_test_v2.py
@@ -1,0 +1,35 @@
+#
+# Copyright (c) Hathor Labs and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+from hathor import (
+    Blueprint,
+    CallerId,
+    Context,
+    export,
+    public,
+)
+
+
+@export
+class UpgradeTestV2(Blueprint):
+    """Upgraded version of UpgradeTestV1.
+
+    State is identical (single `counter: int`) so the in-place upgrade via
+    `syscall.change_blueprint` is storage-compatible. Only the public method
+    signature of `set_value` differs: it now accepts a CallerId instead of an
+    Address.
+    """
+
+    counter: int
+
+    @public
+    def initialize(self, ctx: Context) -> None:
+        self.counter = 0
+
+    @public
+    def set_value(self, ctx: Context, addr: CallerId) -> None:
+        self.counter += 1

--- a/__tests__/integration/nanocontracts/full_blueprint.test.ts
+++ b/__tests__/integration/nanocontracts/full_blueprint.test.ts
@@ -610,7 +610,7 @@ describe('Full blueprint basic tests', () => {
 
     const onChainBlueprintList = await ncApi.getOnChainBlueprintList();
     expect(onChainBlueprintList.success).toBe(true);
-    expect(onChainBlueprintList.blueprints.length).toBe(6);
+    expect(onChainBlueprintList.blueprints.length).toBe(8);
 
     const nanoList = await ncApi.getNanoContractCreationList();
     // The correct length depends on the execution order, so I

--- a/__tests__/integration/nanocontracts/full_blueprint.test.ts
+++ b/__tests__/integration/nanocontracts/full_blueprint.test.ts
@@ -610,7 +610,10 @@ describe('Full blueprint basic tests', () => {
 
     const onChainBlueprintList = await ncApi.getOnChainBlueprintList();
     expect(onChainBlueprintList.success).toBe(true);
-    expect(onChainBlueprintList.blueprints.length).toBe(8);
+    // Lower-bound check rather than exact count: the global on-chain blueprint
+    // list grows whenever a new fixture is registered in setupTests-integration.js,
+    // so an exact assertion couples this test to unrelated additions.
+    expect(onChainBlueprintList.blueprints.length).toBeGreaterThanOrEqual(8);
 
     const nanoList = await ncApi.getNanoContractCreationList();
     // The correct length depends on the execution order, so I

--- a/__tests__/integration/nanocontracts/upgrade_contract.test.ts
+++ b/__tests__/integration/nanocontracts/upgrade_contract.test.ts
@@ -1,0 +1,121 @@
+import { isEmpty } from 'lodash';
+import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import { generateWalletHelper, waitForTxReceived, waitTxConfirmed } from '../helpers/wallet.helper';
+import { NANO_CONTRACTS_INITIALIZE_METHOD } from '../../../src/constants';
+import ncApi from '../../../src/api/nano';
+import { bufferToHex } from '../../../src/utils/buffer';
+import helpersUtils from '../../../src/utils/helpers';
+import { getBlueprintId } from '../../../src/nano_contracts/utils';
+
+/**
+ * End-to-end test for the wallet-lib's blueprint-id resolution on upgraded
+ * nano contracts.
+ *
+ * Setup:
+ * - UpgradeTestV1 declares `set_value(addr: Address)` and `upgrade_to(BlueprintId)`.
+ * - UpgradeTestV2 declares `set_value(addr: CallerId)` (storage-compatible).
+ *
+ * Flow:
+ * 1. Create a contract from V1; call `set_value` with a base58 Address (matches V1).
+ * 2. Call `upgrade_to(V2)`; assert the state endpoint now reports V2 as the
+ *    blueprint id, while the creation tx still carries V1 in `nc_blueprint_id`.
+ * 3. Call `set_value` again with a 64-char hex (a ContractId-form CallerId).
+ *    This succeeds only when the wallet-lib resolves the *current* blueprint
+ *    via the state endpoint. Without that fix, it parses against V1's `Address`
+ *    schema and rejects the value with a Zod regex error.
+ */
+describe('Upgradable nano contract', () => {
+  /** @type HathorWallet */
+  let hWallet;
+  let address0;
+
+  beforeAll(async () => {
+    hWallet = await generateWalletHelper();
+    address0 = await hWallet.getAddressAtIndex(0);
+    await GenesisWalletHelper.injectFunds(hWallet, address0, 1000n);
+  });
+
+  afterAll(async () => {
+    await hWallet.stop();
+    await GenesisWalletHelper.clearListeners();
+  });
+
+  const checkTxValid = async (wallet, tx) => {
+    const txId = tx.hash;
+    const network = wallet.getNetworkObject();
+    const txBytes = tx.toBytes();
+    const deserializedTx = helpersUtils.createTxFromBytes(txBytes, network);
+    expect(bufferToHex(txBytes)).toBe(bufferToHex(deserializedTx.toBytes()));
+
+    expect(txId).toBeDefined();
+    await waitForTxReceived(wallet, txId);
+    await waitTxConfirmed(wallet, txId);
+    const txAfterExecution = await wallet.getFullTxById(txId);
+    expect(isEmpty(txAfterExecution.meta.voided_by)).toBe(true);
+    expect(txAfterExecution.meta.first_block).not.toBeNull();
+  };
+
+  it('resolves the post-upgrade blueprint id when validating method args', async () => {
+    const v1 = global.UPGRADE_TEST_V1_BLUEPRINT_ID;
+    const v2 = global.UPGRADE_TEST_V2_BLUEPRINT_ID;
+    expect(v1).toBeDefined();
+    expect(v2).toBeDefined();
+    expect(v1).not.toBe(v2);
+
+    // 1. Initialize a contract from V1.
+    const txInit = await hWallet.createAndSendNanoContractTransaction(
+      NANO_CONTRACTS_INITIALIZE_METHOD,
+      address0,
+      { blueprintId: v1, args: [] }
+    );
+    await checkTxValid(hWallet, txInit);
+    const ncId = txInit.hash;
+
+    // V1's `set_value` accepts an Address — a wallet-owned base58 string works.
+    const txSetV1 = await hWallet.createAndSendNanoContractTransaction(
+      'set_value',
+      address0,
+      { ncId, args: [address0] }
+    );
+    await checkTxValid(hWallet, txSetV1);
+
+    // Sanity: state reports V1 as the current blueprint and creation tx
+    // carries V1 in nc_blueprint_id.
+    const stateBefore = await ncApi.getNanoContractState(ncId, [], [], []);
+    expect(stateBefore.blueprint_id).toBe(v1);
+    const initTxData = await hWallet.getFullTxById(ncId);
+    expect(initTxData.tx.nc_blueprint_id).toBe(v1);
+
+    // 2. Upgrade in-place to V2.
+    const txUpgrade = await hWallet.createAndSendNanoContractTransaction(
+      'upgrade_to',
+      address0,
+      { ncId, args: [v2] }
+    );
+    await checkTxValid(hWallet, txUpgrade);
+
+    // State now reports V2; the creation tx still carries V1 — this is the
+    // discrepancy that motivates the wallet-lib fix.
+    const stateAfter = await ncApi.getNanoContractState(ncId, [], [], []);
+    expect(stateAfter.blueprint_id).toBe(v2);
+    const stillInitTxData = await hWallet.getFullTxById(ncId);
+    expect(stillInitTxData.tx.nc_blueprint_id).toBe(v1);
+
+    // 3. `getBlueprintId` must return V2 (the current blueprint), not V1.
+    const resolved = await getBlueprintId(ncId, hWallet);
+    expect(resolved).toBe(v2);
+
+    // 4. With V2 active, `set_value` accepts a CallerId. A 64-char hex value
+    // is parsed by the wallet-lib as a ContractId-tagged CallerId. This
+    // request only succeeds when the wallet-lib uses V2's signature for
+    // arg validation — a regression of the fix would throw a Zod regex
+    // error here.
+    const callerIdHex = '0000421da6413f181b86c3fcf731976ad6f7ec0983598000a6658f35a212e3e1';
+    const txSetV2 = await hWallet.createAndSendNanoContractTransaction(
+      'set_value',
+      address0,
+      { ncId, args: [callerIdHex] }
+    );
+    await checkTxValid(hWallet, txSetV2);
+  });
+});

--- a/__tests__/integration/nanocontracts/upgrade_contract.test.ts
+++ b/__tests__/integration/nanocontracts/upgrade_contract.test.ts
@@ -72,11 +72,10 @@ describe('Upgradable nano contract', () => {
     const ncId = txInit.hash;
 
     // V1's `set_value` accepts an Address — a wallet-owned base58 string works.
-    const txSetV1 = await hWallet.createAndSendNanoContractTransaction(
-      'set_value',
-      address0,
-      { ncId, args: [address0] }
-    );
+    const txSetV1 = await hWallet.createAndSendNanoContractTransaction('set_value', address0, {
+      ncId,
+      args: [address0],
+    });
     await checkTxValid(hWallet, txSetV1);
 
     // Sanity: state reports V1 as the current blueprint and creation tx
@@ -87,11 +86,10 @@ describe('Upgradable nano contract', () => {
     expect(initTxData.tx.nc_blueprint_id).toBe(v1);
 
     // 2. Upgrade in-place to V2.
-    const txUpgrade = await hWallet.createAndSendNanoContractTransaction(
-      'upgrade_to',
-      address0,
-      { ncId, args: [v2] }
-    );
+    const txUpgrade = await hWallet.createAndSendNanoContractTransaction('upgrade_to', address0, {
+      ncId,
+      args: [v2],
+    });
     await checkTxValid(hWallet, txUpgrade);
 
     // State now reports V2; the creation tx still carries V1 — this is the
@@ -111,11 +109,10 @@ describe('Upgradable nano contract', () => {
     // arg validation — a regression of the fix would throw a Zod regex
     // error here.
     const callerIdHex = '0000421da6413f181b86c3fcf731976ad6f7ec0983598000a6658f35a212e3e1';
-    const txSetV2 = await hWallet.createAndSendNanoContractTransaction(
-      'set_value',
-      address0,
-      { ncId, args: [callerIdHex] }
-    );
+    const txSetV2 = await hWallet.createAndSendNanoContractTransaction('set_value', address0, {
+      ncId,
+      args: [callerIdHex],
+    });
     await checkTxValid(hWallet, txSetV2);
   });
 });

--- a/__tests__/nano_contracts/utils.test.ts
+++ b/__tests__/nano_contracts/utils.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import ncApi from '../../src/api/nano';
+import { getBlueprintId } from '../../src/nano_contracts/utils';
+import { NanoContractTransactionError } from '../../src/errors';
+
+const NC_ID = '00000eecf6a990576c12bfa9e12ee089a5b1ea65e6de1456687ba1f4dc7fd463';
+const STATE_BLUEPRINT_ID = '00000000d6b22be00e31e4a7edabd0a9024611b3459a06fe1c49eeb194162702';
+const CREATION_BLUEPRINT_ID = '00000013be63bc36d6a2f668e063be3536a990ef14874553057688e99f40929f';
+
+type FakeWallet = { getFullTxById: jest.Mock };
+
+const makeFakeWallet = (): FakeWallet => ({ getFullTxById: jest.fn() });
+
+const stateOk = (blueprintId: string) => ({ success: true, blueprint_id: blueprintId });
+const txOk = (blueprintId: string) => ({
+  success: true,
+  tx: { nc_id: NC_ID, nc_blueprint_id: blueprintId },
+});
+
+describe('getBlueprintId', () => {
+  let stateSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    stateSpy = jest.spyOn(ncApi, 'getNanoContractState');
+  });
+
+  afterEach(() => {
+    stateSpy.mockRestore();
+  });
+
+  it('throws when ncId is empty', async () => {
+    const wallet = makeFakeWallet();
+    await expect(getBlueprintId('', wallet as never)).rejects.toThrow(
+      'Nano contract ID is not defined'
+    );
+    expect(stateSpy).not.toHaveBeenCalled();
+    expect(wallet.getFullTxById).not.toHaveBeenCalled();
+  });
+
+  it('returns the post-upgrade blueprint id from the state endpoint', async () => {
+    // Even when both endpoints would return different ids (i.e. an upgraded
+    // contract), state is the source of truth.
+    stateSpy.mockResolvedValue(stateOk(STATE_BLUEPRINT_ID));
+    const wallet = makeFakeWallet();
+    wallet.getFullTxById.mockResolvedValue(txOk(CREATION_BLUEPRINT_ID));
+
+    const result = await getBlueprintId(NC_ID, wallet as never);
+
+    expect(result).toBe(STATE_BLUEPRINT_ID);
+    // Tx endpoint is not consulted when state succeeds.
+    expect(wallet.getFullTxById).not.toHaveBeenCalled();
+  });
+
+  it('falls back to tx endpoint when the state endpoint throws', async () => {
+    stateSpy.mockRejectedValue(new Error('state unavailable'));
+    const wallet = makeFakeWallet();
+    wallet.getFullTxById.mockResolvedValue(txOk(CREATION_BLUEPRINT_ID));
+
+    const result = await getBlueprintId(NC_ID, wallet as never);
+
+    expect(result).toBe(CREATION_BLUEPRINT_ID);
+    expect(wallet.getFullTxById).toHaveBeenCalledWith(NC_ID);
+  });
+
+  it('falls back to tx endpoint when state response has no blueprint_id', async () => {
+    // E.g. a 200 response with an unexpected shape — should still fall through.
+    stateSpy.mockResolvedValue({ success: true });
+    const wallet = makeFakeWallet();
+    wallet.getFullTxById.mockResolvedValue(txOk(CREATION_BLUEPRINT_ID));
+
+    const result = await getBlueprintId(NC_ID, wallet as never);
+
+    expect(result).toBe(CREATION_BLUEPRINT_ID);
+  });
+
+  it('throws NanoContractTransactionError when both endpoints fail', async () => {
+    stateSpy.mockRejectedValue(new Error('state unavailable'));
+    const wallet = makeFakeWallet();
+    wallet.getFullTxById.mockRejectedValue(new Error('tx unavailable'));
+
+    await expect(getBlueprintId(NC_ID, wallet as never)).rejects.toBeInstanceOf(
+      NanoContractTransactionError
+    );
+    // The thrown message should surface at least one underlying cause so the
+    // caller can diagnose. Prefer the state error since state is the primary path.
+    await expect(getBlueprintId(NC_ID, wallet as never)).rejects.toThrow(/state unavailable/);
+  });
+
+  it('throws when state has no blueprint_id and tx response is malformed', async () => {
+    stateSpy.mockResolvedValue({ success: true });
+    const wallet = makeFakeWallet();
+    wallet.getFullTxById.mockResolvedValue({ success: true, tx: { nc_id: NC_ID } });
+
+    await expect(getBlueprintId(NC_ID, wallet as never)).rejects.toBeInstanceOf(
+      NanoContractTransactionError
+    );
+  });
+});

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -96,6 +96,28 @@ async function createOCBs(sharedState) {
   const txFee = await ocbWallet.createAndSendOnChainBlueprintTransaction(codeFee, address0);
   await waitTxConfirmed(ocbWallet, txFee.hash, null);
   sharedState.blueprintIds.FEE_BLUEPRINT_ID = txFee.hash;
+
+  const codeUpgradeV1 = fs.readFileSync(
+    './__tests__/integration/configuration/blueprints/upgrade_test_v1.py',
+    'utf8'
+  );
+  const txUpgradeV1 = await ocbWallet.createAndSendOnChainBlueprintTransaction(
+    codeUpgradeV1,
+    address0
+  );
+  await waitTxConfirmed(ocbWallet, txUpgradeV1.hash, null);
+  sharedState.blueprintIds.UPGRADE_TEST_V1_BLUEPRINT_ID = txUpgradeV1.hash;
+
+  const codeUpgradeV2 = fs.readFileSync(
+    './__tests__/integration/configuration/blueprints/upgrade_test_v2.py',
+    'utf8'
+  );
+  const txUpgradeV2 = await ocbWallet.createAndSendOnChainBlueprintTransaction(
+    codeUpgradeV2,
+    address0
+  );
+  await waitTxConfirmed(ocbWallet, txUpgradeV2.hash, null);
+  sharedState.blueprintIds.UPGRADE_TEST_V2_BLUEPRINT_ID = txUpgradeV2.hash;
 }
 
 // This function will run before each test file is executed
@@ -141,6 +163,8 @@ beforeAll(async () => {
   global.PARENT_BLUEPRINT_ID = sharedState.blueprintIds.PARENT_BLUEPRINT_ID;
   global.CHILDREN_BLUEPRINT_ID = sharedState.blueprintIds.CHILDREN_BLUEPRINT_ID;
   global.FEE_BLUEPRINT_ID = sharedState.blueprintIds.FEE_BLUEPRINT_ID;
+  global.UPGRADE_TEST_V1_BLUEPRINT_ID = sharedState.blueprintIds.UPGRADE_TEST_V1_BLUEPRINT_ID;
+  global.UPGRADE_TEST_V2_BLUEPRINT_ID = sharedState.blueprintIds.UPGRADE_TEST_V2_BLUEPRINT_ID;
 });
 
 afterAll(async () => {

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -364,6 +364,10 @@ export const getBlueprintId = async (ncId: string, wallet: HathorWallet): Promis
     throw new Error('Nano contract ID is not defined');
   }
 
+  // Primary path: ask the state endpoint. It reports the contract's *current*
+  // blueprint id, which reflects any in-place upgrades performed via
+  // syscall.change_blueprint. This is the id a method call must be validated
+  // against.
   const [stateError, stateResponse] = await getResultHelper(() =>
     ncApi.getNanoContractState(ncId, [], [], [])
   );
@@ -371,6 +375,11 @@ export const getBlueprintId = async (ncId: string, wallet: HathorWallet): Promis
     return stateResponse.blueprint_id;
   }
 
+  // Fallback: state endpoint can't serve the contract — typically because the
+  // creation tx isn't confirmed/indexed yet, or the contract was created by
+  // another contract whose state isn't yet queryable. In those cases the
+  // contract cannot have been upgraded yet, so the *creation* blueprint id
+  // (carried by the tx) is also the current one.
   const [txError, txResponse] = (await getResultHelper(() => wallet.getFullTxById(ncId))) as [
     Error | null,
     FullNodeTxResponse | null,
@@ -379,6 +388,7 @@ export const getBlueprintId = async (ncId: string, wallet: HathorWallet): Promis
     return txResponse.tx.nc_blueprint_id;
   }
 
+  // Both endpoints failed — surface whichever underlying error is more useful.
   throw new NanoContractTransactionError(
     `Error getting nano contract transaction data with id ${ncId} from the full node: ${stateError?.message || txError?.message || 'Invalid response structure'}`
   );

--- a/src/nano_contracts/utils.ts
+++ b/src/nano_contracts/utils.ts
@@ -345,10 +345,15 @@ export const getResultHelper = async <T>(
 /**
  * Retrieves the blueprint ID for a nano contract by its ID.
  *
- * The priority is to get the data from the getFullTxById API because
- * it gets contract txs that are still to be confirmed by a block. If it fails,
- * the contract might have been created by another contract, so we fallback to the state
- * API, which gets the information correctly in that case.
+ * Prefers the state API because it returns the contract's *current* blueprint id,
+ * which is what a method call must be validated against. The transaction's
+ * `nc_blueprint_id` is the *creation* blueprint id, so it is stale for any
+ * contract that has been upgraded via `upgrade_contract`.
+ *
+ * Falls back to `getFullTxById` for cases the state API can't serve — notably
+ * a contract creation tx that hasn't been confirmed yet, or a contract created
+ * by another contract whose state isn't indexed yet. In those cases the contract
+ * cannot have been upgraded, so the creation blueprint id is also the current one.
  *
  * @returns A promise resolving to the blueprint ID.
  * @throws {NanoContractTransactionError} If both API calls fail or if the nano contract ID is not defined.
@@ -359,6 +364,13 @@ export const getBlueprintId = async (ncId: string, wallet: HathorWallet): Promis
     throw new Error('Nano contract ID is not defined');
   }
 
+  const [stateError, stateResponse] = await getResultHelper(() =>
+    ncApi.getNanoContractState(ncId, [], [], [])
+  );
+  if (!stateError && stateResponse?.blueprint_id) {
+    return stateResponse.blueprint_id;
+  }
+
   const [txError, txResponse] = (await getResultHelper(() => wallet.getFullTxById(ncId))) as [
     Error | null,
     FullNodeTxResponse | null,
@@ -367,14 +379,7 @@ export const getBlueprintId = async (ncId: string, wallet: HathorWallet): Promis
     return txResponse.tx.nc_blueprint_id;
   }
 
-  const [stateError, stateResponse] = await getResultHelper(() =>
-    ncApi.getNanoContractState(ncId!, [], [], [])
+  throw new NanoContractTransactionError(
+    `Error getting nano contract transaction data with id ${ncId} from the full node: ${stateError?.message || txError?.message || 'Invalid response structure'}`
   );
-  if (stateError || !stateResponse?.blueprint_id) {
-    throw new NanoContractTransactionError(
-      `Error getting nano contract transaction data with id ${ncId} from the full node: ${stateError?.message || 'Invalid response structure'}`
-    );
-  }
-
-  return stateResponse.blueprint_id;
 };


### PR DESCRIPTION
## Summary

`getBlueprintId(ncId, wallet)` returned the *creation* blueprint id of a nano contract instead of its *current* one. For contracts that had been upgraded in-place via `syscall.change_blueprint`, every method call was validated against the original blueprint's signature, so any method whose argument types had changed across the upgrade would be rejected client-side before the request ever reached the network.

Switches the function to query the state endpoint first (which reports the current blueprint id) and falls back to `wallet.getFullTxById` only when the state endpoint cannot serve the contract — preserving support for unconfirmed/unindexed contracts, which by definition cannot have been upgraded yet.

## Acceptance Criteria

- Correctly get current blueprint id for any nano contract


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests for upgradable nano contracts and two new upgrade test blueprints (v1→v2); test setup now publishes those blueprints for use.
  * Added unit tests for blueprint-ID resolution behavior and updated an on-chain blueprint list assertion to be resilient to growth.
* **Bug Fixes**
  * Prefer retrieving a contract’s current blueprint ID from state first, falling back to transaction data with improved error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-lib/pull/1091?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->