### PR TITLE
fix: support bigint JSON serialization on react-native engines (Hermes/JSC)

### DIFF
--- a/__tests__/utils/bigint.test.js.ts
+++ b/__tests__/utils/bigint.test.js.ts
@@ -106,6 +106,14 @@ describe('test JSONBigInt', () => {
   test('should stringify bigint', () => {
     expect(JSONBigInt.stringify(bigIntObj)).toStrictEqual(bigIntJson);
   });
+
+  test('does not corrupt string values that resemble the bigint marker', () => {
+    // Only a NUL-prefixed sentinel is unquoted, so ordinary strings that merely
+    // contain "bigint:<digits>" must round-trip untouched.
+    const tricky = { note: 'bigint:123', mixed: 'x bigint:456 y' };
+    expect(JSONBigInt.stringify(tricky)).toStrictEqual(JSON.stringify(tricky));
+    expect(JSONBigInt.parse(JSONBigInt.stringify(tricky))).toStrictEqual(tricky);
+  });
 });
 
 describe('test parseJsonBigInt', () => {
@@ -115,5 +123,43 @@ describe('test parseJsonBigInt', () => {
 
   test('should parse object with small and large bigints', () => {
     expect(parseJsonBigInt(bigIntJson, bigIntObjSchema)).toStrictEqual(bigIntCoercedObj);
+  });
+});
+
+describe('JSONBigInt without native JSON source text access (e.g. Hermes/JSC)', () => {
+  // Simulates react-native engines that do not implement the "JSON source text
+  // access" proposal: `JSON.parse` falls back to the core-js-pure ponyfill, and
+  // BigInt stringify uses the native-JSON sentinel path (no `JSON.rawJSON`).
+  let rawJSONDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    rawJSONDescriptor = Object.getOwnPropertyDescriptor(JSON, 'rawJSON');
+    delete (JSON as { rawJSON?: unknown }).rawJSON;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    if (rawJSONDescriptor) {
+      Object.defineProperty(JSON, 'rawJSON', rawJSONDescriptor);
+    }
+    jest.resetModules();
+  });
+
+  test('falls back to the core-js ponyfill and still round-trips bigints', () => {
+    // Sanity check: the native API must really be absent for this test to be meaningful.
+    expect(typeof (JSON as { rawJSON?: unknown }).rawJSON).not.toBe('function');
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const { JSONBigInt: FallbackJSONBigInt } = require('../../src/utils/bigint');
+
+    // The whole point of the fix: stringifying a bigint must not throw.
+    expect(FallbackJSONBigInt.stringify(bigIntObj)).toStrictEqual(bigIntJson);
+    expect(FallbackJSONBigInt.parse(bigIntJson)).toStrictEqual(bigIntObj);
+
+    // Behaviour must match the native path for plain JSON and precision edges.
+    expect(FallbackJSONBigInt.stringify(obj)).toStrictEqual(nativeJson);
+    expect(FallbackJSONBigInt.parse('9007199254740991')).toStrictEqual(9007199254740991);
+    expect(FallbackJSONBigInt.parse('9007199254740992')).toStrictEqual(9007199254740992n);
+    expect(FallbackJSONBigInt.parse('123.456')).toStrictEqual(123.456);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "bitcore-lib": "8.25.10",
         "bitcore-mnemonic": "8.25.10",
         "buffer": "6.0.3",
+        "core-js-pure": "3.41.0",
         "crypto-js": "4.2.0",
         "isomorphic-ws": "5.0.0",
         "lodash": "4.17.21",
@@ -4739,6 +4740,17 @@
       "dependencies": {
         "browserslist": "^4.23.0"
       },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.41.0.tgz",
+      "integrity": "sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bitcore-lib": "8.25.10",
     "bitcore-mnemonic": "8.25.10",
     "buffer": "6.0.3",
+    "core-js-pure": "3.41.0",
     "crypto-js": "4.2.0",
     "isomorphic-ws": "5.0.0",
     "lodash": "4.17.21",

--- a/src/utils/bigint.ts
+++ b/src/utils/bigint.ts
@@ -8,6 +8,37 @@
 import { z } from 'zod';
 import { getDefaultLogger } from '../types';
 
+/*
+ * `JSONBigInt` depends on the "JSON source text access" proposal, which ships in
+ * V8 / Node v22 but is NOT implemented by react-native engines (Hermes and
+ * JavaScriptCore):
+ *
+ *  - `parse` relies on the `context` argument of the `JSON.parse` reviver
+ *    (`context.source`) to detect integers above `Number.MAX_SAFE_INTEGER`.
+ *    Without it, large integers silently lose precision. We feature-detect the
+ *    native support and fall back to the core-js-pure parse ponyfill on engines
+ *    that lack it. `JSON.rawJSON` is used as the probe because it ships in the
+ *    same proposal as the parse `context`.
+ *
+ *  - `stringify` would use `JSON.rawJSON` to emit a `bigint` as a raw, unquoted
+ *    JSON number. That API is missing on react-native, and the core-js-pure
+ *    stringify/rawJSON ponyfills break under SES hardening used by some consumers
+ *    (e.g. hathor-wallet-mobile) with "Cannot assign to read-only property". So
+ *    instead we serialize bigints to a sentinel string with the native (SES-safe)
+ *    `JSON.stringify` and then unquote them into raw numbers. The leading NUL byte
+ *    makes a collision with real string data effectively impossible.
+ */
+/* eslint-disable global-require, @typescript-eslint/no-var-requires */
+const hasNativeJsonSourceText = typeof (JSON as { rawJSON?: unknown }).rawJSON === 'function';
+
+const jsonParse: typeof JSON.parse = hasNativeJsonSourceText
+  ? JSON.parse
+  : require('core-js-pure/actual/json/parse');
+/* eslint-enable global-require, @typescript-eslint/no-var-requires */
+
+const BIGINT_SENTINEL = `${String.fromCharCode(0)}bigint:`;
+const BIGINT_SENTINEL_RE = /"\\u0000bigint:(-?\d+)"/g;
+
 /**
  * An object equivalent to the native global JSON, providing `parse()` and `stringify()` functions with compatible signatures, except
  * for the `reviver` and `replacer` parameters that are not supported to prevent accidental override of the custom BigInt behavior.
@@ -18,17 +49,24 @@ import { getDefaultLogger } from '../types';
 export const JSONBigInt = {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   parse(text: string): any {
-    // @ts-expect-error TypeScript hasn't been updated with the `context` argument from Node v22.
-    return JSON.parse(text, this.bigIntReviver);
+    return jsonParse(text, this.bigIntReviver);
   },
 
   stringify(value: any, space?: string | number): string {
-    return JSON.stringify(value, this.bigIntReplacer, space);
+    // Native JSON.stringify is SES-safe; bigIntReplacer tags BigInts with a
+    // sentinel string which we then unquote into raw JSON numbers.
+    return JSON.stringify(value, this.bigIntReplacer, space).replace(BIGINT_SENTINEL_RE, '$1');
   },
 
-  bigIntReviver(_key: string, value: any, context: { source: string }): any {
+  bigIntReviver(_key: string, value: any, context?: { source: string }): any {
     if (typeof value !== 'number') {
       // No special handling needed for non-number values.
+      return value;
+    }
+
+    if (!context) {
+      // Engines without JSON source text access do not provide `context`, so we
+      // cannot inspect the original token; keep the value as a Number.
       return value;
     }
 
@@ -44,8 +82,10 @@ export const JSONBigInt = {
     } catch (e) {
       if (
         e instanceof SyntaxError &&
-        (e.message === `Cannot convert ${context.source} to a BigInt` ||
-          e.message === `invalid BigInt syntax`)
+        (e.message === `Cannot convert ${context.source} to a BigInt` || // V8 / Node
+          e.message === `invalid BigInt syntax` || // older V8
+          e.message === `can't convert string to bigint` || // JavaScriptCore
+          e.message === `Failed to parse String to BigInt`) // Hermes
       ) {
         // When this error happens, it means the number cannot be converted to a BigInt,
         // so it's a double, for example '123.456' or '1e2'.
@@ -59,9 +99,9 @@ export const JSONBigInt = {
   },
 
   bigIntReplacer(_key: string, value_: any): any {
-    // If the value is a BigInt, we simply return its string representation.
-    // @ts-expect-error TypeScript hasn't been updated with the `rawJSON` function from Node v22.
-    return typeof value_ === 'bigint' ? JSON.rawJSON(value_.toString(10)) : value_;
+    // Tag BigInts with a sentinel string; stringify() unquotes them into raw JSON
+    // numbers so they round-trip back to a BigInt through bigIntReviver.
+    return typeof value_ === 'bigint' ? `${BIGINT_SENTINEL}${value_.toString(10)}` : value_;
   },
   /* eslint-enable @typescript-eslint/no-explicit-any */
 };


### PR DESCRIPTION
## Problem

`JSONBigInt` (in `src/utils/bigint.ts`) is the helper used across the library to (de)serialize JSON while preserving `bigint` precision. It depends on the **"JSON source text access"** proposal:

- `parse` relies on the **`context` argument of the `JSON.parse` reviver** (`context.source`) to detect integers above `Number.MAX_SAFE_INTEGER` and revive them as `bigint`.
- `stringify` uses **`JSON.rawJSON(...)`** to emit a `bigint` as an *unquoted* JSON number, so it round-trips back to a `bigint`.

Both ship in **V8 / Node v22**, but **react-native engines (Hermes and JavaScriptCore) do not implement them**. On those engines, serializing a value containing a `bigint` throws **`TypeError: JSON.rawJSON is not a function`**, and parsing large integers silently **loses precision**.

This was hit in **hathor-wallet-mobile**: persisting registered tokens to AsyncStorage serializes their `bigint` balance fields through `JSONBigInt.stringify`, which crashed (the token-per-network snapshot was silently never saved). The mobile app worked around it with a `patch-package` patch; this PR fixes it at the source.

> **Why not just ponyfill `JSON.rawJSON` with core-js?** That was the first attempt, but `core-js-pure`'s `stringify`/`rawJSON` modules **break under the SES hardening** that hathor-wallet-mobile applies — their initialization tries to mutate a frozen intrinsic and throws `Cannot assign to read-only property 'get'`, cascading into `Cannot read property 'set' of undefined`. core-js's **parse** ponyfill is fine under SES, but stringify/rawJSON are not.

## Fix

- **parse** — feature-detect native support (probed via `JSON.rawJSON`, which ships in the same proposal as the parse `context`). Use native `JSON.parse` on Node; fall back to the `core-js-pure` parse ponyfill on engines without the reviver `context`. The reviver also tolerates a missing `context` and matches the `BigInt()` `SyntaxError` messages of V8, JavaScriptCore and Hermes.
- **stringify** — no `JSON.rawJSON` and no core-js. The replacer tags each `bigint` with a **NUL-prefixed sentinel string**, the SES-safe native `JSON.stringify` serializes it, and a final pass unquotes the sentinels into raw JSON numbers. The leading NUL byte makes a collision with real string data effectively impossible.

The on-the-wire format is unchanged (bigints are emitted as raw, unquoted integers), so data written/read across platforms stays compatible.

## Tests

- Existing `JSONBigInt` / `parseJsonBigInt` tests keep passing.
- Added a test that removes `JSON.rawJSON`, reloads the module, and asserts the fallback (core-js parse + sentinel stringify) round-trips bigints and matches native behaviour for plain JSON and precision edge cases.
- Added a test that strings resembling the sentinel (`"bigint:123"`) are not corrupted.

`npx tsc` and `eslint` pass on the changed files.

> Verified end-to-end on the iOS simulator (Hermes + SES) with hathor-wallet-mobile: the snapshot now persists, the stored `bigint` balances are serialized as raw JSON numbers, and the previous errors are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced JSON serialization of large integers with improved cross-platform compatibility and automatic fallback support for different JavaScript runtime environments.

* **Tests**
  * Added comprehensive regression tests verifying JSON serialization and parsing of large integers work correctly across various JavaScript runtime scenarios and platform capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HathorNetwork/hathor-wallet-lib/pull/1104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->