### PR TITLE
fix(nano): reuse HTR deposit change to pay fee-token fees

### DIFF
--- a/__tests__/integration/nanocontracts/fee.test.ts
+++ b/__tests__/integration/nanocontracts/fee.test.ts
@@ -600,6 +600,60 @@ describe('FeeBlueprint nano contract operations', () => {
     expect(BigInt(ncStateAfter.balances[fbtUid].value)).toBe(fbtBalanceBefore - 100n);
   });
 
+  it('should pay fees when the wallet has a single HTR utxo covering deposit + fee', async () => {
+    // Regression test for the bug where executeDeposit locks the only HTR utxo
+    // before selectFeeInputs runs, causing selectFeeInputs to fail even though
+    // the deposit's change output has more than enough HTR to cover the fee.
+    const singleUtxoWallet = await generateWalletHelper(null);
+    const recipient = await singleUtxoWallet.getAddressAtIndex(0);
+
+    // Single HTR utxo sized to cover deposit (10n) + fee (1n) + small change (9n)
+    await GenesisWalletHelper.injectFunds(singleUtxoWallet, recipient, 20n, {});
+
+    const fbtWithdrawalAmount = 50n;
+    const htrDepositAmount = 10n;
+    const expectedFee = 1n;
+
+    const tx = await singleUtxoWallet.createAndSendNanoContractTransaction('noop', recipient, {
+      ncId: contractId,
+      args: [],
+      actions: [
+        {
+          type: 'deposit',
+          token: NATIVE_TOKEN_UID,
+          amount: htrDepositAmount,
+          changeAddress: recipient,
+        },
+        {
+          type: 'withdrawal',
+          token: fbtUid,
+          amount: fbtWithdrawalAmount,
+          address: recipient,
+        },
+      ],
+    });
+    await checkTxValid(singleUtxoWallet, tx);
+
+    // Single HTR input was used to fund both deposit and fee.
+    expect(tx.inputs.length).toBe(1);
+
+    // Outputs: HTR change (20 - 10 - 1 = 9) + FBT withdrawal (50)
+    const htrOutputs = tx.outputs.filter(o => o.tokenData === 0);
+    const fbtOutputs = tx.outputs.filter(o => o.tokenData !== 0);
+    expect(htrOutputs.length).toBe(1);
+    expect(htrOutputs[0].value).toBe(20n - htrDepositAmount - expectedFee);
+    expect(fbtOutputs.length).toBe(1);
+    expect(fbtOutputs[0].value).toBe(fbtWithdrawalAmount);
+
+    // FeeHeader carries the expected fee.
+    const feeHeader = tx.getFeeHeader();
+    expect(feeHeader).not.toBeNull();
+    expect(feeHeader!.entries[0].tokenIndex).toBe(0);
+    expect(feeHeader!.entries[0].amount).toBe(expectedFee);
+
+    await singleUtxoWallet.stop();
+  });
+
   it('should get an error when trying to pay fees without enough HTR', async () => {
     /** Dedicated wallet for tests that require an empty wallet (never funded) */
     const emptyWallet = await generateWalletHelper(null);

--- a/src/nano_contracts/builder.ts
+++ b/src/nano_contracts/builder.ts
@@ -913,9 +913,33 @@ class NanoContractTransactionBuilder {
       }
 
       if (totalFee > 0n && !this.contractPaysFees && !this.tokenFeeAddedInDeposit) {
-        const { inputs: feeInputs, outputs: feeOutputs } = await this.selectFeeInputs(totalFee);
-        inputs = concat(inputs, feeInputs);
-        outputs = concat(outputs, feeOutputs);
+        // Try to fund the fee from an HTR deposit change output already in the
+        // tx before selecting new HTR utxos. This avoids failing when the only
+        // HTR utxo was already consumed (and locked) by the HTR deposit action.
+        let remainingFee = totalFee;
+        const changeIdx = outputs.findIndex(
+          o =>
+            'token' in o &&
+            o.token === NATIVE_TOKEN_UID &&
+            o.authorities === 0n &&
+            o.isChange === true
+        );
+        if (changeIdx !== -1) {
+          const change = outputs[changeIdx];
+          if (change.value > remainingFee) {
+            change.value -= remainingFee;
+            remainingFee = 0n;
+          } else {
+            remainingFee -= change.value;
+            outputs.splice(changeIdx, 1);
+          }
+        }
+        if (remainingFee > 0n) {
+          const { inputs: feeInputs, outputs: feeOutputs } =
+            await this.selectFeeInputs(remainingFee);
+          inputs = concat(inputs, feeInputs);
+          outputs = concat(outputs, feeOutputs);
+        }
       }
 
       // When contractPaysFees is true, deduct fee from HTR withdrawal output


### PR DESCRIPTION
### Problem
  When a nano contract transaction had both an HTR `DEPOSIT` action and a fee-based token operation, the builder
  ran two independent HTR UTXO selections — one inside `executeDeposit`, another inside `selectFeeInputs`. With a
   single HTR UTXO in the wallet, the deposit selection locked it before the fee selection ran, throwing `'Not
  enough HTR utxos to pay the fee.'` even though the deposit's change output had more than enough HTR to cover
  the fee.

  ### Acceptance Criteria
  - Use the same utxo for HTR nano deposit and fee payment when possible

  ### Security Checklist
  - [x] No new dependencies added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fee funding logic for nano contract transactions to more efficiently utilize existing outputs when covering fees.

* **Tests**
  * Added regression test for fee payment scenarios in nano contract transactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-lib/pull/1097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->