### PR TITLE
test: retry transient wallet/init flake in adapter

### DIFF
--- a/__tests__/integration/adapters/service.adapter.ts
+++ b/__tests__/integration/adapters/service.adapter.ts
@@ -17,6 +17,7 @@ import {
   pollForTx,
   pollForTokenDetails,
   pollUntilCondition,
+  retryOnTransientWalletInit,
 } from '../helpers/service-facade.helper';
 import { GenesisWalletServiceHelper } from '../helpers/genesis-wallet.helper';
 import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
@@ -180,10 +181,13 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
 
     // Pass options through directly — do NOT fill defaults when the caller
     // explicitly passes undefined (used by validation tests).
-    await sw.start({
-      pinCode: options?.pinCode,
-      password: options?.password,
-    });
+    // Wrap in retryOnTransientWalletInit so a freshly-spawned wallet-service
+    // backend rejecting `POST wallet/init` doesn't fail the suite's beforeAll
+    // (Jest's retryTimes only re-runs it() bodies, not setup hooks).
+    await retryOnTransientWalletInit(
+      () => sw.start({ pinCode: options?.pinCode, password: options?.password }),
+      'ServiceWalletTestAdapter.startWallet'
+    );
   }
 
   async waitForReady(_wallet: FuzzyWalletType): Promise<void> {

--- a/__tests__/integration/helpers/service-facade.helper.ts
+++ b/__tests__/integration/helpers/service-facade.helper.ts
@@ -4,7 +4,7 @@ import { delay } from '../utils/core.util';
 import { HathorWalletServiceWallet, MemoryStore, Storage, walletUtils } from '../../../src';
 import Network from '../../../src/models/network';
 import { FULLNODE_URL, NETWORK_NAME } from '../configuration/test-constants';
-import { TxNotFoundError } from '../../../src/errors';
+import { TxNotFoundError, WalletRequestError } from '../../../src/errors';
 import { precalculationHelpers } from './wallet-precalculation.helper';
 import config from '../../../src/config';
 import ncApi from '../../../src/api/nano';
@@ -150,6 +150,60 @@ export async function pollForTx(walletForPolling: HathorWalletServiceWallet, txI
     await delay(delayMs);
   }
   throw new Error(`Transaction ${txId} not found after ${maxAttempts} attempts`);
+}
+
+/**
+ * Backoff sequence between retry attempts on a transient `wallet/init` failure.
+ * 4 total attempts (initial + 3 backoffs), ~3.5s worst-case added latency.
+ */
+const TRANSIENT_WALLET_INIT_BACKOFFS_MS = [500, 1000, 2000];
+
+/**
+ * The exact error message thrown by `walletApi.createWallet` at `walletApi.ts:123`
+ * when `POST wallet/init` returns an unexpected status/body. Matching this exact
+ * string keeps the retry surface minimal — see `retryOnTransientWalletInit`.
+ */
+const TRANSIENT_WALLET_INIT_ERROR_MESSAGE = 'Error creating wallet.';
+
+/**
+ * Retries a wallet-init operation on transient `wallet/init` HTTP failures.
+ *
+ * The wallet-service backend can briefly reject `POST wallet/init` while a freshly-spawned
+ * docker stack is still settling. Jest's `retryTimes(2)` cannot help, because the failure
+ * typically happens inside `beforeAll` — and Jest only retries `it()` bodies.
+ *
+ * Retry surface is intentionally narrow: only `WalletRequestError` with message
+ * `"Error creating wallet."` is treated as transient. Test-injected mocks (e.g.
+ * `new Error('Crash')`) and other errors propagate immediately on the first attempt.
+ */
+export async function retryOnTransientWalletInit<T>(
+  op: () => Promise<T>,
+  label: string
+): Promise<T> {
+  const maxAttempts = TRANSIENT_WALLET_INIT_BACKOFFS_MS.length + 1;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const result = await op();
+      if (attempt > 1) {
+        loggers.test!.log(`${label} succeeded on attempt ${attempt}`);
+      }
+      return result;
+    } catch (err) {
+      const isTransient =
+        err instanceof WalletRequestError && err.message === TRANSIENT_WALLET_INIT_ERROR_MESSAGE;
+      if (!isTransient || attempt === maxAttempts) {
+        throw err;
+      }
+      const backoffMs = TRANSIENT_WALLET_INIT_BACKOFFS_MS[attempt - 1];
+      loggers.test!.warn(
+        `${label} hit transient wallet/init flake on attempt ${attempt}, retrying in ${backoffMs}ms`,
+        { error: (err as Error).message }
+      );
+      await delay(backoffMs);
+    }
+  }
+  // Unreachable: the loop above either returns or throws on the final attempt.
+  throw new Error(`retryOnTransientWalletInit: unreachable for ${label}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

The Hathor Lib Integration Test was flaking frequently with the same error:

```
WalletRequestError: Error creating wallet.
  at Object.createWallet (src/wallet/api/walletApi.ts:123)
```

Root cause: `POST wallet/init` against a freshly-spawned wallet-service backend is briefly rejected while the docker stack settles.

The failure cascades because it happens inside `beforeAll`, and `jest.retryTimes(2)` ( added on #1070 ) only re-runs `it()` bodies — not setup hooks.

The auth-token race fix (PR HathorNetwork/hathor-wallet-lib#1058) wrapped the *second* HTTP leg (`renewAuthToken`) in `retryOnTransientWalletError`, but the *first* leg (`wallet/init`) was left unguarded.

Changes were made on test infrastructure only — no production code is changed.

## What this does

- Adds `retryOnTransientWalletInit(op, label)` in `__tests__/integration/helpers/service-facade.helper.ts`, next to the existing `pollUntilCondition` / `pollForTx` helpers. 4 total attempts, exponential backoff (500ms / 1s / 2s).
- Wraps `sw.start(...)` inside `ServiceWalletTestAdapter.startWallet` with that helper.
- The retry surface is intentionally narrow: only `WalletRequestError` with the exact message `"Error creating wallet."` is treated as transient. Test-injected mocks (e.g. `start.test.ts:78`'s `'Crash'` rejection) and every other error class propagate immediately on the first attempt. `startReadOnly()` is left untouched because it does not hit `wallet/init`.

## Acceptance Criteria

- A transient single-shot 4xx/5xx on `POST wallet/init` no longer fails the suite — the adapter retries up to 3 times before throwing.
- Tests that intentionally expect `wallet.start()` to throw are unaffected (the predicate matches only the exact wallet-init error message).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test suite stability with enhanced retry logic to handle transient wallet initialization failures during test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-lib/pull/1096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->