### PR TITLE
feat(shielded): shielded-aware transaction utils + history data model

### DIFF
--- a/__tests__/models/transaction.test.ts
+++ b/__tests__/models/transaction.test.ts
@@ -14,6 +14,7 @@ import P2PKH from '../../src/models/p2pkh';
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
 import ShieldedOutput from '../../src/models/shielded_output';
+import ShieldedOutputsHeader from '../../src/headers/shielded_outputs';
 import { hexToBuffer, bufferToHex } from '../../src/utils/buffer';
 import helpers from '../../src/utils/helpers';
 import { DEFAULT_TX_VERSION, MAX_OUTPUTS, DEFAULT_SIGNAL_BITS } from '../../src/constants';
@@ -627,19 +628,24 @@ test('getOutputsSum / weight exclude shielded output values (privacy: GAP1-01)',
     const p2pkh = new P2PKH(address);
     const transparentOut = new Output(1000n, p2pkh.createScript());
     const tx = new Transaction([], [transparentOut], { version: DEFAULT_TX_VERSION });
-    tx.shieldedOutputs = shieldedValues.map(
-      value =>
-        ({
-          mode: 1,
-          commitment: Buffer.alloc(33),
-          rangeProof: Buffer.alloc(675),
-          tokenData: 0,
-          script: Buffer.alloc(25),
-          ephemeralPubkey: Buffer.alloc(33),
-          value,
-          serialize: () => [Buffer.alloc(1)],
-          serializeSighash: () => [Buffer.alloc(1)],
-        }) as unknown as ShieldedOutput
+    // shieldedOutputs is a header-backed getter; populate via the header.
+    tx.headers.push(
+      new ShieldedOutputsHeader(
+        shieldedValues.map(
+          value =>
+            ({
+              mode: 1,
+              commitment: Buffer.alloc(33),
+              rangeProof: Buffer.alloc(675),
+              tokenData: 0,
+              script: Buffer.alloc(25),
+              ephemeralPubkey: Buffer.alloc(33),
+              value,
+              serialize: () => [Buffer.alloc(1)],
+              serializeSighash: () => [Buffer.alloc(1)],
+            }) as unknown as ShieldedOutput
+        )
+      )
     );
     return tx;
   };

--- a/__tests__/models/transaction.test.ts
+++ b/__tests__/models/transaction.test.ts
@@ -13,6 +13,7 @@ import Input from '../../src/models/input';
 import P2PKH from '../../src/models/p2pkh';
 import Address from '../../src/models/address';
 import Network from '../../src/models/network';
+import ShieldedOutput from '../../src/models/shielded_output';
 import { hexToBuffer, bufferToHex } from '../../src/utils/buffer';
 import helpers from '../../src/utils/helpers';
 import { DEFAULT_TX_VERSION, MAX_OUTPUTS, DEFAULT_SIGNAL_BITS } from '../../src/constants';
@@ -611,4 +612,47 @@ describe('NFT Validation', () => {
     txInstance = helpers.createTxFromHistoryObject(historyTx);
     expect(() => txInstance.validateNft(network)).toThrow('mint and melt is allowed');
   });
+});
+
+test('getOutputsSum / weight exclude shielded output values (privacy: GAP1-01)', () => {
+  // hathor-core derives the minimum tx weight from the transparent
+  // `sum_outputs` only (hathor/daa.py::minimum_tx_weight). If the wallet folded
+  // the plaintext shielded values into getOutputsSum(), the published weight
+  // would invert to reveal the exact total shielded amount of every tx. This
+  // guards that the two are decoupled.
+  const buildTx = (shieldedValues: bigint[]): Transaction => {
+    const address = new Address('WR1i8USJWQuaU423fwuFQbezfevmT4vFWX', {
+      network: new Network('testnet'),
+    });
+    const p2pkh = new P2PKH(address);
+    const transparentOut = new Output(1000n, p2pkh.createScript());
+    const tx = new Transaction([], [transparentOut], { version: DEFAULT_TX_VERSION });
+    tx.shieldedOutputs = shieldedValues.map(
+      value =>
+        ({
+          mode: 1,
+          commitment: Buffer.alloc(33),
+          rangeProof: Buffer.alloc(675),
+          tokenData: 0,
+          script: Buffer.alloc(25),
+          ephemeralPubkey: Buffer.alloc(33),
+          value,
+          serialize: () => [Buffer.alloc(1)],
+          serializeSighash: () => [Buffer.alloc(1)],
+        }) as unknown as ShieldedOutput
+    );
+    return tx;
+  };
+
+  // Output sum reflects only the transparent output, regardless of how much
+  // value is hidden in the shielded outputs.
+  expect(buildTx([5000n, 7000n]).getOutputsSum()).toBe(1000n);
+
+  // Two structurally-identical txs that differ ONLY in the hidden shielded
+  // amounts must produce identical output sums and identical weights, so an
+  // observer cannot recover the shielded total from the on-chain weight.
+  const txSmall = buildTx([1n, 2n]);
+  const txLarge = buildTx([9_000_000n, 1_000_000n]);
+  expect(txSmall.getOutputsSum()).toBe(txLarge.getOutputsSum());
+  expect(txSmall.calculateWeight()).toBe(txLarge.calculateWeight());
 });

--- a/__tests__/models/transaction.test.ts
+++ b/__tests__/models/transaction.test.ts
@@ -662,3 +662,15 @@ test('getOutputsSum / weight exclude shielded output values (privacy: GAP1-01)',
   expect(txSmall.getOutputsSum()).toBe(txLarge.getOutputsSum());
   expect(txSmall.calculateWeight()).toBe(txLarge.calculateWeight());
 });
+
+test('shieldedOutputs getter returns a frozen empty array when there is no header', () => {
+  const tx = new Transaction([], [], { version: DEFAULT_TX_VERSION });
+  // Always an array (never undefined) so readers stay null-check-free.
+  expect(tx.shieldedOutputs).toEqual([]);
+  // Read-only: a stray push fails loudly at runtime instead of being silently
+  // dropped onto a throwaway array (a JS caller bypasses the `readonly` type, so
+  // we cast it away here to exercise the runtime freeze).
+  expect(() =>
+    (tx.shieldedOutputs as ShieldedOutput[]).push({} as unknown as ShieldedOutput)
+  ).toThrow();
+});

--- a/__tests__/storage/storage.test.ts
+++ b/__tests__/storage/storage.test.ts
@@ -1246,4 +1246,31 @@ describe('shielded key access (smoke)', () => {
     storage.setShieldedCryptoProvider(undefined);
     expect(storage.shieldedCryptoProvider).toBeUndefined();
   });
+
+  it('getShieldedCryptoProvider returns the provider when one is set', () => {
+    const storage = new Storage(new MemoryStore());
+    const provider = {
+      id: 'mock',
+    } as unknown as import('../../src/shielded/types').IShieldedCryptoProvider;
+    storage.setShieldedCryptoProvider(provider);
+    expect(storage.getShieldedCryptoProvider()).toBe(provider);
+  });
+
+  it('getShieldedCryptoProvider throws (never silently defaults) when none is set', () => {
+    const storage = new Storage(new MemoryStore());
+    // Unset on a fresh storage.
+    expect(() => storage.getShieldedCryptoProvider()).toThrow(
+      'Shielded crypto provider is not set'
+    );
+    // And still throws after an explicit clear — a missing provider is a setup
+    // error that must fail loudly, not be defaulted around.
+    const provider = {
+      id: 'mock',
+    } as unknown as import('../../src/shielded/types').IShieldedCryptoProvider;
+    storage.setShieldedCryptoProvider(provider);
+    storage.setShieldedCryptoProvider(undefined);
+    expect(() => storage.getShieldedCryptoProvider()).toThrow(
+      'Shielded crypto provider is not set'
+    );
+  });
 });

--- a/__tests__/utils/storage.test.ts
+++ b/__tests__/utils/storage.test.ts
@@ -7,7 +7,13 @@
 
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import { HistorySyncMode, WalletType, TokenVersion, SCANNING_POLICY } from '../../src/types';
+import {
+  HistorySyncMode,
+  WalletType,
+  TokenVersion,
+  SCANNING_POLICY,
+  IHistoryTx,
+} from '../../src/types';
 import { MemoryStore, Storage } from '../../src/storage';
 import {
   scanPolicyStartAddresses,
@@ -17,10 +23,62 @@ import {
   getHistorySyncMethod,
   apiSyncHistory,
   addCreatedTokenFromTx,
+  processNewTx,
 } from '../../src/utils/storage';
 import { manualStreamSyncHistory, xpubStreamSyncHistory } from '../../src/sync/stream';
 import CreateTokenTransaction from '../../src/models/create_token_transaction';
 import Transaction from '../../src/models/transaction';
+
+describe('processNewTx — confidential (shielded) inputs', () => {
+  // SEPARATED model: a shielded input carries NO transparent fields
+  // (value/token/token_data/decoded are hidden in commitments). processNewTx
+  // must skip it via the type-level guard — its balance handling is the
+  // receive pipeline's job (next PR). Without the guard the loop dereferences
+  // `input.decoded.address` and throws.
+  function spendTx(inputs): IHistoryTx {
+    return {
+      tx_id: 'spend-tx',
+      version: 1,
+      weight: 1,
+      timestamp: 1,
+      is_voided: false,
+      inputs,
+      outputs: [],
+      parents: [],
+    } as unknown as IHistoryTx;
+  }
+
+  it('skips a fully-confidential shielded input (all transparent fields absent)', async () => {
+    const storage = new Storage(new MemoryStore());
+    const tx = spendTx([{ tx_id: 'parent', index: 0, type: 'shielded' }]);
+
+    const result = await processNewTx(storage, tx, {
+      rewardLock: 0,
+      nowTs: 1,
+      currentHeight: 0,
+    });
+
+    // No throw, and the confidential input contributed no token to the metadata.
+    expect(result.tokens.size).toBe(0);
+  });
+
+  it('skips a partial input missing `decoded` even when token fields are present', async () => {
+    const storage = new Storage(new MemoryStore());
+    // value/token/token_data present but `decoded` undefined → still skipped by
+    // the OR-guard, so the token is never counted and `decoded.address` is
+    // never dereferenced.
+    const tx = spendTx([{ tx_id: 'parent', index: 0, value: 5n, token: '01', token_data: 1 }]);
+
+    const result = await processNewTx(storage, tx, {
+      rewardLock: 0,
+      nowTs: 1,
+      currentHeight: 0,
+    });
+
+    expect(result.tokens.has('01')).toBe(false);
+    expect(result.tokens.size).toBe(0);
+  });
+});
 
 describe('scanning policy methods', () => {
   it('start addresses', async () => {

--- a/__tests__/utils/storage.test.ts
+++ b/__tests__/utils/storage.test.ts
@@ -24,6 +24,7 @@ import {
   apiSyncHistory,
   addCreatedTokenFromTx,
   processNewTx,
+  processSingleTx,
 } from '../../src/utils/storage';
 import { manualStreamSyncHistory, xpubStreamSyncHistory } from '../../src/sync/stream';
 import CreateTokenTransaction from '../../src/models/create_token_transaction';
@@ -77,6 +78,60 @@ describe('processNewTx — confidential (shielded) inputs', () => {
 
     expect(result.tokens.has('01')).toBe(false);
     expect(result.tokens.size).toBe(0);
+  });
+});
+
+describe('processSingleTx — SEPARATED-model spent-output resolution', () => {
+  // The spent-output loop resolves `input.index` (an absolute on-chain index
+  // spanning transparent then shielded outputs) via resolveSpentOutput, instead
+  // of a positional `outputs[index]` read. These cover the two index-driven
+  // branches (the transparent-delete branch needs an owned UTXO and is exercised
+  // by the integration suite).
+  const baseTx = (fields: Partial<IHistoryTx>): IHistoryTx =>
+    ({
+      tx_id: 'tx',
+      version: 1,
+      weight: 1,
+      timestamp: 1,
+      is_voided: false,
+      inputs: [],
+      outputs: [],
+      parents: [],
+      ...fields,
+    }) as unknown as IHistoryTx;
+
+  it('throws "Spending an unexistent output" when the input index is past all outputs', async () => {
+    const storage = new Storage(new MemoryStore());
+    // Parent: 1 transparent output, no shielded → T + S = 1.
+    const parent = baseTx({
+      tx_id: 'parent',
+      outputs: [{ value: 1n, token_data: 0, decoded: {} }],
+    } as unknown as Partial<IHistoryTx>);
+    await storage.store.saveTx(parent);
+    // Spend absolute index 5 (>= T + S) → resolveSpentOutput returns undefined.
+    const spend = baseTx({
+      tx_id: 'spend',
+      inputs: [{ tx_id: 'parent', index: 5 }],
+    } as unknown as Partial<IHistoryTx>);
+    await expect(processSingleTx(storage, spend)).rejects.toThrow('Spending an unexistent output');
+  });
+
+  it('skips a shielded input (index resolves into the shielded range) without throwing', async () => {
+    const storage = new Storage(new MemoryStore());
+    // Parent: 0 transparent outputs, 1 shielded → absolute index 0 is shielded.
+    const parent = baseTx({
+      tx_id: 'parent',
+      outputs: [],
+      shielded_outputs: [{ commitment: 'aa', decoded: {} }],
+    } as unknown as Partial<IHistoryTx>);
+    await storage.store.saveTx(parent);
+    const spend = baseTx({
+      tx_id: 'spend',
+      inputs: [{ tx_id: 'parent', index: 0, type: 'shielded' }],
+    } as unknown as Partial<IHistoryTx>);
+    // Resolves to a shielded slot → the transparent-spend loop skips it (the
+    // shielded UTXO lifecycle is the receive pipeline's), so no throw.
+    await expect(processSingleTx(storage, spend)).resolves.toBeUndefined();
   });
 });
 

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -159,6 +159,71 @@ test('getSignatureForTx signing nano contract when we are not the caller', async
   ).toBe(true);
 });
 
+test('getSignatureForTx uses the spend key chain for a shielded-spend input', async () => {
+  // A shielded UTXO is spent with the spend key chain (m/44'/280'/2'/0), not the
+  // legacy/main chain. The spent output is a shielded slot (on-chain index ≥ the
+  // parent's transparent outputs.length), resolved via the SEPARATED-model
+  // resolver, and its addressInfo is marked `addressType: 'shielded-spend'`.
+  const mainXpriv = new HDPrivateKey();
+  const spendXpriv = new HDPrivateKey();
+  const store = new MemoryStore();
+  const storage = new Storage(store);
+  const shieldedSpendAddr = 'W-shielded-spend-p2pkh';
+  const idx = 7;
+
+  jest.spyOn(storage, 'getMainXPrivKey').mockReturnValue(Promise.resolve(mainXpriv.xprivkey));
+  const getSpendSpy = jest
+    .spyOn(storage, 'getSpendXPrivKey')
+    .mockReturnValue(Promise.resolve(spendXpriv.xprivkey));
+  jest.spyOn(storage, 'getAddressInfo').mockImplementation(async addr =>
+    addr === shieldedSpendAddr
+      ? {
+          base58: addr,
+          bip32AddressIndex: idx,
+          addressType: 'shielded-spend',
+          numTransactions: 1,
+          balance: new Map(),
+        }
+      : null
+  );
+  // Parent tx: 0 transparent outputs + 1 shielded output at on-chain index 0,
+  // whose spend-derived P2PKH (decoded.address) is our shielded-spend address.
+  const spentTx = {
+    outputs: [],
+    shielded_outputs: [{ decoded: { address: shieldedSpendAddr } }],
+  };
+  async function* getSpentMock(inputs) {
+    yield { index: 0, input: inputs[0], tx: spentTx };
+  }
+  jest.spyOn(storage, 'getSpentTxs').mockImplementation(getSpentMock);
+  // Input spends parent on-chain index 0 → the shielded slot (parent has T=0).
+  const input = new Input('cafe', 0);
+  const tx = new Transaction([input], []);
+
+  const sigData = await transaction.getSignatureForTx(tx, storage, '123');
+
+  // The spend chain was lazily loaded and used for the signature.
+  expect(getSpendSpy).toHaveBeenCalledWith('123');
+  expect(sigData.inputSignatures).toHaveLength(1);
+  expect(sigData.inputSignatures[0]).toMatchObject({ inputIndex: 0, addressIndex: idx });
+  expect(sigData.inputSignatures[0].pubkey).toStrictEqual(
+    spendXpriv.deriveNonCompliantChild(idx).publicKey.toDER()
+  );
+  // And NOT the legacy/main-chain key at the same index.
+  expect(sigData.inputSignatures[0].pubkey).not.toStrictEqual(
+    mainXpriv.deriveNonCompliantChild(idx).publicKey.toDER()
+  );
+  // The signature verifies against the spend pubkey.
+  const hashdata = tx.getDataToSignHash();
+  expect(
+    crypto.ECDSA.verify(
+      hashdata,
+      crypto.Signature.fromDER(sigData.inputSignatures[0].signature),
+      spendXpriv.deriveNonCompliantChild(idx).publicKey
+    )
+  ).toBe(true);
+});
+
 test('signTransaction', async () => {
   const xpriv = new HDPrivateKey();
   const store = new MemoryStore();

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Direct coverage for the shielded-aware transaction utils introduced in
+ * this PR: isShieldedOutputEntry, findSpentOutput (the sparse-decode-safe
+ * parent lookup), and normalizeShieldedOutputs. The receive pipeline that
+ * consumes them lands in the next PR with its own end-to-end tests.
+ */
+
+import transactionUtils from '../../src/utils/transaction';
+import { IHistoryTx, IHistoryOutput, IShieldedOutputEntry } from '../../src/types';
+
+function makeTransparentOutput(value: bigint, address: string): IHistoryOutput {
+  return {
+    value,
+    token_data: 0,
+    script: 'aa',
+    decoded: { type: 'P2PKH', address, timelock: null },
+    token: '00',
+    spent_by: null,
+  };
+}
+
+function makeShieldedEntry(onChainIndex: number, commitment: string): IShieldedOutputEntry {
+  return {
+    type: 'shielded',
+    value: 10n,
+    token_data: 0,
+    script: 'bb',
+    decoded: { type: 'P2PKH', address: 'W-spend-address', timelock: null },
+    token: '00',
+    spent_by: null,
+    commitment,
+    range_proof: 'cc',
+    ephemeral_pubkey: 'dd',
+    onChainIndex,
+  };
+}
+
+function makeTx(outputs: IHistoryOutput[], extra: Partial<IHistoryTx> = {}): IHistoryTx {
+  return {
+    tx_id: 'test-tx',
+    version: 1,
+    weight: 1,
+    timestamp: 1,
+    is_voided: false,
+    inputs: [],
+    outputs,
+    parents: [],
+    ...extra,
+  };
+}
+
+describe('isShieldedOutputEntry', () => {
+  it('discriminates on the commitment field', () => {
+    expect(transactionUtils.isShieldedOutputEntry(makeShieldedEntry(1, 'ab'))).toBe(true);
+    expect(transactionUtils.isShieldedOutputEntry(makeTransparentOutput(5n, 'W-addr'))).toBe(false);
+  });
+});
+
+describe('findSpentOutput', () => {
+  it('returns the positional output for transparent-only parents', () => {
+    const tx = makeTx([makeTransparentOutput(1n, 'A'), makeTransparentOutput(2n, 'B')]);
+    expect(transactionUtils.findSpentOutput(tx, 1)).toMatchObject({ value: 2n });
+  });
+
+  it('resolves a decoded shielded output by onChainIndex, not array position', () => {
+    // Parent: 1 transparent output + 1 DECODED shielded entry whose on-chain
+    // absolute index is 2 (e.g. another shielded output at index 1 was not
+    // decryptable and is absent from outputs[]). A positional lookup
+    // tx.outputs[2] would be undefined; index 1 would WRONGLY return the
+    // decoded entry sitting at array position 1.
+    const tx = makeTx([makeTransparentOutput(1n, 'A'), makeShieldedEntry(2, 'c0ffee')]);
+
+    const atTwo = transactionUtils.findSpentOutput(tx, 2);
+    expect(atTwo).toBeDefined();
+    expect((atTwo as IShieldedOutputEntry).commitment).toBe('c0ffee');
+
+    // Index 1 is the UNDECODED shielded output: it must resolve to nothing,
+    // not to the entry that happens to sit at array position 1.
+    expect(transactionUtils.findSpentOutput(tx, 1)).toBeUndefined();
+  });
+
+  it('returns undefined for an out-of-range index', () => {
+    const tx = makeTx([makeTransparentOutput(1n, 'A')]);
+    expect(transactionUtils.findSpentOutput(tx, 5)).toBeUndefined();
+  });
+});
+
+describe('normalizeShieldedOutputs', () => {
+  it('extracts shielded entries from outputs[] and converts base64 fields to hex', () => {
+    const base64Proof = Buffer.from([0x01, 0x02, 0xff]).toString('base64');
+    const tx = makeTx([
+      makeTransparentOutput(1n, 'A'),
+      {
+        // Wire shape from to_json_extended: shielded entry inside outputs[]
+        // with base64-encoded buffers.
+        type: 'shielded',
+        value: 0n,
+        token_data: 0,
+        script: Buffer.from([0xaa]).toString('base64'),
+        decoded: {},
+        token: '00',
+        spent_by: null,
+        commitment: 'ab'.repeat(33), // already hex — must pass through
+        range_proof: base64Proof,
+        ephemeral_pubkey: 'cd'.repeat(33),
+      } as IHistoryOutput,
+    ]);
+
+    transactionUtils.normalizeShieldedOutputs(tx);
+
+    // Transparent output stays; shielded entry moved to shielded_outputs[]
+    expect(tx.outputs).toHaveLength(1);
+    expect(tx.shielded_outputs).toHaveLength(1);
+    const so = tx.shielded_outputs![0];
+    expect(so.commitment).toBe('ab'.repeat(33));
+    expect(so.range_proof).toBe('0102ff'); // base64 -> hex
+  });
+
+  it('is idempotent when shielded_outputs is already populated', () => {
+    const tx = makeTx([makeTransparentOutput(1n, 'A')], {
+      shielded_outputs: [
+        {
+          commitment: 'ab'.repeat(33),
+          range_proof: '0102ff',
+          script: 'aa',
+          ephemeral_pubkey: 'cd'.repeat(33),
+          decoded: {},
+        },
+      ],
+    });
+    const before = JSON.stringify(tx.shielded_outputs);
+    transactionUtils.normalizeShieldedOutputs(tx);
+    expect(tx.outputs).toHaveLength(1);
+    expect(JSON.stringify(tx.shielded_outputs)).toBe(before);
+  });
+});

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *
  * Direct coverage for the SEPARATED-model shielded transaction utils:
- * isInlineShieldedWireEntry (the wire discriminator), resolveSpentOutput (the
- * arithmetic parent-output resolver: idx < T → transparent, T ≤ idx < T+S →
- * shielded slot idx-T, else undefined), normalizeShieldedOutputs, and
- * getTxBalance crediting/debiting owned shielded outputs.
+ * resolveSpentOutput (the arithmetic parent-output resolver: idx < T →
+ * transparent, T ≤ idx < T+S → shielded slot idx-T, else undefined),
+ * normalizeShieldedOutputs, and getTxBalance crediting/debiting owned
+ * shielded outputs.
  */
 
 import transactionUtils from '../../src/utils/transaction';
@@ -76,17 +76,6 @@ function makeTx(
     ...extra,
   };
 }
-
-describe('isInlineShieldedWireEntry', () => {
-  it('discriminates inline wire entries on the type field', () => {
-    expect(transactionUtils.isInlineShieldedWireEntry({ type: 'shielded', commitment: 'ab' })).toBe(
-      true
-    );
-    expect(transactionUtils.isInlineShieldedWireEntry(makeTransparentOutput(5n, 'W-addr'))).toBe(
-      false
-    );
-  });
-});
 
 describe('resolveSpentOutput', () => {
   // Parent layout: T=2 transparent outputs, S=2 shielded outputs.
@@ -163,34 +152,39 @@ describe('resolveSpentOutput', () => {
 });
 
 describe('normalizeShieldedOutputs', () => {
-  it('extracts inline shielded entries from outputs[] and converts base64 fields to hex', () => {
+  it('converts base64 confidential fields in shielded_outputs[] to hex in place', () => {
     const base64Proof = Buffer.from([0x01, 0x02, 0xff]).toString('base64');
-    const tx = makeTx([
-      makeTransparentOutput(1n, 'A'),
-      {
-        // Wire shape from to_json_extended: shielded entry inside outputs[]
-        // with base64-encoded buffers.
-        type: 'shielded',
-        value: 0n,
-        token_data: 0,
-        script: Buffer.from([0xaa]).toString('base64'),
-        decoded: {},
-        token: '00',
-        spent_by: null,
-        commitment: 'ab'.repeat(33), // already hex — must pass through
-        range_proof: base64Proof,
-        ephemeral_pubkey: 'cd'.repeat(33),
-      } as unknown as IHistoryOutput,
-    ]);
+    const tx = makeTx(
+      [makeTransparentOutput(1n, 'A')],
+      [
+        {
+          mode: ShieldedOutputMode.AMOUNT_SHIELDED,
+          commitment: 'ab'.repeat(33), // already hex — must pass through unchanged
+          range_proof: base64Proof, // base64 — must become hex
+          script: 'aa',
+          token_data: 0,
+          ephemeral_pubkey: 'cd'.repeat(33),
+          decoded: {},
+          spent_by: null,
+        },
+      ]
+    );
 
     transactionUtils.normalizeShieldedOutputs(tx);
 
-    // Transparent output stays; shielded entry moved to shielded_outputs[]
+    // outputs[] is untouched (transparent-only); the shielded entry is converted in place
     expect(tx.outputs).toHaveLength(1);
     expect(tx.shielded_outputs).toHaveLength(1);
     const so = tx.shielded_outputs![0];
     expect(so.commitment).toBe('ab'.repeat(33));
     expect(so.range_proof).toBe('0102ff'); // base64 -> hex
+  });
+
+  it('is a no-op for a transparent-only tx (no shielded_outputs)', () => {
+    const tx = makeTx([makeTransparentOutput(1n, 'A')]);
+    transactionUtils.normalizeShieldedOutputs(tx);
+    expect(tx.outputs).toHaveLength(1);
+    expect(tx.shielded_outputs).toBeUndefined();
   });
 
   it('is idempotent when shielded_outputs is already populated', () => {
@@ -212,27 +206,31 @@ describe('normalizeShieldedOutputs', () => {
     expect(JSON.stringify(tx.shielded_outputs)).toBe(before);
   });
 
-  it('preserves owned-marker fields on an inline wire entry', () => {
-    const tx = makeTx([
-      makeTransparentOutput(1n, 'A'),
-      {
-        type: 'shielded',
-        value: 77n,
-        token: '00',
-        token_data: 0,
-        script: 'bb',
-        decoded: { type: 'P2PKH', address: 'W-spend', timelock: null },
-        spent_by: null,
-        commitment: 'ab'.repeat(33),
-        range_proof: 'cc',
-        ephemeral_pubkey: 'dd',
-        blindingFactor: 'ff'.repeat(32),
-      } as unknown as IHistoryOutput,
-    ]);
+  it('preserves owned-marker fields while converting an owned shielded entry', () => {
+    const tx = makeTx(
+      [makeTransparentOutput(1n, 'A')],
+      [
+        {
+          mode: ShieldedOutputMode.AMOUNT_SHIELDED,
+          commitment: 'ab'.repeat(33),
+          range_proof: Buffer.from([0xcc]).toString('base64'), // base64 — converted to hex
+          script: 'bb',
+          token_data: 0,
+          ephemeral_pubkey: 'dd',
+          decoded: { type: 'P2PKH', address: 'W-spend', timelock: null },
+          spent_by: null,
+          // owned-marker fields, populated post-decryption — must survive normalize
+          value: 77n,
+          token: '00',
+          blindingFactor: 'ff'.repeat(32),
+        },
+      ]
+    );
 
     transactionUtils.normalizeShieldedOutputs(tx);
 
     const so = tx.shielded_outputs![0];
+    expect(so.range_proof).toBe('cc'); // base64 -> hex
     expect(so.value).toBe(77n);
     expect(so.token).toBe('00');
     expect(so.blindingFactor).toBe('ff'.repeat(32));

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -48,8 +48,9 @@ function makeTransparentOutput(value: bigint, address: string): IHistoryOutput {
 
 /**
  * Build a shielded_outputs[] entry. An OWNED entry carries the decoded
- * value/token/decoded.address fields (the single ownership gate is
- * `value !== undefined`). A non-owned entry leaves `value` undefined.
+ * value/token/decoded.address fields; getTxBalance gates an owned slot on
+ * `value !== undefined` (authoritative) plus isAddressMine(decoded.address). A
+ * non-owned entry leaves `value` undefined.
  */
 function makeShieldedEntry(
   commitment: string,
@@ -334,40 +335,6 @@ describe('getTxBalance (shielded)', () => {
 
     const balance = await transactionUtils.getTxBalance(spendingTx, storage);
     expect(balance['00'].tokens.unlocked).toBe(-300n);
-  });
-
-  it('credits an owned shielded receive even when its address is not a stored wallet address', async () => {
-    // `value !== undefined` is the sole ownership gate (written only when the
-    // wallet decrypts an output it owns). An owned slot whose spend-P2PKH is not
-    // a stored address must still be credited — the old isAddressMine second-gate
-    // would have skipped it and under-reported the balance.
-    const tx = makeTx(
-      [],
-      [makeShieldedEntry('owned-unstored', { value: 700n, address: 'W-not-stored', token: '00' })],
-      { tx_id: 'recv-unstored' }
-    );
-    // makeStorage's isAddressMine returns false for anything but OWNED.
-    const balance = await transactionUtils.getTxBalance(tx, makeStorage());
-    expect(balance['00'].tokens.unlocked).toBe(700n);
-  });
-
-  it('debits a bare shielded input even when its parent slot address is not stored', async () => {
-    // Same gate on the debit side: a bare shielded input proves ownership via
-    // its decrypted parent slot, so it is debited without the isAddressMine gate
-    // (which still applies to transparent inputs).
-    const parentTx = makeTx(
-      [],
-      [makeShieldedEntry('spent-unstored', { value: 250n, address: 'W-not-stored', token: '00' })],
-      { tx_id: 'parent-unstored' }
-    );
-    const spendingTx = makeTx([], undefined, {
-      tx_id: 'spend-unstored',
-      inputs: [{ tx_id: 'parent-unstored', index: 0, type: 'shielded' }],
-    });
-    const storage = makeStorage({ utxo: null });
-    (storage.getTx as jest.Mock).mockResolvedValue(parentTx);
-    const balance = await transactionUtils.getTxBalance(spendingTx, storage);
-    expect(balance['00'].tokens.unlocked).toBe(-250n);
   });
 });
 

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -335,6 +335,40 @@ describe('getTxBalance (shielded)', () => {
     const balance = await transactionUtils.getTxBalance(spendingTx, storage);
     expect(balance['00'].tokens.unlocked).toBe(-300n);
   });
+
+  it('credits an owned shielded receive even when its address is not a stored wallet address', async () => {
+    // `value !== undefined` is the sole ownership gate (written only when the
+    // wallet decrypts an output it owns). An owned slot whose spend-P2PKH is not
+    // a stored address must still be credited — the old isAddressMine second-gate
+    // would have skipped it and under-reported the balance.
+    const tx = makeTx(
+      [],
+      [makeShieldedEntry('owned-unstored', { value: 700n, address: 'W-not-stored', token: '00' })],
+      { tx_id: 'recv-unstored' }
+    );
+    // makeStorage's isAddressMine returns false for anything but OWNED.
+    const balance = await transactionUtils.getTxBalance(tx, makeStorage());
+    expect(balance['00'].tokens.unlocked).toBe(700n);
+  });
+
+  it('debits a bare shielded input even when its parent slot address is not stored', async () => {
+    // Same gate on the debit side: a bare shielded input proves ownership via
+    // its decrypted parent slot, so it is debited without the isAddressMine gate
+    // (which still applies to transparent inputs).
+    const parentTx = makeTx(
+      [],
+      [makeShieldedEntry('spent-unstored', { value: 250n, address: 'W-not-stored', token: '00' })],
+      { tx_id: 'parent-unstored' }
+    );
+    const spendingTx = makeTx([], undefined, {
+      tx_id: 'spend-unstored',
+      inputs: [{ tx_id: 'parent-unstored', index: 0, type: 'shielded' }],
+    });
+    const storage = makeStorage({ utxo: null });
+    (storage.getTx as jest.Mock).mockResolvedValue(parentTx);
+    const balance = await transactionUtils.getTxBalance(spendingTx, storage);
+    expect(balance['00'].tokens.unlocked).toBe(-250n);
+  });
 });
 
 describe('_attachShieldedHeaders + per-header helpers', () => {

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -18,8 +18,22 @@ import {
   IHistoryShieldedOutput,
   IStorage,
   IUtxo,
+  IDataTx,
+  IDataInput,
+  IDataOutput,
 } from '../../src/types';
-import { ShieldedOutputMode } from '../../src/shielded/types';
+import { ShieldedOutputMode, IDataShieldedOutput } from '../../src/shielded/types';
+import Transaction from '../../src/models/transaction';
+import {
+  DEFAULT_TX_VERSION,
+  CREATE_TOKEN_TX_VERSION,
+  TOKEN_MINT_MASK,
+  TOKEN_MELT_MASK,
+} from '../../src/constants';
+import ShieldedOutputsHeader from '../../src/headers/shielded_outputs';
+import UnshieldBalanceHeader from '../../src/headers/unshield_balance';
+import { MintHeader } from '../../src/headers/mint_header';
+import { MeltHeader } from '../../src/headers/melt_header';
 
 function makeTransparentOutput(value: bigint, address: string): IHistoryOutput {
   return {
@@ -236,6 +250,40 @@ describe('normalizeShieldedOutputs', () => {
     expect(so.blindingFactor).toBe('ff'.repeat(32));
     expect(so.decoded.address).toBe('W-spend');
   });
+
+  it('converts the FullShielded-only fields (asset_commitment, surjection_proof) base64→hex, idempotently', () => {
+    const b64 = (byte: number) => Buffer.from([byte]).toString('base64');
+    const tx = makeTx(
+      [makeTransparentOutput(1n, 'A')],
+      [
+        {
+          mode: ShieldedOutputMode.FULLY_SHIELDED,
+          commitment: 'ab'.repeat(33), // already hex — unchanged
+          range_proof: b64(0x01),
+          script: b64(0x02),
+          ephemeral_pubkey: b64(0x03),
+          asset_commitment: b64(0xaa), // FullShielded-only — must convert
+          surjection_proof: b64(0xbb), // FullShielded-only — must convert
+          decoded: {},
+          spent_by: null,
+        },
+      ]
+    );
+
+    transactionUtils.normalizeShieldedOutputs(tx);
+    const so = tx.shielded_outputs![0];
+    expect(so.commitment).toBe('ab'.repeat(33));
+    expect(so.range_proof).toBe('01');
+    expect(so.script).toBe('02');
+    expect(so.ephemeral_pubkey).toBe('03');
+    expect(so.asset_commitment).toBe('aa');
+    expect(so.surjection_proof).toBe('bb');
+
+    // Idempotent: a second pass leaves the now-hex FullShielded fields unchanged.
+    transactionUtils.normalizeShieldedOutputs(tx);
+    expect(tx.shielded_outputs![0].asset_commitment).toBe('aa');
+    expect(tx.shielded_outputs![0].surjection_proof).toBe('bb');
+  });
 });
 
 describe('getTxBalance (shielded)', () => {
@@ -286,5 +334,202 @@ describe('getTxBalance (shielded)', () => {
 
     const balance = await transactionUtils.getTxBalance(spendingTx, storage);
     expect(balance['00'].tokens.unlocked).toBe(-300n);
+  });
+});
+
+describe('_attachShieldedHeaders + per-header helpers', () => {
+  const buf = (n: number, byte = 0xab): Buffer => Buffer.alloc(n, byte);
+
+  // Minimal AmountShielded build entry. Buffers are dummies — ShieldedOutput
+  // validates at serialize time, which header attachment never triggers.
+  const amountShieldedData = (token = '00', value = 5n): IDataShieldedOutput => ({
+    shieldedMode: ShieldedOutputMode.AMOUNT_SHIELDED,
+    address: 'W-addr',
+    value,
+    token,
+    scanPubkey: 'ab'.repeat(33),
+    ephemeralPubkey: buf(33),
+    commitment: buf(33),
+    rangeProof: buf(8),
+    blindingFactor: buf(32),
+    script: 'aa',
+  });
+
+  const fullShieldedData = (): IDataShieldedOutput => ({
+    ...(amountShieldedData() as object),
+    shieldedMode: ShieldedOutputMode.FULLY_SHIELDED,
+    assetCommitment: buf(33),
+    assetBlindingFactor: buf(32),
+    surjectionProof: buf(8),
+  });
+
+  const dataInput = (token: string, value: bigint, authorities = 0n): IDataInput => ({
+    txId: 'parent',
+    index: 0,
+    value,
+    authorities,
+    token,
+    address: 'W-addr',
+  });
+
+  // A fund output (authorities = 0). Omit `token` to model a create-token
+  // output (the new token has no uid yet).
+  const fundOutput = (token: string | undefined, value: bigint): IDataOutput => {
+    const base = { type: 'p2pkh', value, authorities: 0n, address: 'W-addr', timelock: null };
+    return (token === undefined ? base : { ...base, token }) as unknown as IDataOutput;
+  };
+
+  const makeDataTx = (over: Partial<IDataTx> = {}): IDataTx => ({
+    version: DEFAULT_TX_VERSION,
+    inputs: [],
+    outputs: [],
+    tokens: [],
+    ...over,
+  });
+
+  const newTx = () => new Transaction([], []);
+
+  describe('_attachShieldedOutputsHeader', () => {
+    it('builds models, sets tx.shieldedOutputs, and pushes a ShieldedOutputsHeader', () => {
+      const tx = newTx();
+      transactionUtils._attachShieldedOutputsHeader(
+        tx,
+        makeDataTx({ shieldedOutputs: [amountShieldedData()] })
+      );
+      expect(tx.shieldedOutputs).toHaveLength(1);
+      expect(tx.headers.some(h => h instanceof ShieldedOutputsHeader)).toBe(true);
+    });
+
+    it('carries assetCommitment/surjectionProof for FullShielded outputs', () => {
+      const tx = newTx();
+      transactionUtils._attachShieldedOutputsHeader(
+        tx,
+        makeDataTx({ shieldedOutputs: [fullShieldedData()] })
+      );
+      expect(tx.shieldedOutputs[0].assetCommitment).toBeDefined();
+      expect(tx.shieldedOutputs[0].surjectionProof).toBeDefined();
+    });
+
+    it('is a no-op when there are no shielded outputs', () => {
+      const tx = newTx();
+      transactionUtils._attachShieldedOutputsHeader(tx, makeDataTx());
+      expect(tx.headers).toHaveLength(0);
+    });
+
+    it('throws when a shielded output is missing a required crypto field', () => {
+      const tx = newTx();
+      const bad = {
+        ...amountShieldedData(),
+        commitment: undefined,
+      } as unknown as IDataShieldedOutput;
+      expect(() =>
+        transactionUtils._attachShieldedOutputsHeader(tx, makeDataTx({ shieldedOutputs: [bad] }))
+      ).toThrow(/missing required crypto fields/);
+    });
+  });
+
+  describe('_attachUnshieldBalanceHeader', () => {
+    it('pushes an UnshieldBalanceHeader when an excess blinding factor is present', () => {
+      const tx = newTx();
+      transactionUtils._attachUnshieldBalanceHeader(
+        tx,
+        makeDataTx({ excessBlindingFactor: buf(32) })
+      );
+      expect(tx.headers.some(h => h instanceof UnshieldBalanceHeader)).toBe(true);
+    });
+
+    it('throws when both an excess and shielded outputs are present (mutually exclusive)', () => {
+      const tx = newTx();
+      expect(() =>
+        transactionUtils._attachUnshieldBalanceHeader(
+          tx,
+          makeDataTx({ excessBlindingFactor: buf(32), shieldedOutputs: [amountShieldedData()] })
+        )
+      ).toThrow(/cannot carry both|mutually exclusive/i);
+    });
+
+    it('is a no-op without an excess blinding factor', () => {
+      const tx = newTx();
+      transactionUtils._attachUnshieldBalanceHeader(tx, makeDataTx());
+      expect(tx.headers).toHaveLength(0);
+    });
+  });
+
+  describe('_attachMintMeltHeaders', () => {
+    // isShieldedTx is satisfied via excessBlindingFactor so the block runs.
+    it('declares a MintHeader for a createToken positive delta', () => {
+      const tx = newTx();
+      transactionUtils._attachMintMeltHeaders(
+        tx,
+        makeDataTx({
+          version: CREATE_TOKEN_TX_VERSION,
+          excessBlindingFactor: buf(32),
+          outputs: [fundOutput(undefined, 100n)], // new token, no uid yet
+        })
+      );
+      expect(tx.headers.some(h => h instanceof MintHeader)).toBe(true);
+    });
+
+    it('declares a MintHeader for a regular tx when a mint authority is held and delta > 0', () => {
+      const tx = newTx();
+      transactionUtils._attachMintMeltHeaders(
+        tx,
+        makeDataTx({
+          excessBlindingFactor: buf(32),
+          tokens: ['tokenA'],
+          inputs: [dataInput('tokenA', 0n, TOKEN_MINT_MASK)],
+          outputs: [fundOutput('tokenA', 100n)],
+        })
+      );
+      expect(tx.headers.some(h => h instanceof MintHeader)).toBe(true);
+    });
+
+    it('declares a MeltHeader when a melt authority is held and delta < 0', () => {
+      const tx = newTx();
+      transactionUtils._attachMintMeltHeaders(
+        tx,
+        makeDataTx({
+          excessBlindingFactor: buf(32),
+          tokens: ['tokenA'],
+          inputs: [dataInput('tokenA', 100n), dataInput('tokenA', 0n, TOKEN_MELT_MASK)],
+          outputs: [], // in > out → melt
+        })
+      );
+      expect(tx.headers.some(h => h instanceof MeltHeader)).toBe(true);
+    });
+
+    it('declares nothing for a pure shielding move (no authority held)', () => {
+      const tx = newTx();
+      transactionUtils._attachMintMeltHeaders(
+        tx,
+        makeDataTx({
+          excessBlindingFactor: buf(32),
+          tokens: ['tokenA'],
+          inputs: [dataInput('tokenA', 50n)],
+          outputs: [fundOutput('tokenA', 100n)], // delta>0 but no mint authority held
+        })
+      );
+      expect(tx.headers.some(h => h instanceof MintHeader || h instanceof MeltHeader)).toBe(false);
+    });
+
+    it('is a no-op for a non-shielded tx', () => {
+      const tx = newTx();
+      transactionUtils._attachMintMeltHeaders(
+        tx,
+        makeDataTx({ tokens: ['tokenA'], outputs: [fundOutput('tokenA', 100n)] })
+      );
+      expect(tx.headers).toHaveLength(0);
+    });
+  });
+
+  describe('_attachShieldedHeaders (orchestrator)', () => {
+    it('delegates: a shielded-output tx ends up with a ShieldedOutputsHeader', () => {
+      const tx = newTx();
+      transactionUtils._attachShieldedHeaders(
+        tx,
+        makeDataTx({ shieldedOutputs: [amountShieldedData()] })
+      );
+      expect(tx.headers.some(h => h instanceof ShieldedOutputsHeader)).toBe(true);
+    });
   });
 });

--- a/__tests__/utils/transaction_shielded.test.ts
+++ b/__tests__/utils/transaction_shielded.test.ts
@@ -4,14 +4,22 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * Direct coverage for the shielded-aware transaction utils introduced in
- * this PR: isShieldedOutputEntry, findSpentOutput (the sparse-decode-safe
- * parent lookup), and normalizeShieldedOutputs. The receive pipeline that
- * consumes them lands in the next PR with its own end-to-end tests.
+ * Direct coverage for the SEPARATED-model shielded transaction utils:
+ * isInlineShieldedWireEntry (the wire discriminator), resolveSpentOutput (the
+ * arithmetic parent-output resolver: idx < T → transparent, T ≤ idx < T+S →
+ * shielded slot idx-T, else undefined), normalizeShieldedOutputs, and
+ * getTxBalance crediting/debiting owned shielded outputs.
  */
 
 import transactionUtils from '../../src/utils/transaction';
-import { IHistoryTx, IHistoryOutput, IShieldedOutputEntry } from '../../src/types';
+import {
+  IHistoryTx,
+  IHistoryOutput,
+  IHistoryShieldedOutput,
+  IStorage,
+  IUtxo,
+} from '../../src/types';
+import { ShieldedOutputMode } from '../../src/shielded/types';
 
 function makeTransparentOutput(value: bigint, address: string): IHistoryOutput {
   return {
@@ -24,23 +32,37 @@ function makeTransparentOutput(value: bigint, address: string): IHistoryOutput {
   };
 }
 
-function makeShieldedEntry(onChainIndex: number, commitment: string): IShieldedOutputEntry {
-  return {
-    type: 'shielded',
-    value: 10n,
-    token_data: 0,
-    script: 'bb',
-    decoded: { type: 'P2PKH', address: 'W-spend-address', timelock: null },
-    token: '00',
-    spent_by: null,
+/**
+ * Build a shielded_outputs[] entry. An OWNED entry carries the decoded
+ * value/token/decoded.address fields (the single ownership gate is
+ * `value !== undefined`). A non-owned entry leaves `value` undefined.
+ */
+function makeShieldedEntry(
+  commitment: string,
+  owned: { value: bigint; address: string; token?: string } | null
+): IHistoryShieldedOutput {
+  const base: IHistoryShieldedOutput = {
+    mode: ShieldedOutputMode.AMOUNT_SHIELDED,
     commitment,
     range_proof: 'cc',
+    script: 'bb',
+    token_data: 0,
     ephemeral_pubkey: 'dd',
-    onChainIndex,
+    decoded: owned ? { type: 'P2PKH', address: owned.address, timelock: null } : {},
+    spent_by: null,
   };
+  if (owned) {
+    base.value = owned.value;
+    base.token = owned.token ?? '00';
+  }
+  return base;
 }
 
-function makeTx(outputs: IHistoryOutput[], extra: Partial<IHistoryTx> = {}): IHistoryTx {
+function makeTx(
+  outputs: IHistoryOutput[],
+  shieldedOutputs?: IHistoryShieldedOutput[],
+  extra: Partial<IHistoryTx> = {}
+): IHistoryTx {
   return {
     tx_id: 'test-tx',
     version: 1,
@@ -50,48 +72,98 @@ function makeTx(outputs: IHistoryOutput[], extra: Partial<IHistoryTx> = {}): IHi
     inputs: [],
     outputs,
     parents: [],
+    ...(shieldedOutputs ? { shielded_outputs: shieldedOutputs } : {}),
     ...extra,
   };
 }
 
-describe('isShieldedOutputEntry', () => {
-  it('discriminates on the commitment field', () => {
-    expect(transactionUtils.isShieldedOutputEntry(makeShieldedEntry(1, 'ab'))).toBe(true);
-    expect(transactionUtils.isShieldedOutputEntry(makeTransparentOutput(5n, 'W-addr'))).toBe(false);
+describe('isInlineShieldedWireEntry', () => {
+  it('discriminates inline wire entries on the type field', () => {
+    expect(transactionUtils.isInlineShieldedWireEntry({ type: 'shielded', commitment: 'ab' })).toBe(
+      true
+    );
+    expect(transactionUtils.isInlineShieldedWireEntry(makeTransparentOutput(5n, 'W-addr'))).toBe(
+      false
+    );
   });
 });
 
-describe('findSpentOutput', () => {
-  it('returns the positional output for transparent-only parents', () => {
-    const tx = makeTx([makeTransparentOutput(1n, 'A'), makeTransparentOutput(2n, 'B')]);
-    expect(transactionUtils.findSpentOutput(tx, 1)).toMatchObject({ value: 2n });
+describe('resolveSpentOutput', () => {
+  // Parent layout: T=2 transparent outputs, S=2 shielded outputs.
+  // On-chain index space: 0,1 transparent; 2 = shielded slot 0; 3 = slot 1.
+  const buildParent = () =>
+    makeTx(
+      [makeTransparentOutput(1n, 'A'), makeTransparentOutput(2n, 'B')],
+      [
+        makeShieldedEntry('s0', null), // non-owned middle slot (value undefined)
+        makeShieldedEntry('s1', { value: 10n, address: 'W-spend' }), // owned
+      ]
+    );
+
+  it('resolves transparent slots for idx in [0, T)', () => {
+    const tx = buildParent();
+    const r0 = transactionUtils.resolveSpentOutput(tx, 0);
+    expect(r0).toMatchObject({ kind: 'transparent' });
+    expect(r0!.output).toMatchObject({ value: 1n });
+    const r1 = transactionUtils.resolveSpentOutput(tx, 1);
+    expect(r1).toMatchObject({ kind: 'transparent' });
+    expect(r1!.output).toMatchObject({ value: 2n });
   });
 
-  it('resolves a decoded shielded output by onChainIndex, not array position', () => {
-    // Parent: 1 transparent output + 1 DECODED shielded entry whose on-chain
-    // absolute index is 2 (e.g. another shielded output at index 1 was not
-    // decryptable and is absent from outputs[]). A positional lookup
-    // tx.outputs[2] would be undefined; index 1 would WRONGLY return the
-    // decoded entry sitting at array position 1.
-    const tx = makeTx([makeTransparentOutput(1n, 'A'), makeShieldedEntry(2, 'c0ffee')]);
-
-    const atTwo = transactionUtils.findSpentOutput(tx, 2);
-    expect(atTwo).toBeDefined();
-    expect((atTwo as IShieldedOutputEntry).commitment).toBe('c0ffee');
-
-    // Index 1 is the UNDECODED shielded output: it must resolve to nothing,
-    // not to the entry that happens to sit at array position 1.
-    expect(transactionUtils.findSpentOutput(tx, 1)).toBeUndefined();
+  it('resolves idx === T to the first shielded slot', () => {
+    const tx = buildParent();
+    const r = transactionUtils.resolveSpentOutput(tx, 2); // T = 2
+    expect(r).toMatchObject({ kind: 'shielded', sIndex: 0 });
+    // Non-owned slot: still a valid shielded resolve, value undefined.
+    expect((r!.output as IHistoryShieldedOutput).value).toBeUndefined();
+    expect((r!.output as IHistoryShieldedOutput).commitment).toBe('s0');
   });
 
-  it('returns undefined for an out-of-range index', () => {
+  it('resolves idx === T+S-1 to the last shielded slot (owned, value defined)', () => {
+    const tx = buildParent();
+    const r = transactionUtils.resolveSpentOutput(tx, 3); // T+S-1 = 3
+    expect(r).toMatchObject({ kind: 'shielded', sIndex: 1 });
+    expect((r!.output as IHistoryShieldedOutput).value).toBe(10n);
+    expect((r!.output as IHistoryShieldedOutput).commitment).toBe('s1');
+  });
+
+  it('returns undefined for idx === T+S (past the last shielded slot)', () => {
+    const tx = buildParent();
+    expect(transactionUtils.resolveSpentOutput(tx, 4)).toBeUndefined(); // T+S = 4
+  });
+
+  it('returns undefined for a negative index', () => {
+    const tx = buildParent();
+    expect(transactionUtils.resolveSpentOutput(tx, -1)).toBeUndefined();
+  });
+
+  it('resolves a non-owned middle slot and the owned next slot independently', () => {
+    // T=1 transparent; shielded_outputs = [nonOwned#0, owned#1].
+    // idx = T+0 → slot 0 (value undefined); idx = T+1 → slot 1 (value defined).
+    const tx = makeTx(
+      [makeTransparentOutput(5n, 'A')],
+      [
+        makeShieldedEntry('non-owned', null),
+        makeShieldedEntry('owned', { value: 42n, address: 'W-spend' }),
+      ]
+    );
+    const slot0 = transactionUtils.resolveSpentOutput(tx, 1); // T+0
+    expect(slot0).toMatchObject({ kind: 'shielded', sIndex: 0 });
+    expect((slot0!.output as IHistoryShieldedOutput).value).toBeUndefined();
+
+    const slot1 = transactionUtils.resolveSpentOutput(tx, 2); // T+1
+    expect(slot1).toMatchObject({ kind: 'shielded', sIndex: 1 });
+    expect((slot1!.output as IHistoryShieldedOutput).value).toBe(42n);
+  });
+
+  it('returns undefined for a shielded idx when the parent has no shielded list (S=0)', () => {
     const tx = makeTx([makeTransparentOutput(1n, 'A')]);
-    expect(transactionUtils.findSpentOutput(tx, 5)).toBeUndefined();
+    expect(transactionUtils.resolveSpentOutput(tx, 1)).toBeUndefined();
   });
 });
 
 describe('normalizeShieldedOutputs', () => {
-  it('extracts shielded entries from outputs[] and converts base64 fields to hex', () => {
+  it('extracts inline shielded entries from outputs[] and converts base64 fields to hex', () => {
     const base64Proof = Buffer.from([0x01, 0x02, 0xff]).toString('base64');
     const tx = makeTx([
       makeTransparentOutput(1n, 'A'),
@@ -108,7 +180,7 @@ describe('normalizeShieldedOutputs', () => {
         commitment: 'ab'.repeat(33), // already hex — must pass through
         range_proof: base64Proof,
         ephemeral_pubkey: 'cd'.repeat(33),
-      } as IHistoryOutput,
+      } as unknown as IHistoryOutput,
     ]);
 
     transactionUtils.normalizeShieldedOutputs(tx);
@@ -122,8 +194,9 @@ describe('normalizeShieldedOutputs', () => {
   });
 
   it('is idempotent when shielded_outputs is already populated', () => {
-    const tx = makeTx([makeTransparentOutput(1n, 'A')], {
-      shielded_outputs: [
+    const tx = makeTx(
+      [makeTransparentOutput(1n, 'A')],
+      [
         {
           commitment: 'ab'.repeat(33),
           range_proof: '0102ff',
@@ -131,11 +204,89 @@ describe('normalizeShieldedOutputs', () => {
           ephemeral_pubkey: 'cd'.repeat(33),
           decoded: {},
         },
-      ],
-    });
+      ]
+    );
     const before = JSON.stringify(tx.shielded_outputs);
     transactionUtils.normalizeShieldedOutputs(tx);
     expect(tx.outputs).toHaveLength(1);
     expect(JSON.stringify(tx.shielded_outputs)).toBe(before);
+  });
+
+  it('preserves owned-marker fields on an inline wire entry', () => {
+    const tx = makeTx([
+      makeTransparentOutput(1n, 'A'),
+      {
+        type: 'shielded',
+        value: 77n,
+        token: '00',
+        token_data: 0,
+        script: 'bb',
+        decoded: { type: 'P2PKH', address: 'W-spend', timelock: null },
+        spent_by: null,
+        commitment: 'ab'.repeat(33),
+        range_proof: 'cc',
+        ephemeral_pubkey: 'dd',
+        blindingFactor: 'ff'.repeat(32),
+      } as unknown as IHistoryOutput,
+    ]);
+
+    transactionUtils.normalizeShieldedOutputs(tx);
+
+    const so = tx.shielded_outputs![0];
+    expect(so.value).toBe(77n);
+    expect(so.token).toBe('00');
+    expect(so.blindingFactor).toBe('ff'.repeat(32));
+    expect(so.decoded.address).toBe('W-spend');
+  });
+});
+
+describe('getTxBalance (shielded)', () => {
+  const OWNED = 'W-owned-shielded';
+
+  function makeStorage(opts: { utxo?: IUtxo | null } = {}): IStorage {
+    return {
+      getCurrentHeight: jest.fn().mockResolvedValue(0),
+      version: { reward_spend_min_blocks: 0 },
+      isAddressMine: jest.fn(async (addr: string) => addr === OWNED),
+      getUtxo: jest.fn().mockResolvedValue(opts.utxo ?? null),
+      getTx: jest.fn().mockResolvedValue(null),
+    } as unknown as IStorage;
+  }
+
+  it('credits an owned shielded receive (value defined) and ignores non-owned slots', async () => {
+    const tx = makeTx(
+      [], // no transparent outputs
+      [
+        makeShieldedEntry('non-owned', null), // value undefined → ignored
+        makeShieldedEntry('owned', { value: 500n, address: OWNED, token: '00' }),
+      ],
+      { tx_id: 'recv-tx' }
+    );
+
+    const balance = await transactionUtils.getTxBalance(tx, makeStorage());
+    expect(balance['00'].tokens.unlocked).toBe(500n);
+  });
+
+  it('debits a shielded input whose UTXO is already deleted via the parent resolver', async () => {
+    // Parent tx: T=0 transparent, one owned shielded output at on-chain idx 0.
+    const parentTx = makeTx(
+      [],
+      [makeShieldedEntry('spent-commit', { value: 300n, address: OWNED, token: '00' })],
+      { tx_id: 'parent-tx' }
+    );
+
+    // Spending tx: a shielded input referencing parent idx 0. No decoded
+    // value/token on the input and the UTXO has been deleted (getUtxo → null),
+    // so getTxBalance must recover the debit from the parent's shielded entry.
+    const spendingTx = makeTx([], undefined, {
+      tx_id: 'spend-tx',
+      inputs: [{ tx_id: 'parent-tx', index: 0, type: 'shielded' }],
+    });
+
+    const storage = makeStorage({ utxo: null });
+    (storage.getTx as jest.Mock).mockResolvedValue(parentTx);
+
+    const balance = await transactionUtils.getTxBalance(spendingTx, storage);
+    expect(balance['00'].tokens.unlocked).toBe(-300n);
   });
 });

--- a/__tests__/wallet/walletServiceStorageProxy.test.ts
+++ b/__tests__/wallet/walletServiceStorageProxy.test.ts
@@ -17,6 +17,7 @@ import { AddressInfoObject } from '../../src/wallet/types';
 
 jest.mock('../../src/utils/transaction', () => ({
   getSignatureForTx: jest.fn(),
+  isShieldedOutputEntry: jest.fn().mockReturnValue(false),
 }));
 
 describe('WalletServiceStorageProxy', () => {

--- a/__tests__/wallet/walletServiceStorageProxy.test.ts
+++ b/__tests__/wallet/walletServiceStorageProxy.test.ts
@@ -17,7 +17,6 @@ import { AddressInfoObject } from '../../src/wallet/types';
 
 jest.mock('../../src/utils/transaction', () => ({
   getSignatureForTx: jest.fn(),
-  isInlineShieldedWireEntry: jest.fn().mockReturnValue(false),
 }));
 
 describe('WalletServiceStorageProxy', () => {

--- a/__tests__/wallet/walletServiceStorageProxy.test.ts
+++ b/__tests__/wallet/walletServiceStorageProxy.test.ts
@@ -17,7 +17,7 @@ import { AddressInfoObject } from '../../src/wallet/types';
 
 jest.mock('../../src/utils/transaction', () => ({
   getSignatureForTx: jest.fn(),
-  isShieldedOutputEntry: jest.fn().mockReturnValue(false),
+  isInlineShieldedWireEntry: jest.fn().mockReturnValue(false),
 }));
 
 describe('WalletServiceStorageProxy', () => {

--- a/src/models/shielded_output.ts
+++ b/src/models/shielded_output.ts
@@ -65,7 +65,7 @@ class ShieldedOutput {
    *   Required so callers can't silently get a 0n placeholder where a real
    *   value is known. It is NOT serialized on-chain and MUST NOT influence
    *   tx weight. For wire-format outputs whose value is hidden until rewind,
-   *   pass `0n` explicitly — see `ShieldedOutputsHeader.deserialize` in PR 3.
+   *   pass `0n` explicitly — see `ShieldedOutputsHeader.deserialize`.
    * @param options.assetCommitment / options.surjectionProof — required
    *   for FullShielded mode; absent for AmountShielded mode. Enforced at
    *   serialize time, not construction time, so deserializers can build

--- a/src/models/shielded_output.ts
+++ b/src/models/shielded_output.ts
@@ -51,14 +51,21 @@ class ShieldedOutput {
 
   surjectionProof?: Buffer;
 
-  /** The plaintext value, used for weight calculation. Not serialized on-chain. */
+  /**
+   * The wallet's locally-known plaintext value of this output. Not serialized
+   * on-chain (the value is hidden in the Pedersen commitment). MUST NOT be fed
+   * into tx-weight calculation — see `Transaction.getOutputsSum` — or it leaks
+   * the hidden amount through the public weight. `0n` for wire-format outputs
+   * whose value is not yet known (before rewind).
+   */
   value: OutputValueType;
 
   /**
-   * @param value Plaintext value (required so callers can't silently get
-   *   a 0n placeholder that would skew weight calculation). For wire-
-   *   format outputs whose value is hidden until rewind, pass `0n`
-   *   explicitly — see `ShieldedOutputsHeader.deserialize` in PR 3.
+   * @param value Plaintext value, for the wallet's local bookkeeping only.
+   *   Required so callers can't silently get a 0n placeholder where a real
+   *   value is known. It is NOT serialized on-chain and MUST NOT influence
+   *   tx weight. For wire-format outputs whose value is hidden until rewind,
+   *   pass `0n` explicitly — see `ShieldedOutputsHeader.deserialize` in PR 3.
    * @param options.assetCommitment / options.surjectionProof — required
    *   for FullShielded mode; absent for AmountShielded mode. Enforced at
    *   serialize time, not construction time, so deserializers can build

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -73,6 +73,12 @@ type optionsType = {
  * - `helpers.createTxFromData`: creates from a standard lib data object
  * - `helpers.createTxFromHistoryObject`: creates from a tx populated by the HathorWallet history methods
  */
+
+// Shared frozen empty array returned by the `shieldedOutputs` getter when a tx
+// has no ShieldedOutputsHeader. Frozen so a stray push fails loudly at runtime
+// (JS callers) instead of being silently dropped onto a throwaway array.
+const EMPTY_SHIELDED_OUTPUTS: readonly ShieldedOutput[] = Object.freeze([]);
+
 class Transaction {
   inputs: Input[];
 
@@ -131,16 +137,26 @@ class Transaction {
   }
 
   /**
-   * Shielded outputs (SEPARATED model), read straight from the
-   * ShieldedOutputsHeader so there is a single source of truth: the header owns
-   * the array, mutating the returned array updates the header, and there is no
-   * separate cached field to drift. Empty when the tx carries no shielded
-   * outputs (no header). The header is produced by
-   * `transactionUtils._attachShieldedOutputsHeader`.
+   * Shielded outputs (SEPARATED model). READ-ONLY accessor backed by the
+   * ShieldedOutputsHeader, the single source of truth (no separate cached field
+   * to drift): returns the header's array when one is present, or a shared
+   * frozen empty array when the tx carries no shielded outputs. Never undefined
+   * — an empty result unambiguously means "no shielded outputs" (a header is
+   * only ever created with at least one output), and the always-an-array
+   * contract keeps callers like validate() and the local-history emission
+   * null-check-free.
+   *
+   * The return type is `readonly` (so a `.push` is a compile error) and the
+   * empty case is frozen (so a `.push` also throws at runtime). To ADD shielded
+   * outputs go through `transactionUtils._attachShieldedOutputsHeader` — pushing
+   * onto this getter's result is never the way to add them: with a header it
+   * would bypass that builder, and with no header it would be dropped.
    */
-  get shieldedOutputs(): ShieldedOutput[] {
+  get shieldedOutputs(): readonly ShieldedOutput[] {
     const header = this.headers.find(h => h instanceof ShieldedOutputsHeader);
-    return header instanceof ShieldedOutputsHeader ? header.shieldedOutputs : [];
+    return header instanceof ShieldedOutputsHeader
+      ? header.shieldedOutputs
+      : EMPTY_SHIELDED_OUTPUTS;
   }
 
   /**

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -78,8 +78,6 @@ class Transaction {
 
   outputs: Output[];
 
-  shieldedOutputs: ShieldedOutput[];
-
   signalBits: number;
 
   version: number;
@@ -118,7 +116,6 @@ class Transaction {
 
     this.inputs = inputs;
     this.outputs = outputs;
-    this.shieldedOutputs = [];
     this.signalBits = signalBits!;
     this.version = version!;
     this.weight = weight!;
@@ -131,6 +128,19 @@ class Transaction {
 
     // All inputs sign the same data, so we cache it in the first getDataToSign method call
     this._dataToSignCache = null;
+  }
+
+  /**
+   * Shielded outputs (SEPARATED model), read straight from the
+   * ShieldedOutputsHeader so there is a single source of truth: the header owns
+   * the array, mutating the returned array updates the header, and there is no
+   * separate cached field to drift. Empty when the tx carries no shielded
+   * outputs (no header). The header is produced by
+   * `transactionUtils._attachShieldedOutputsHeader`.
+   */
+  get shieldedOutputs(): ShieldedOutput[] {
+    const header = this.headers.find(h => h instanceof ShieldedOutputsHeader);
+    return header instanceof ShieldedOutputsHeader ? header.shieldedOutputs : [];
   }
 
   /**
@@ -676,15 +686,8 @@ class Transaction {
     // so we must exhaust the buffer until it's empty
     // or we will throw an error
     tx.getHeadersFromBytes(txBuffer, network);
-
-    // Hydrate shieldedOutputs from the ShieldedOutputsHeader (if present)
-    // so validate() and weight calculations use the correct count.
-    for (const header of tx.headers) {
-      if (header instanceof ShieldedOutputsHeader) {
-        tx.shieldedOutputs = header.shieldedOutputs;
-        break;
-      }
-    }
+    // No shieldedOutputs hydration needed: the `shieldedOutputs` getter reads
+    // the ShieldedOutputsHeader (parsed above) directly.
 
     tx.updateHash();
 

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -17,6 +17,7 @@ import {
   DEFAULT_TX_VERSION,
   MAX_INPUTS,
   MAX_OUTPUTS,
+  MAX_SHIELDED_OUTPUTS,
   MERGED_MINED_BLOCK_VERSION,
   TX_HASH_SIZE_BYTES,
   TX_WEIGHT_CONSTANTS,
@@ -33,6 +34,7 @@ import {
 } from '../utils/buffer';
 import Input from './input';
 import Output from './output';
+import ShieldedOutput from './shielded_output';
 import Network from './network';
 import { MaximumNumberInputsError, MaximumNumberOutputsError } from '../errors';
 import { OutputValueType } from '../types';
@@ -40,6 +42,7 @@ import type Header from '../headers/base';
 import NanoContractHeader from '../nano_contracts/header';
 import FeeHeader from '../headers/fee';
 import HeaderParser from '../headers/parser';
+import ShieldedOutputsHeader from '../headers/shielded_outputs';
 import { getVertexHeaderIdFromBuffer } from '../headers/types';
 
 enum txType {
@@ -74,6 +77,8 @@ class Transaction {
   inputs: Input[];
 
   outputs: Output[];
+
+  shieldedOutputs: ShieldedOutput[];
 
   signalBits: number;
 
@@ -113,6 +118,7 @@ class Transaction {
 
     this.inputs = inputs;
     this.outputs = outputs;
+    this.shieldedOutputs = [];
     this.signalBits = signalBits!;
     this.version = version!;
     this.weight = weight!;
@@ -220,7 +226,7 @@ class Transaction {
     // Len inputs
     array.push(intToBytes(this.inputs.length, 1));
 
-    // Len outputs
+    // Len outputs (transparent only; shielded go in the ShieldedOutputsHeader)
     array.push(intToBytes(this.outputs.length, 1));
   }
 
@@ -238,6 +244,7 @@ class Transaction {
     for (const outputTx of this.outputs) {
       array.push(...outputTx.serialize());
     }
+    // Shielded outputs are serialized in the ShieldedOutputsHeader, not here.
   }
 
   /**
@@ -340,10 +347,11 @@ class Transaction {
     // For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     const amount = sumOutputs / 10 ** DECIMAL_PLACES;
 
-    let weight =
-      constants.txWeightCoefficient * Math.log2(txSize) +
-      4 / (1 + constants.txMinWeightK / amount) +
-      4;
+    // When txMinWeightK is 0, avoid the division-by-zero in `k/amount` —
+    // the term `4 / (1 + 0)` collapses to 4.
+    const kTerm = constants.txMinWeightK === 0 ? 4 : 4 / (1 + constants.txMinWeightK / amount);
+
+    let weight = constants.txWeightCoefficient * Math.log2(txSize) + kTerm + 4;
 
     // Make sure the calculated weight is at least the minimum
     weight = Math.max(weight, constants.txMinWeight);
@@ -366,6 +374,10 @@ class Transaction {
         continue;
       }
       sumOutputs += output.value;
+    }
+    // Shielded outputs also contribute to the weight calculation
+    for (const shieldedOut of this.shieldedOutputs) {
+      sumOutputs += shieldedOut.value;
     }
     return sumOutputs;
   }
@@ -415,6 +427,12 @@ class Transaction {
     if (this.outputs.length > MAX_OUTPUTS) {
       throw new MaximumNumberOutputsError(
         `Transaction has ${this.outputs.length} outputs and can have at most ${MAX_OUTPUTS}.`
+      );
+    }
+
+    if (this.shieldedOutputs.length > MAX_SHIELDED_OUTPUTS) {
+      throw new MaximumNumberOutputsError(
+        `Transaction has ${this.shieldedOutputs.length} shielded outputs and can have at most ${MAX_SHIELDED_OUTPUTS}.`
       );
     }
   }
@@ -655,6 +673,15 @@ class Transaction {
     // so we must exhaust the buffer until it's empty
     // or we will throw an error
     tx.getHeadersFromBytes(txBuffer, network);
+
+    // Hydrate shieldedOutputs from the ShieldedOutputsHeader (if present)
+    // so validate() and weight calculations use the correct count.
+    for (const header of tx.headers) {
+      if (header instanceof ShieldedOutputsHeader) {
+        tx.shieldedOutputs = header.shieldedOutputs;
+        break;
+      }
+    }
 
     tx.updateHash();
 

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -347,11 +347,10 @@ class Transaction {
     // For instance, if one wants to transfer 20 HTRs, the amount will be 2000.
     const amount = sumOutputs / 10 ** DECIMAL_PLACES;
 
-    // When txMinWeightK is 0, avoid the division-by-zero in `k/amount` —
-    // the term `4 / (1 + 0)` collapses to 4.
-    const kTerm = constants.txMinWeightK === 0 ? 4 : 4 / (1 + constants.txMinWeightK / amount);
-
-    let weight = constants.txWeightCoefficient * Math.log2(txSize) + kTerm + 4;
+    let weight =
+      constants.txWeightCoefficient * Math.log2(txSize) +
+      4 / (1 + constants.txMinWeightK / amount) +
+      4;
 
     // Make sure the calculated weight is at least the minimum
     weight = Math.max(weight, constants.txMinWeight);
@@ -362,6 +361,14 @@ class Transaction {
 
   /**
    * Calculate the sum of outputs. Authority outputs are ignored.
+   *
+   * Shielded outputs are intentionally excluded: hathor-core derives the
+   * minimum tx weight from the transparent `sum_outputs` only (see
+   * `hathor/daa.py::minimum_tx_weight` and `base_transaction.py::sum_outputs`),
+   * with shielded outputs living in a separate property that never enters the
+   * weight. Including their plaintext values here would leak the exact total
+   * shielded amount through the publicly-invertible weight formula. Keep this
+   * in lockstep with core.
    *
    * @return {number} Sum of outputs
    * @memberof Transaction
@@ -374,10 +381,6 @@ class Transaction {
         continue;
       }
       sumOutputs += output.value;
-    }
-    // Shielded outputs also contribute to the weight calculation
-    for (const shieldedOut of this.shieldedOutputs) {
-      sumOutputs += shieldedOut.value;
     }
     return sumOutputs;
   }

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -32,24 +32,35 @@ export type {
  * A shielded output as received from the full node API.
  * This is the on-chain data before decryption.
  */
-export interface IShieldedOutput {
+/**
+ * The on-chain confidential fields of a shielded output: the Pedersen value
+ * commitment, its range proof, the ECDH ephemeral pubkey, and (FullShielded
+ * only) the asset commitment + surjection proof. Defined once and shared by
+ * every shielded-output representation — the wire `IShieldedOutput` here and
+ * the decrypted `IShieldedOutputEntry` in tx.outputs[] (src/types.ts) — so the
+ * field set can't drift between them.
+ */
+export interface IShieldedOutputProofs {
+  commitment: string; // hex, 33 bytes
+  range_proof: string; // hex, variable (~675 bytes)
+  ephemeral_pubkey: string; // hex, 33 bytes
+  // FullShielded only:
+  asset_commitment?: string; // hex, 33 bytes
+  surjection_proof?: string; // hex, variable
+}
+
+export interface IShieldedOutput extends IShieldedOutputProofs {
   // Optional because hathor-core nodes pre-`_shielded_output_to_json`
   // mode-field addition still send shielded outputs without `mode`.
   // Readers must fall back to detecting FullShielded via the presence
   // of `asset_commitment` (the same pattern already used in the
   // explorer's `TxData.isFullShielded`).
   mode?: ShieldedOutputMode;
-  commitment: string; // hex, 33 bytes
-  range_proof: string; // hex, variable (~675 bytes)
   script: string; // hex, output script (P2PKH/P2SH)
   // FullShielded outputs may omit `token_data` (the token UID is hidden
   // behind `asset_commitment`, so the field has no meaningful value).
   token_data?: number; // token index (AmountShielded only)
-  ephemeral_pubkey: string; // hex, 33 bytes
   decoded: IShieldedOutputDecoded;
-  // FullShielded only:
-  asset_commitment?: string; // hex, 33 bytes
-  surjection_proof?: string; // hex, variable
 }
 
 export interface IShieldedOutputDecoded {

--- a/src/shielded/types.ts
+++ b/src/shielded/types.ts
@@ -37,8 +37,8 @@ export type {
  * commitment, its range proof, the ECDH ephemeral pubkey, and (FullShielded
  * only) the asset commitment + surjection proof. Defined once and shared by
  * every shielded-output representation — the wire `IShieldedOutput` here and
- * the decrypted `IShieldedOutputEntry` in tx.outputs[] (src/types.ts) — so the
- * field set can't drift between them.
+ * the history/storage `IHistoryShieldedOutput` in tx.shielded_outputs[]
+ * (src/types.ts) — so the field set can't drift between them.
  */
 export interface IShieldedOutputProofs {
   commitment: string; // hex, 33 bytes

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -391,6 +391,9 @@ export class Storage implements IStorage {
    * @returns {Promise<void>}
    */
   async addTx(tx: IHistoryTx): Promise<void> {
+    // Normalize: extract shielded entries from outputs[] into shielded_outputs[],
+    // converting base64 fields to hex.
+    transactionUtils.normalizeShieldedOutputs(tx);
     await this.store.saveTx(tx);
   }
 
@@ -760,7 +763,12 @@ export class Storage implements IStorage {
     if (!tx) {
       return;
     }
-    const output = tx.outputs[utxo.index];
+    // Resolve the actual output the UTXO record refers to via the sparse-
+    // decode-aware helper. A positional `tx.outputs[utxo.index]` would read
+    // a different decoded shielded entry when `utxo.index` (the on-chain
+    // absolute index) doesn't equal the entry's array position — the
+    // `.spent_by` check below would then consult the wrong entry's flag.
+    const output = transactionUtils.findSpentOutput(tx, utxo.index);
     if (!output) {
       return;
     }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -181,6 +181,21 @@ export class Storage implements IStorage {
   }
 
   /**
+   * Get the shielded crypto provider, or throw if it has not been configured.
+   * Confidential-transaction code paths require the provider; a missing one is a
+   * setup error and must fail loudly rather than silently degrade.
+   */
+  getShieldedCryptoProvider(): IShieldedCryptoProvider {
+    if (!this.shieldedCryptoProvider) {
+      throw new Error(
+        'Shielded crypto provider is not set. It is required for confidential ' +
+          'transaction operations; configure it via setShieldedCryptoProvider().'
+      );
+    }
+    return this.shieldedCryptoProvider;
+  }
+
+  /**
    * Sign the transaction
    * @param {Transaction} tx The transaction to sign
    * @param {string} pinCode The pin code

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -763,17 +763,20 @@ export class Storage implements IStorage {
     if (!tx) {
       return;
     }
-    // Resolve the actual output the UTXO record refers to via the sparse-
-    // decode-aware helper. A positional `tx.outputs[utxo.index]` would read
-    // a different decoded shielded entry when `utxo.index` (the on-chain
-    // absolute index) doesn't equal the entry's array position — the
-    // `.spent_by` check below would then consult the wrong entry's flag.
-    const output = transactionUtils.findSpentOutput(tx, utxo.index);
-    if (!output) {
+    // Resolve the actual output the UTXO record refers to via the
+    // SEPARATED-model resolver. A shielded UTXO has on-chain index
+    // outputs.length + s, so a positional `tx.outputs[utxo.index]` would read
+    // the wrong (or no) entry — the `.spent_by` check below would then consult
+    // the wrong entry's flag.
+    const resolved = transactionUtils.resolveSpentOutput(tx, utxo.index);
+    if (!resolved) {
       return;
     }
 
-    if (markAs && output.spent_by !== null) {
+    // Both transparent (`string | null`) and shielded (`string | null |
+    // undefined`) outputs carry spent_by; treat undefined as unspent.
+    const spentBy = resolved.output.spent_by ?? null;
+    if (markAs && spentBy !== null) {
       // Already spent, no need to mark as selected_as_input
       return;
     }

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -391,8 +391,9 @@ export class Storage implements IStorage {
    * @returns {Promise<void>}
    */
   async addTx(tx: IHistoryTx): Promise<void> {
-    // Normalize: extract shielded entries from outputs[] into shielded_outputs[],
-    // converting base64 fields to hex.
+    // Normalize: convert base64-encoded confidential fields to hex in
+    // tx.shielded_outputs[] (the fullnode delivers the transparent/shielded
+    // split; this does not move or extract entries).
     transactionUtils.normalizeShieldedOutputs(tx);
     await this.store.saveTx(tx);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,11 @@ import Transaction from './models/transaction';
 import Input from './models/input';
 import FullNodeConnection from './new/connection';
 import Header from './headers/base';
-import type { IShieldedCryptoProvider, IShieldedOutput } from './shielded/types';
+import type {
+  IShieldedCryptoProvider,
+  IShieldedOutput,
+  IDataShieldedOutput,
+} from './shielded/types';
 
 /**
  * Token version used to identify the type of token during the token creation process.
@@ -293,13 +297,28 @@ export enum TxHistoryProcessingStatus {
 }
 
 export interface IHistoryInput {
-  value: OutputValueType;
-  token_data: number;
-  script: string;
-  decoded: IHistoryOutputDecoded;
-  token: string;
+  // These fields are resolved from the spent output.
+  // For shielded inputs (spending shielded outputs), they may be absent
+  // because the spent output's value/token are hidden in commitments.
+  value?: OutputValueType;
+  token_data?: number;
+  script?: string;
+  decoded?: IHistoryOutputDecoded;
+  token?: string;
+  // Always present:
   tx_id: string;
   index: number;
+  // Set to 'shielded' when this input spends a shielded output. The
+  // fullnode emits this on the wire for inputs in `address_history` /
+  // `/transaction?id=…` responses; the wallet's sender-local insert
+  // (`txUtils.convertTransactionToHistoryTx`) also stamps it so
+  // self-sent shielded spends carry the discriminator before any
+  // WebSocket re-delivery. Absent on transparent inputs.
+  type?: 'shielded';
+  // Shielded inputs carry their own commitment on the wire; surfaced
+  // here so the explorer's unblinding verifier (and any future
+  // re-derive flows) can read it without round-tripping the full tx.
+  commitment?: string;
 }
 
 // Obs: this will change with nano contracts
@@ -310,7 +329,7 @@ export interface IHistoryOutputDecoded {
   data?: string;
 }
 
-export interface IHistoryOutput {
+export interface ITransparentOutput {
   value: OutputValueType;
   token_data: number;
   script: string;
@@ -319,6 +338,38 @@ export interface IHistoryOutput {
   spent_by: string | null;
   selected_as_input?: boolean;
 }
+
+/**
+ * Shielded output entry as it appears in tx.outputs after decryption.
+ * Before decryption (from fullnode), value/token/decoded are absent.
+ * After decryption (by processNewTx), they are populated so the output
+ * can be processed uniformly with transparent outputs.
+ */
+export interface IShieldedOutputEntry {
+  type: 'shielded';
+  value: OutputValueType;
+  token_data: number;
+  script: string;
+  decoded: IHistoryOutputDecoded;
+  token: string;
+  spent_by: string | null;
+  commitment: string;
+  range_proof: string;
+  ephemeral_pubkey: string;
+  asset_commitment?: string;
+  surjection_proof?: string;
+  blindingFactor?: string; // hex, 32 bytes — value blinding factor (populated after decryption)
+  assetBlindingFactor?: string; // hex, 32 bytes — asset blinding factor (FullShielded only)
+  // The fullnode-canonical absolute output index (`transparentCount + s_index`).
+  // Recorded when the wallet decodes a shielded output and appends it to
+  // `tx.outputs[]` (see `utils/storage.ts:processSingleTxUtil`). Older cached
+  // history entries written before this field existed don't carry it; readers
+  // must recover the index by matching `commitment` back to its position in
+  // `tx.shielded_outputs[]` and adding the transparent count.
+  onChainIndex?: number;
+}
+
+export type IHistoryOutput = ITransparentOutput | IShieldedOutputEntry;
 
 export interface IDataOutputData {
   type: 'data';
@@ -391,6 +442,20 @@ export interface IDataTx extends Partial<IDataTokenCreationTx> {
   inputs: IDataInput[];
   outputs: IDataOutput[];
   tokens: string[];
+  shieldedOutputs?: IDataShieldedOutput[];
+  /**
+   * 32-byte excess blinding factor for a full-unshield transaction
+   * (shielded inputs → transparent outputs only, no shielded outputs).
+   *
+   * When present, `prepareTransaction` attaches an `UnshieldBalanceHeader`
+   * (id 0x13) to the built Transaction. Mutually exclusive with
+   * `shieldedOutputs`; the fullnode rejects a tx that carries both, and
+   * rejects a tx with shielded inputs but no shielded outputs and no
+   * excess. See hathor-core
+   * `hathor/transaction/headers/unshield_balance_header.py` and
+   * Section 2.4 of the shielded outputs client guide.
+   */
+  excessBlindingFactor?: Buffer;
   weight?: number;
   nonce?: number;
   timestamp?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,6 @@ import Header from './headers/base';
 import type {
   IShieldedCryptoProvider,
   IShieldedOutput,
-  IShieldedOutputProofs,
   IDataShieldedOutput,
 } from './shielded/types';
 
@@ -290,6 +289,18 @@ export interface IHistoryShieldedOutput extends Omit<IShieldedOutput, 'decoded'>
   // the processNewTx decryption append so the wallet treats shielded
   // and transparent outputs identically when checking spend status.
   spent_by?: string | null;
+  // ─── owned-marker fields (SEPARATED model) ───────────────────────────────
+  // Populated IN PLACE on this entry when the wallet decrypts a shielded
+  // output it owns (received or change). The single ownership gate is
+  // `value !== undefined`: a slot with `value === undefined` is non-owned (or
+  // not yet decrypted) and is excluded from balance/credit/sign. `decoded`
+  // (address) is NOT an ownership signal — the fullnode emits a decoded
+  // address for non-owned outputs too, so keying ownership off `decoded`
+  // would let the wallet sign foreign inputs. `decoded` stays REQUIRED.
+  value?: OutputValueType;
+  token?: string;
+  blindingFactor?: string; // hex, 32 bytes — value blinding factor (after decryption)
+  assetBlindingFactor?: string; // hex, 32 bytes — asset blinding factor (FullShielded only)
 }
 
 export enum TxHistoryProcessingStatus {
@@ -340,33 +351,13 @@ export interface ITransparentOutput {
   selected_as_input?: boolean;
 }
 
-/**
- * Shielded output entry as it appears in tx.outputs after decryption, so the
- * output can be processed uniformly with transparent outputs.
- *
- * It reuses the standard output fields from `ITransparentOutput` (value,
- * token_data, script, decoded, token, spent_by) and the on-chain confidential
- * fields from `IShieldedOutputProofs` (commitment, range_proof,
- * ephemeral_pubkey, asset_commitment?, surjection_proof?) so neither set is
- * re-declared here. It adds only the `'shielded'` discriminant and the
- * wallet-local results produced by decryption.
- */
-export interface IShieldedOutputEntry
-  extends Omit<ITransparentOutput, 'selected_as_input'>,
-    IShieldedOutputProofs {
-  type: 'shielded';
-  blindingFactor?: string; // hex, 32 bytes — value blinding factor (populated after decryption)
-  assetBlindingFactor?: string; // hex, 32 bytes — asset blinding factor (FullShielded only)
-  // The fullnode-canonical absolute output index (`transparentCount + s_index`).
-  // Recorded when the wallet decodes a shielded output and appends it to
-  // `tx.outputs[]` (see `utils/storage.ts:processSingleTxUtil`). Older cached
-  // history entries written before this field existed don't carry it; readers
-  // must recover the index by matching `commitment` back to its position in
-  // `tx.shielded_outputs[]` and adding the transparent count.
-  onChainIndex?: number;
-}
-
-export type IHistoryOutput = ITransparentOutput | IShieldedOutputEntry;
+// SEPARATED model: `outputs[]` is transparent-only as a POST-NORMALIZE
+// internal invariant. Shielded outputs live in their own on-chain-ordered
+// `shielded_outputs[]` list (see `IHistoryShieldedOutput`); the on-chain
+// absolute index of `shielded_outputs[s]` is `outputs.length + s`. Resolve
+// "what does an input spend" via `resolveSpentOutput` (utils/transaction.ts),
+// never positional `outputs[idx]` for an idx that may be ≥ outputs.length.
+export type IHistoryOutput = ITransparentOutput;
 
 export interface IDataOutputData {
   type: 'data';

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ import Header from './headers/base';
 import type {
   IShieldedCryptoProvider,
   IShieldedOutput,
+  IShieldedOutputProofs,
   IDataShieldedOutput,
 } from './shielded/types';
 
@@ -340,24 +341,20 @@ export interface ITransparentOutput {
 }
 
 /**
- * Shielded output entry as it appears in tx.outputs after decryption.
- * Before decryption (from fullnode), value/token/decoded are absent.
- * After decryption (by processNewTx), they are populated so the output
- * can be processed uniformly with transparent outputs.
+ * Shielded output entry as it appears in tx.outputs after decryption, so the
+ * output can be processed uniformly with transparent outputs.
+ *
+ * It reuses the standard output fields from `ITransparentOutput` (value,
+ * token_data, script, decoded, token, spent_by) and the on-chain confidential
+ * fields from `IShieldedOutputProofs` (commitment, range_proof,
+ * ephemeral_pubkey, asset_commitment?, surjection_proof?) so neither set is
+ * re-declared here. It adds only the `'shielded'` discriminant and the
+ * wallet-local results produced by decryption.
  */
-export interface IShieldedOutputEntry {
+export interface IShieldedOutputEntry
+  extends Omit<ITransparentOutput, 'selected_as_input'>,
+    IShieldedOutputProofs {
   type: 'shielded';
-  value: OutputValueType;
-  token_data: number;
-  script: string;
-  decoded: IHistoryOutputDecoded;
-  token: string;
-  spent_by: string | null;
-  commitment: string;
-  range_proof: string;
-  ephemeral_pubkey: string;
-  asset_commitment?: string;
-  surjection_proof?: string;
   blindingFactor?: string; // hex, 32 bytes — value blinding factor (populated after decryption)
   assetBlindingFactor?: string; // hex, 32 bytes — asset blinding factor (FullShielded only)
   // The fullnode-canonical absolute output index (`transparentCount + s_index`).

--- a/src/types.ts
+++ b/src/types.ts
@@ -746,6 +746,10 @@ export interface IStorage {
   // Shielded (confidential transaction) crypto provider
   shieldedCryptoProvider?: IShieldedCryptoProvider;
   setShieldedCryptoProvider(provider?: IShieldedCryptoProvider): void;
+  // Get the provider, or throw if it has not been configured. Confidential
+  // code paths require it; a missing provider is a setup error, not a
+  // condition to silently default around.
+  getShieldedCryptoProvider(): IShieldedCryptoProvider;
 
   setApiVersion(version: ApiVersion): void;
   getDecimalPlaces(): number;

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -12,11 +12,11 @@ export const isHexa = (value: string): boolean => {
 /**
  * Return a hex-encoded copy of a string that may be either hex or base64.
  *
- * Confidential shielded-output fields (commitment / range_proof / script /
- * ephemeral_pubkey / asset_commitment / surjection_proof) arrive hex over the
- * HTTP tx API but base64 over the websocket real-time path. Downstream
- * decryption does `Buffer.from(value, 'hex')`, so base64 must be normalized to
- * hex first.
+ * The fullnode serializes a shielded output's confidential fields with a fixed
+ * per-field encoding (`_shielded_output_to_json`): commitment / ephemeral_pubkey
+ * / asset_commitment as hex, and range_proof / script / surjection_proof as
+ * base64. So base64 is the only non-hex form we can receive. Downstream
+ * decryption does `Buffer.from(value, 'hex')`, so we normalize to hex first.
  *
  * Detection is character-set based: a string matching only [0-9a-fA-F] is taken
  * as already-hex and returned unchanged — so this is idempotent on hex (and on

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -4,9 +4,30 @@ import { OutputValueType } from '../types';
 import { MAX_OUTPUT_VALUE, MAX_OUTPUT_VALUE_32 } from '../constants';
 import { prettyValue } from './numbers';
 
-const isHexa = (value: string): boolean => {
+export const isHexa = (value: string): boolean => {
   // test if value is string?
   return /^[0-9a-fA-F]*$/.test(value);
+};
+
+/**
+ * Return a hex-encoded copy of a string that may be either hex or base64.
+ *
+ * Confidential shielded-output fields (commitment / range_proof / script /
+ * ephemeral_pubkey / asset_commitment / surjection_proof) arrive hex over the
+ * HTTP tx API but base64 over the websocket real-time path. Downstream
+ * decryption does `Buffer.from(value, 'hex')`, so base64 must be normalized to
+ * hex first.
+ *
+ * Detection is character-set based: a string matching only [0-9a-fA-F] is taken
+ * as already-hex and returned unchanged — so this is idempotent on hex (and on
+ * the empty string). Anything containing a non-hex character (e.g. '+', '/',
+ * '=', or letters g-z/G-Z) is treated as base64, decoded, and re-encoded as hex.
+ */
+export const ensureHex = (value: string): string => {
+  if (isHexa(value)) {
+    return value;
+  }
+  return Buffer.from(value, 'base64').toString('hex');
 };
 
 /**

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -434,11 +434,21 @@ export async function processSingleTx(
       continue;
     }
 
-    if (origTx.outputs.length <= input.index) {
+    // SEPARATED model: `input.index` is an absolute on-chain index spanning the
+    // transparent outputs then the shielded outputs, so resolve it via the
+    // arithmetic resolver rather than a positional `outputs[index]` read — which
+    // would wrongly reject (or misread) a shielded input whose index is
+    // >= outputs.length.
+    const resolved = transactionUtils.resolveSpentOutput(origTx, input.index);
+    if (!resolved) {
       throw new Error('Spending an unexistent output');
     }
-
-    const output = origTx.outputs[input.index];
+    if (resolved.kind !== 'transparent') {
+      // A shielded input's UTXO lifecycle is handled by the receive pipeline;
+      // this transparent-spend loop has nothing to delete for it.
+      continue;
+    }
+    const { output } = resolved;
     if (!output.decoded.address) {
       // Tx is ours but output is not from an address.
       continue;
@@ -941,7 +951,12 @@ export async function processUtxoUnlock(
   const { store } = storage;
 
   const { tx } = lockedUtxo;
-  const output = tx.outputs[lockedUtxo.index];
+  // SEPARATED model: resolve via the arithmetic resolver, not a positional
+  // `outputs[index]` read (out of range for a shielded index). A shielded locked
+  // UTXO is handled by the receive pipeline, so there's nothing to unlock here.
+  const resolved = transactionUtils.resolveSpentOutput(tx, lockedUtxo.index);
+  if (!resolved || resolved.kind !== 'transparent') return;
+  const { output } = resolved;
   // Skip data outputs since they do not have an address and do not "belong" in a wallet
   // This shouldn't happen, but we check it just in case
   if (!output.decoded.address) return;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -780,6 +780,18 @@ export async function processNewTx(
   }
 
   for (const input of tx.inputs) {
+    // Inputs spending shielded outputs carry no transparent fields
+    // (value/token/decoded are hidden in commitments). Their balance
+    // handling lands with the receive pipeline in the next PR; here we
+    // only need the type-level guard so transparent processing narrows.
+    if (
+      input.value === undefined ||
+      input.token === undefined ||
+      input.token_data === undefined ||
+      input.decoded === undefined
+    ) {
+      continue;
+    }
     // We ignore data inputs since they do not have an address
     if (!input.decoded.address) continue;
 
@@ -787,7 +799,9 @@ export async function processNewTx(
     // This is not our address, ignore
     if (!addressInfo) continue;
 
-    const isAuthority: boolean = transactionUtils.isAuthorityOutput(input);
+    const isAuthority: boolean = transactionUtils.isAuthorityOutput({
+      token_data: input.token_data,
+    });
     let addressMeta = await store.getAddressMeta(input.decoded.address);
     let tokenMeta = await store.getTokenMeta(input.token);
 
@@ -813,11 +827,11 @@ export async function processNewTx(
     txAddresses.add(input.decoded.address);
 
     if (isAuthority) {
-      if (transactionUtils.isMint(input)) {
+      if (transactionUtils.isMint({ value: input.value, token_data: input.token_data })) {
         tokenMeta.balance.authorities.mint.unlocked -= 1n;
         addressMeta.balance.get(input.token)!.authorities.mint.unlocked -= 1n;
       }
-      if (transactionUtils.isMelt(input)) {
+      if (transactionUtils.isMelt({ value: input.value, token_data: input.token_data })) {
         tokenMeta.balance.authorities.melt.unlocked -= 1n;
         addressMeta.balance.get(input.token)!.authorities.melt.unlocked -= 1n;
       }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -45,7 +45,7 @@ import {
   IDataTx,
   isDataOutputCreateToken,
   IHistoryOutput,
-  IShieldedOutputEntry,
+  ITransparentOutput,
   IUtxoId,
   IInputSignature,
   ITxSignatureData,
@@ -83,15 +83,20 @@ const transaction = {
   },
 
   /**
-   * Check if an output entry from IHistoryTx.outputs is a shielded output appended
-   * by the fullnode's to_json_extended(). These entries have type='shielded' and lack
-   * the 'value' and 'token' fields that transparent outputs have.
-   * Shielded outputs are processed separately via processShieldedOutputs().
+   * Detect a shielded output delivered INLINE in `tx.outputs[]` on the wire.
+   *
+   * In the SEPARATED model `outputs[]` is transparent-only once normalized,
+   * but the fullnode/WS can still deliver shielded outputs nested inside
+   * `outputs[]` with `type: 'shielded'` (the legacy wire form, v3-compat).
+   * `normalizeShieldedOutputs` case-(a), `convertFullNodeTxToHistoryTx`, and
+   * `walletServiceStorageProxy` use this to detect and extract them. Returns a
+   * plain boolean; callers that need to read the inline wire fields cast the
+   * entry themselves.
    */
-  isShieldedOutputEntry(
+  isInlineShieldedWireEntry(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     output: IHistoryOutput | Record<string, any>
-  ): output is IShieldedOutputEntry {
+  ): boolean {
     return output != null && (output as { type?: string }).type === 'shielded';
   },
 
@@ -109,51 +114,46 @@ const transaction = {
   },
 
   /**
-   * Look up the on-chain output of a parent tx that is spent by an input
-   * with absolute on-chain index `inputIndex`.
+   * Resolve the on-chain output of a parent tx that an input with absolute
+   * on-chain index `idx` spends, using the SEPARATED / arithmetic model that
+   * mirrors hathor-core (`base_transaction.py:347-363`).
    *
-   * Sparse-decode handling: when the wallet decodes only some of a parent
-   * tx's shielded outputs (the rest belong to other wallets and can't be
-   * decrypted), the decoded entries are appended to `parentTx.outputs[]`
-   * and their position in that array does NOT necessarily match their
-   * on-chain absolute index. Each decoded entry carries the true on-chain
-   * index in `onChainIndex`. Callers that need to resolve "what does this
-   * input spend" must NOT do `parentTx.outputs[inputIndex]` positionally
-   * for those entries — they'd get a different output, with a different
-   * value/token/address, leading to:
-   *   - wrong token-meta debit (per-tx balance off by an input's value)
-   *   - wrong UTXO deletion key (spent UTXO leaks in storage)
-   *   - signing with the wrong spend key (fullnode rejects with
-   *     "Failed to verify if elements are equal")
+   * The parent has `T = outputs.length` transparent outputs followed by
+   * `S = shielded_outputs.length` shielded outputs. The on-chain absolute
+   * index of `shielded_outputs[s]` is `T + s`. Resolution is pure arithmetic
+   * — NO scan, NO commitment-match, NO `onChainIndex`:
+   *   - `idx in [0, T)`     → `{ kind: 'transparent', output }`
+   *   - `idx in [T, T + S)` → `{ kind: 'shielded', sIndex: idx - T, output }`
+   *       for EVERY slot regardless of decoded state. A non-owned slot
+   *       (`output.value === undefined`) still resolves to a valid `shielded`
+   *       result; callers gate ownership off `value !== undefined`, not off
+   *       resolver kind.
+   *   - otherwise (`idx >= T + S` or `idx < 0`) → `undefined`
    *
-   * This helper first looks for any shielded entry whose recorded
-   * `onChainIndex` equals `inputIndex` — that's the genuine spent output.
-   * When no shielded entry claims that index, the input must reference a
-   * transparent output of the parent (transparent outputs occupy their
-   * on-chain positions exactly), so positional `outputs[inputIndex]` is
-   * correct and used as a fallback. Returns `undefined` when no output
-   * matches (e.g. the parent has fewer outputs than the input claims to
-   * spend, or the parent has shielded outputs but none claim this index
-   * and there's no transparent at this position either).
+   * The full `shielded_outputs[]` list MUST be present (owned + non-owned) for
+   * the arithmetic to land on the right slot — a partial list would shift
+   * `idx - T` onto the wrong entry.
    */
-  findSpentOutput(parentTx: IHistoryTx, inputIndex: number): IHistoryOutput | undefined {
+  resolveSpentOutput(
+    parentTx: IHistoryTx,
+    idx: number
+  ):
+    | { kind: 'transparent'; output: ITransparentOutput }
+    | { kind: 'shielded'; sIndex: number; output: IHistoryShieldedOutput }
+    | undefined {
     const outputs = parentTx.outputs ?? [];
-    // Prefer a shielded entry whose recorded on-chain index matches.
-    const shieldedMatch = outputs.find(
-      o =>
-        this.isShieldedOutputEntry(o) &&
-        (o as IShieldedOutputEntry & { onChainIndex?: number }).onChainIndex === inputIndex
-    );
-    if (shieldedMatch) return shieldedMatch;
-    if (inputIndex < 0 || inputIndex >= outputs.length) return undefined;
-    const positional = outputs[inputIndex];
-    // Positional fallback is only valid for transparent outputs. If the
-    // entry at the requested position is a shielded entry but no shielded
-    // entry has a matching onChainIndex, the input refers to a shielded
-    // slot the wallet doesn't have locally — returning the positional
-    // shielded entry would silently substitute the wrong output.
-    if (this.isShieldedOutputEntry(positional)) return undefined;
-    return positional;
+    const shieldedOutputs = parentTx.shielded_outputs ?? [];
+    const T = outputs.length;
+    const S = shieldedOutputs.length;
+    if (idx < 0) return undefined;
+    if (idx < T) {
+      return { kind: 'transparent', output: outputs[idx] };
+    }
+    if (idx < T + S) {
+      const sIndex = idx - T;
+      return { kind: 'shielded', sIndex, output: shieldedOutputs[sIndex] };
+    }
+    return undefined;
   },
 
   /**
@@ -188,29 +188,39 @@ const transaction = {
       const shieldedEntries: IHistoryShieldedOutput[] = [];
       const transparentOutputs: IHistoryOutput[] = [];
       for (const output of tx.outputs) {
-        if (this.isShieldedOutputEntry(output)) {
+        if (this.isInlineShieldedWireEntry(output)) {
+          // The inline wire entry carries the on-chain confidential fields,
+          // which are not part of `ITransparentOutput`; cast to read them.
+          const wire = output as unknown as IHistoryShieldedOutput;
           shieldedEntries.push({
-            mode: output.asset_commitment
+            mode: wire.asset_commitment
               ? ShieldedOutputMode.FULLY_SHIELDED
               : ShieldedOutputMode.AMOUNT_SHIELDED,
-            commitment: this.ensureHex(output.commitment),
-            range_proof: this.ensureHex(output.range_proof),
-            script: this.ensureHex(output.script),
-            token_data: output.token_data,
-            ephemeral_pubkey: this.ensureHex(output.ephemeral_pubkey),
-            decoded: output.decoded,
-            asset_commitment: output.asset_commitment
-              ? this.ensureHex(output.asset_commitment)
+            commitment: this.ensureHex(wire.commitment),
+            range_proof: this.ensureHex(wire.range_proof),
+            script: this.ensureHex(wire.script),
+            token_data: wire.token_data,
+            ephemeral_pubkey: this.ensureHex(wire.ephemeral_pubkey),
+            decoded: wire.decoded,
+            asset_commitment: wire.asset_commitment
+              ? this.ensureHex(wire.asset_commitment)
               : undefined,
-            surjection_proof: output.surjection_proof
-              ? this.ensureHex(output.surjection_proof)
+            surjection_proof: wire.surjection_proof
+              ? this.ensureHex(wire.surjection_proof)
               : undefined,
             // hathor-core's `_shielded_output_to_json` (base_transaction.py)
             // sets spent_by on shielded entries the same way it does for
             // transparent outputs. Preserve it through the normalize so the
             // wallet can use the canonical `output.spent_by !== null` check
             // for both kinds of outputs.
-            spent_by: output.spent_by ?? null,
+            spent_by: wire.spent_by ?? null,
+            // Preserve any owned-marker fields already present on the inline
+            // wire entry (e.g. a re-delivered tx the wallet had decrypted).
+            // Stripping these would wipe owned data on every re-add.
+            value: wire.value,
+            token: wire.token,
+            blindingFactor: wire.blindingFactor,
+            assetBlindingFactor: wire.assetBlindingFactor,
           });
         } else {
           transparentOutputs.push(output);
@@ -383,15 +393,28 @@ const transaction = {
         continue;
       }
 
-      // Resolve the spent output via the sparse-decode-aware helper. A
+      // Resolve the spent output via the SEPARATED-model resolver. A
       // positional `spentTx.outputs[input.index]` would return the wrong
-      // entry on a sparse-decoded parent and the signature would be
-      // computed for the wrong pubkey, failing OP_EQUALVERIFY at the
-      // fullnode with "Failed to verify if elements are equal".
-      let spentOut:
-        | { decoded?: { address?: string }; script?: string; value?: bigint }
-        | undefined = this.findSpentOutput(spentTx, input.index);
-      if (!spentOut) {
+      // entry for a shielded input (whose on-chain index is ≥ outputs.length)
+      // and the signature would be computed for the wrong pubkey, failing
+      // OP_EQUALVERIFY at the fullnode with "Failed to verify if elements are
+      // equal".
+      const resolved = this.resolveSpentOutput(spentTx, input.index);
+      let spentOut: { decoded?: { address?: string }; value?: bigint } | undefined =
+        resolved?.output;
+      // Fall back to the stored UTXO when the resolved output can't provide a
+      // wallet address: either the parent isn't in storage (resolved ===
+      // undefined) or it resolved to a shielded slot the wallet hasn't decoded
+      // (value undefined and no decoded.address). Keying off the address here
+      // — not the resolver kind — preserves signing of owned shielded inputs
+      // whose parent carries the decoded entry, while still recovering owned
+      // inputs whose parent slot is undecoded but whose UTXO is in storage.
+      const needsUtxoFallback =
+        resolved === undefined ||
+        (resolved.kind === 'shielded' &&
+          resolved.output.value === undefined &&
+          !resolved.output.decoded?.address);
+      if (needsUtxoFallback) {
         const utxo = await storage.getUtxo({ txId: input.hash, index: input.index });
         if (!utxo) {
           // Truly unknown — caller will surface this as an error elsewhere.
@@ -399,7 +422,7 @@ const transaction = {
         }
         spentOut = { decoded: { address: utxo.address }, value: utxo.value };
       }
-      if (!spentOut.decoded?.address) {
+      if (!spentOut?.decoded?.address) {
         // This is not a wallet output
         continue;
       }
@@ -655,6 +678,51 @@ const transaction = {
       }
     }
 
+    // CREDIT loop over shielded outputs (SEPARATED model). Owned shielded
+    // outputs live in tx.shielded_outputs[] with their value/token decrypted
+    // IN PLACE; the single ownership gate is `value !== undefined`. Without
+    // this loop an owned shielded RECEIVE would credit 0 in getTxHistory /
+    // getTxById. Mirrors the transparent loop's authority/lock/value handling.
+    for (const so of tx.shielded_outputs ?? []) {
+      if (so.value === undefined) {
+        // Non-owned (or not-yet-decrypted) slot — excluded by the gate.
+        continue;
+      }
+      const { address } = so.decoded;
+      if (!(address && (await storage.isAddressMine(address)))) {
+        continue;
+      }
+      const token = so.token ?? NATIVE_TOKEN_UID;
+      if (!balance[token]) {
+        balance[token] = getEmptyBalance();
+      }
+      const isLocked = this.isOutputLocked(so, { refTs: nowTs }) || isHeightLocked;
+
+      // token_data on a shielded output may be undefined (FullShielded hides
+      // the token); default to 0 so the authority check reads as funds.
+      const soForAuthority = { token_data: so.token_data ?? 0, value: so.value };
+      if (this.isAuthorityOutput(soForAuthority)) {
+        if (this.isMint(soForAuthority)) {
+          if (isLocked) {
+            balance[token].authorities.mint.locked += 1n;
+          } else {
+            balance[token].authorities.mint.unlocked += 1n;
+          }
+        }
+        if (this.isMelt(soForAuthority)) {
+          if (isLocked) {
+            balance[token].authorities.melt.locked += 1n;
+          } else {
+            balance[token].authorities.melt.unlocked += 1n;
+          }
+        }
+      } else if (isLocked) {
+        balance[token].tokens.locked += so.value;
+      } else {
+        balance[token].tokens.unlocked += so.value;
+      }
+    }
+
     for (const input of tx.inputs) {
       // Shielded inputs arrive without decoded/value/token (hidden in the
       // commitment on-chain). Recover those fields from the stored origTx's
@@ -677,37 +745,36 @@ const transaction = {
           inputTokenData = 0;
         } else {
           // Fallback: the UTXO has already been deleted (processNewTx deletes
-          // the spent shielded UTXO right after enriching the input). Look up
-          // the parent tx's decoded shielded outputs and match by absolute
-          // on-chain index. Without this fallback, a tx that spent a
-          // wallet-owned shielded UTXO whose enriched inputs weren't
-          // persisted reads back as `{tx_id, index}`-only here, the input
-          // gets silently skipped, and the per-tx delta credits outputs
-          // (change) without debiting the input — showing e.g. +8.5M on a
-          // tx that actually sent 500K.
+          // the spent shielded UTXO right after enriching the input). Resolve
+          // the parent tx's spent output by its absolute on-chain index via
+          // the SEPARATED-model resolver and read value/token/decoded off the
+          // shielded entry. Without this fallback, a tx that spent a
+          // wallet-owned shielded UTXO whose enriched inputs weren't persisted
+          // reads back as `{tx_id, index}`-only here, the input gets silently
+          // skipped, and the per-tx delta credits outputs (change) without
+          // debiting the input — showing e.g. +8.5M on a tx that actually
+          // sent 500K. Never "skip if UTXO missing".
           const parentTx = await storage.getTx(input.tx_id);
           if (!parentTx) continue;
-          const decoded = (parentTx.outputs ?? []).find(
-            o =>
-              this.isShieldedOutputEntry(o) &&
-              ((o as IShieldedOutputEntry & { onChainIndex?: number }).onChainIndex ===
-                input.index ||
-                // Older entries written before onChainIndex existed: fall back
-                // to matching directly by array position. Safe when the parent
-                // tx has been decoded with full coverage (one decoded entry
-                // per shielded output), and a no-op otherwise.
-                parentTx.outputs.indexOf(o) === input.index)
-          ) as IShieldedOutputEntry | undefined;
-          if (!decoded?.decoded?.address) continue;
+          const resolved = this.resolveSpentOutput(parentTx, input.index);
+          if (!resolved || resolved.kind !== 'shielded') continue;
+          const decoded = resolved.output;
+          // Owned-marker gate: a non-owned slot has value === undefined.
+          if (decoded.value === undefined) continue;
+          if (!decoded.decoded?.address) continue;
           if (!(await storage.isAddressMine(decoded.decoded.address))) continue;
           address = decoded.decoded.address;
-          inputToken = decoded.token;
+          inputToken = decoded.token ?? NATIVE_TOKEN_UID;
           inputValue = decoded.value;
           inputTokenData = decoded.token_data ?? 0;
         }
       }
 
       if (!(address && (await storage.isAddressMine(address)))) {
+        continue;
+      }
+      if (inputToken === undefined) {
+        // Defensive: a wallet-owned input must carry a token by this point.
         continue;
       }
       if (!balance[inputToken]) {
@@ -1134,7 +1201,13 @@ const transaction = {
                   return reject(new Error(response.message ?? ''));
                 }
 
-                if (input.index >= response.tx.outputs.length) {
+                // SEPARATED model: the on-chain index space spans transparent
+                // outputs followed by shielded outputs, so the bound is the
+                // sum of both arrays. Using outputs.length alone rejects every
+                // shielded spend whose parent isn't in storage.
+                const shieldedCount =
+                  (response.tx as { shielded_outputs?: unknown[] }).shielded_outputs?.length ?? 0;
+                if (input.index >= response.tx.outputs.length + shieldedCount) {
                   return reject(new Error('Index outside of tx output array bounds'));
                 }
                 return resolve(this.convertFullNodeTxToHistoryTx(response));
@@ -1152,78 +1225,52 @@ const transaction = {
         }
       }
 
-      // Detect whether the input references a shielded slot of the parent.
-      // The on-chain absolute index for a shielded output is
-      // `transparent_count + shielded_array_idx`, which may or may not equal
-      // its position in the wallet's stored `spentTx.outputs[]` (sparse
-      // decode shifts decoded entries DOWN when the wallet doesn't own
-      // every shielded output of the parent). Two cases produce a shielded
-      // slot:
-      //   (a) input.index >= spentTx.outputs.length — index is past the
-      //       wallet's stored entries (full-decode of fewer outputs than
-      //       actually exist on-chain).
-      //   (b) input.index < spentTx.outputs.length AND some shielded entry
-      //       claims this on-chain index (the sparse-decode case where the
-      //       wallet's outputs[] has room at this position but positional
-      //       lookup returns the wrong entry).
-      // In both cases, build the input from the saved UTXO (which carries
-      // the correct on-chain `index`, address, value, and token) so we sign
-      // with the right spend key and the fullnode resolves to the right
-      // output.
-      // A shielded slot is one where (a) input.index points past the
-      // wallet's stored outputs (full-decode of fewer than the on-chain
-      // count) OR (b) some decoded shielded entry's onChainIndex equals
-      // input.index (sparse-decode within the wallet's range). The helper
-      // returns the decoded shielded entry in case (b), so we use its
-      // result to detect both cases.
-      const resolvedSpent = this.findSpentOutput(spentTx, input.index);
-      const shieldedEntry =
-        resolvedSpent !== undefined && this.isShieldedOutputEntry(resolvedSpent)
-          ? (resolvedSpent as IShieldedOutputEntry)
-          : null;
-      const isShieldedSlot = shieldedEntry !== null || input.index >= spentTx.outputs.length;
+      // Resolve the parent's spent output by its absolute on-chain index via
+      // the SEPARATED-model resolver. A `kind === 'shielded'` result means the
+      // input spends a shielded slot (on-chain index ≥ outputs.length); we
+      // stamp `type: 'shielded'` so the rest of wallet-lib (e.g.
+      // `getShieldedUnblindingForTx`, the WS-driven tx-history view, the
+      // signing key chain selection) routes this input through the shielded
+      // code paths.
+      const resolvedSpent = this.resolveSpentOutput(spentTx, input.index);
 
-      if (isShieldedSlot) {
-        // The `type: 'shielded'` discriminator is required so the rest of
-        // wallet-lib (e.g. `getShieldedUnblindingForTx`, the WS-driven
-        // tx-history view, the signing key chain selection) routes this
-        // input through the shielded code paths.
-        if (shieldedEntry !== null) {
-          // Sparse-decode hit: the wallet's stored parent tx already
-          // carries a decoded shielded entry for this slot. Read
-          // value/token/decoded/script straight off that entry instead
-          // of touching the UTXO record — the entry survives the
-          // WebSocket-driven `processNewTx` UTXO deletion that races
-          // with this fire-and-forget local-insert call. Headless
-          // wallets pointed at a local fullnode hit that race almost
-          // every time (WS re-delivery wins, UTXO is gone before this
-          // function reaches its lookup) and the old code threw
-          // "no stored UTXO recovery for tx_id=…" on every send.
-          inputs.push({
-            type: 'shielded',
-            tx_id: input.hash,
-            index: input.index,
-            script: shieldedEntry.script ?? '',
-            decoded: shieldedEntry.decoded ?? {},
-            token_data: shieldedEntry.token_data ?? 0,
-            token: shieldedEntry.token ?? NATIVE_TOKEN_UID,
-            value: shieldedEntry.value,
-          });
-          continue;
-        }
+      if (resolvedSpent?.kind === 'shielded' && resolvedSpent.output.value !== undefined) {
+        // The wallet's stored parent tx carries a decoded shielded entry for
+        // this slot. Read value/token/decoded/script straight off that entry
+        // instead of touching the UTXO record — the entry survives the
+        // WebSocket-driven `processNewTx` UTXO deletion that races with this
+        // fire-and-forget local-insert call. Headless wallets pointed at a
+        // local fullnode hit that race almost every time (WS re-delivery wins,
+        // UTXO is gone before this function reaches its lookup).
+        const shieldedEntry = resolvedSpent.output;
+        inputs.push({
+          type: 'shielded',
+          tx_id: input.hash,
+          index: input.index,
+          script: shieldedEntry.script ?? '',
+          decoded: shieldedEntry.decoded ?? {},
+          token_data: shieldedEntry.token_data ?? 0,
+          token: shieldedEntry.token ?? NATIVE_TOKEN_UID,
+          value: shieldedEntry.value,
+        });
+        continue;
+      }
 
-        // Full-decode mismatch (input.index ≥ spentTx.outputs.length):
-        // the wallet decoded fewer outputs than the parent has on-chain
-        // and this input references one of the missing slots. The only
-        // local source of truth is the UTXO record (saved at
-        // processNewTx time but never appended to outputs[]). Fall back
-        // to it. If both records are missing the wallet truly cannot
-        // reconstruct the input — that's a real error worth surfacing.
+      if (
+        (resolvedSpent === undefined && input.index >= spentTx.outputs.length) ||
+        resolvedSpent?.kind === 'shielded'
+      ) {
+        // The input references a shielded slot the wallet hasn't decoded into
+        // shielded_outputs[] (or the parent's shielded list is incomplete in
+        // storage). The only local source of truth is the UTXO record (saved
+        // at processNewTx time). Fall back to it. If it's also missing the
+        // wallet truly cannot reconstruct the input — a real error.
         const utxo = await storage.getUtxo({ txId: input.hash, index: input.index });
         if (!utxo) {
           throw new Error(
             `Input ${input.hash}:${input.index} references a shielded slot the wallet ` +
-              `has neither decoded into outputs[] (length ${spentTx.outputs.length}) ` +
+              `has neither decoded into shielded_outputs[] ` +
+              `(length ${spentTx.shielded_outputs?.length ?? 0}) ` +
               `nor stored as a UTXO record — cannot reconstruct the sender-local insert.`
           );
         }
@@ -1240,13 +1287,9 @@ const transaction = {
         continue;
       }
 
-      // Non-shielded slot: `resolvedSpent` is already the transparent
-      // output (helper returns undefined or transparent — never a
-      // shielded entry without onChainIndex match — by design).
-      const spentOut = resolvedSpent!;
-      const isShieldedSpend = false;
+      // Transparent slot: resolvedSpent is the transparent output.
+      const spentOut = resolvedSpent!.output as ITransparentOutput;
       inputs.push({
-        ...(isShieldedSpend ? { type: 'shielded' } : {}),
         tx_id: input.hash,
         index: input.index,
         script: spentOut.script,
@@ -1533,15 +1576,15 @@ const transaction = {
       // This is not our utxo, so we cannot spend it.
       return false;
     }
-    // Sparse-decode-aware lookup. Positional outputs[utxo.index] would
-    // return the wrong entry on a parent whose shielded outputs were only
-    // partially decoded, and `isOutputLocked` would check the wrong
-    // entry's timelock.
-    const output = this.findSpentOutput(tx, utxo.index);
-    if (!output) {
+    // SEPARATED-model lookup. A shielded UTXO has on-chain index
+    // outputs.length + s, so a positional `tx.outputs[utxo.index]` would read
+    // the wrong (or no) entry; resolve arithmetically and read the timelock
+    // off the resolved output (transparent or shielded — both carry decoded).
+    const resolved = this.resolveSpentOutput(tx, utxo.index);
+    if (!resolved) {
       return false;
     }
-    const isTimelocked = this.isOutputLocked(output, { refTs: nowTs });
+    const isTimelocked = this.isOutputLocked(resolved.output, { refTs: nowTs });
     const isHeightLocked = this.isHeightLocked(tx.height, currentHeight, rewardLock);
     const isSelectedAsInput = await storage.isUtxoSelectedAsInput(utxo);
 
@@ -1628,12 +1671,60 @@ const transaction = {
       const hydratedInput = this.hydrateIOWithToken(i as { token_data: number }, tx.tokens);
       return hydratedInput as IHistoryInput;
     });
-    const outputs: IHistoryOutput[] = tx.outputs.map(o => {
-      // Shielded outputs already have token populated after decryption
-      if (this.isShieldedOutputEntry(o)) return o;
-      const hydratedoutput = this.hydrateIOWithToken(o, tx.tokens);
-      return hydratedoutput as IHistoryOutput;
-    });
+
+    // SEPARATED model: `outputs[]` is transparent-only. The fullnode/WS may
+    // still deliver shielded outputs INLINE inside `outputs[]` (legacy wire
+    // form) and/or in a dedicated `shielded_outputs[]` field. Partition the
+    // wire outputs so transparent ones are hydrated into `outputs[]` while
+    // inline shielded ones are collected for `shielded_outputs[]`, then merge
+    // with any separately delivered list (in on-chain order: inline entries
+    // occupy the positions they had within outputs[]).
+    const outputs: IHistoryOutput[] = [];
+    const inlineShielded: IHistoryShieldedOutput[] = [];
+    for (const o of tx.outputs) {
+      if (this.isInlineShieldedWireEntry(o)) {
+        const wire = o as unknown as IHistoryShieldedOutput;
+        inlineShielded.push({
+          mode: wire.asset_commitment
+            ? ShieldedOutputMode.FULLY_SHIELDED
+            : ShieldedOutputMode.AMOUNT_SHIELDED,
+          commitment: this.ensureHex(wire.commitment),
+          range_proof: this.ensureHex(wire.range_proof),
+          script: this.ensureHex(wire.script),
+          token_data: wire.token_data,
+          ephemeral_pubkey: this.ensureHex(wire.ephemeral_pubkey),
+          decoded: wire.decoded,
+          asset_commitment: wire.asset_commitment
+            ? this.ensureHex(wire.asset_commitment)
+            : undefined,
+          surjection_proof: wire.surjection_proof
+            ? this.ensureHex(wire.surjection_proof)
+            : undefined,
+          spent_by: wire.spent_by ?? null,
+        });
+        continue;
+      }
+      outputs.push(this.hydrateIOWithToken(o, tx.tokens) as IHistoryOutput);
+    }
+
+    // A separately delivered shielded_outputs[] field (passthrough — not in
+    // the zod schema). Convert base64 fields to hex per entry.
+    const separateShielded = (tx as { shielded_outputs?: IHistoryShieldedOutput[] })
+      .shielded_outputs;
+    const shieldedOutputs: IHistoryShieldedOutput[] = [
+      ...inlineShielded,
+      ...(separateShielded ?? []).map(so => ({
+        ...so,
+        commitment: this.ensureHex(so.commitment),
+        range_proof: this.ensureHex(so.range_proof),
+        script: this.ensureHex(so.script),
+        ephemeral_pubkey: this.ensureHex(so.ephemeral_pubkey),
+        asset_commitment: so.asset_commitment ? this.ensureHex(so.asset_commitment) : undefined,
+        surjection_proof: so.surjection_proof ? this.ensureHex(so.surjection_proof) : undefined,
+        spent_by: so.spent_by ?? null,
+      })),
+    ];
+
     const histTx: IHistoryTx = {
       tx_id: tx.hash,
       signalBits: tx.signal_bits,
@@ -1650,6 +1741,7 @@ const transaction = {
       tokens: tx.tokens.map(token => token.uid),
       height: meta.height,
       first_block: meta.first_block,
+      ...(shieldedOutputs.length > 0 ? { shielded_outputs: shieldedOutputs } : {}),
     };
 
     if (tx.nc_id) histTx.nc_id = tx.nc_id;

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -611,15 +611,19 @@ const transaction = {
       if (!address || inputToken === undefined || inputValue === undefined) {
         const spentTx = await storage.getTx(input.tx_id);
         const resolved = spentTx ? this.resolveSpentOutput(spentTx, input.index) : undefined;
-        // Owned-marker gate: only a decrypted shielded slot (value defined) is
-        // a wallet spend we can debit; a non-owned/undecoded slot has value
-        // === undefined.
+        // We can only debit inputs the wallet OWNS. This block runs only for
+        // "bare" inputs (no inline value/token), which the fullnode emits only
+        // for shielded inputs. Anything that isn't an owned, decrypted shielded
+        // slot — a non-shielded resolve, or a shielded slot we never decrypted
+        // (value === undefined) — is not ours, so skip it.
         if (resolved?.kind !== 'shielded' || resolved.output.value === undefined) {
           continue;
         }
         const so = resolved.output;
         address = so.decoded?.address;
-        inputToken = so.token ?? NATIVE_TOKEN_UID;
+        // Token comes from the decrypted slot (an owned slot always carries it).
+        // No NATIVE_TOKEN_UID fallback — that would mislabel a custom token as HTR.
+        inputToken = so.token;
         inputValue = so.value;
         inputTokenData = so.token_data ?? 0;
       }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1229,15 +1229,18 @@ const transaction = {
       ...options,
     };
 
-    // Full-unshield detection for tx paths that don't go through
+    // Attach an UnshieldBalanceHeader for a "full unshield" — a tx that spends
+    // shielded inputs but produces NO shielded outputs — on paths that bypass
     // SendTransaction.prepareTxData (notably `createNewToken` /
-    // `prepareCreateNewToken`, which build txData directly via tokens.ts).
-    // If the inputs include shielded UTXOs and the tx has no shielded
-    // outputs, we must attach an UnshieldBalanceHeader carrying the excess
-    // blinding factor so the fullnode's Pedersen balance check holds — same
-    // logic SendTransaction already runs for the send path. Skip if txData
-    // already carries excess (set upstream) or if there are shielded outputs
-    // (mutually exclusive with the header).
+    // `prepareCreateNewToken`, which build txData directly via tokens.ts). The
+    // header carries the excess blinding factor so the fullnode's Pedersen
+    // balance check holds (same logic SendTransaction runs for the send path).
+    //
+    // The condition AND's two separate things: `!excessBlindingFactor` is a
+    // skip-guard for paths that already computed it upstream, and "no shielded
+    // outputs" is the actual full-unshield signal (mutually exclusive with the
+    // header). The third requirement — that the tx really spends shielded inputs
+    // — is verified below: the header is only attached when shieldedInputs > 0.
     if (
       !txData.excessBlindingFactor &&
       (!txData.shieldedOutputs || txData.shieldedOutputs.length === 0)
@@ -1305,7 +1308,9 @@ const transaction = {
             });
           }
         }
-        // Fee-header amounts (HTR fees + per-token fees) on the output side.
+        // Fees (HTR + per-token) are value leaving the tx, so for the Pedersen
+        // value-conservation check (inputs = outputs + fees) they count on the
+        // OUTPUT side. Zero-blinded because fee amounts are public/explicit.
         for (const header of txData.headers ?? []) {
           if (header instanceof FeeHeader) {
             for (const fee of header.entries) {

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -24,11 +24,18 @@ import {
   POA_BLOCK_VERSION,
   ON_CHAIN_BLUEPRINTS_VERSION,
   TxWeightConstants,
+  ZERO_TWEAK,
 } from '../constants';
 import Transaction from '../models/transaction';
 import CreateTokenTransaction from '../models/create_token_transaction';
 import Input from '../models/input';
 import Output from '../models/output';
+import ShieldedOutput from '../models/shielded_output';
+import ShieldedOutputsHeader from '../headers/shielded_outputs';
+import UnshieldBalanceHeader from '../headers/unshield_balance';
+import FeeHeader from '../headers/fee';
+import { MintHeader } from '../headers/mint_header';
+import { MeltHeader } from '../headers/melt_header';
 import Network from '../models/network';
 import {
   IBalance,
@@ -38,19 +45,23 @@ import {
   IDataTx,
   isDataOutputCreateToken,
   IHistoryOutput,
+  IShieldedOutputEntry,
   IUtxoId,
   IInputSignature,
   ITxSignatureData,
   OutputValueType,
   IHistoryInput,
+  IHistoryShieldedOutput,
   AuthorityType,
 } from '../types';
+import { ShieldedOutputMode } from '../shielded/types';
 import Address from '../models/address';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
 import ScriptData from '../models/script_data';
+import { parseScript } from './scripts';
 import helpers from './helpers';
-import { getAddressType, getAddressFromPubkey } from './address';
+import { getAddressFromPubkey } from './address';
 import txApi from '../api/txApi';
 import { FullNodeTxApiResponse, transactionApiSchema } from '../api/schemas/txApi';
 import tokenUtils from './tokens';
@@ -69,6 +80,189 @@ const transaction = {
       tx.version === MERGED_MINED_BLOCK_VERSION ||
       tx.version === POA_BLOCK_VERSION
     );
+  },
+
+  /**
+   * Check if an output entry from IHistoryTx.outputs is a shielded output appended
+   * by the fullnode's to_json_extended(). These entries have type='shielded' and lack
+   * the 'value' and 'token' fields that transparent outputs have.
+   * Shielded outputs are processed separately via processShieldedOutputs().
+   */
+  isShieldedOutputEntry(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    output: IHistoryOutput | Record<string, any>
+  ): output is IShieldedOutputEntry {
+    return output != null && (output as { type?: string }).type === 'shielded';
+  },
+
+  /**
+   * Shielded inputs arrive from the fullnode inline in tx.inputs[] with
+   * type='shielded' and only a commitment + range_proof — none of the
+   * token_data/decoded/tx_id fields that transparent inputs carry. Call sites
+   * that read those fields must filter these out first.
+   */
+  isShieldedInputEntry(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    input: Record<string, any>
+  ): boolean {
+    return input != null && (input as { type?: string }).type === 'shielded';
+  },
+
+  /**
+   * Look up the on-chain output of a parent tx that is spent by an input
+   * with absolute on-chain index `inputIndex`.
+   *
+   * Sparse-decode handling: when the wallet decodes only some of a parent
+   * tx's shielded outputs (the rest belong to other wallets and can't be
+   * decrypted), the decoded entries are appended to `parentTx.outputs[]`
+   * and their position in that array does NOT necessarily match their
+   * on-chain absolute index. Each decoded entry carries the true on-chain
+   * index in `onChainIndex`. Callers that need to resolve "what does this
+   * input spend" must NOT do `parentTx.outputs[inputIndex]` positionally
+   * for those entries — they'd get a different output, with a different
+   * value/token/address, leading to:
+   *   - wrong token-meta debit (per-tx balance off by an input's value)
+   *   - wrong UTXO deletion key (spent UTXO leaks in storage)
+   *   - signing with the wrong spend key (fullnode rejects with
+   *     "Failed to verify if elements are equal")
+   *
+   * This helper first looks for any shielded entry whose recorded
+   * `onChainIndex` equals `inputIndex` — that's the genuine spent output.
+   * When no shielded entry claims that index, the input must reference a
+   * transparent output of the parent (transparent outputs occupy their
+   * on-chain positions exactly), so positional `outputs[inputIndex]` is
+   * correct and used as a fallback. Returns `undefined` when no output
+   * matches (e.g. the parent has fewer outputs than the input claims to
+   * spend, or the parent has shielded outputs but none claim this index
+   * and there's no transparent at this position either).
+   */
+  findSpentOutput(parentTx: IHistoryTx, inputIndex: number): IHistoryOutput | undefined {
+    const outputs = parentTx.outputs ?? [];
+    // Prefer a shielded entry whose recorded on-chain index matches.
+    const shieldedMatch = outputs.find(
+      o =>
+        this.isShieldedOutputEntry(o) &&
+        (o as IShieldedOutputEntry & { onChainIndex?: number }).onChainIndex === inputIndex
+    );
+    if (shieldedMatch) return shieldedMatch;
+    if (inputIndex < 0 || inputIndex >= outputs.length) return undefined;
+    const positional = outputs[inputIndex];
+    // Positional fallback is only valid for transparent outputs. If the
+    // entry at the requested position is a shielded entry but no shielded
+    // entry has a matching onChainIndex, the input refers to a shielded
+    // slot the wallet doesn't have locally — returning the positional
+    // shielded entry would silently substitute the wrong output.
+    if (this.isShieldedOutputEntry(positional)) return undefined;
+    return positional;
+  },
+
+  /**
+   * Normalize a transaction's outputs by extracting shielded entries from outputs[]
+   * into a separate shielded_outputs[] array AND ensuring base64-encoded fields are
+   * converted to hex. Mutates the tx in place.
+   *
+   * This function is idempotent: running it multiple times on the same tx is a
+   * no-op on the second pass because the base64→hex conversion of an already-hex
+   * string is not valid base64 and would be detected. For that reason we only
+   * convert fields that still look like base64 (contain characters outside the
+   * hex alphabet).
+   *
+   * Two delivery shapes from the fullnode are handled:
+   *   (a) shielded entries nested inside outputs[] with type='shielded' — the
+   *       legacy wire form. Entries are extracted and base64 fields converted.
+   *   (b) shielded entries in a separate shielded_outputs[] field — what most
+   *       recent fullnodes send. No extraction needed, but base64 fields in
+   *       range_proof / surjection_proof / script must still be converted to
+   *       hex so downstream decryption (which uses Buffer.from(value, 'hex'))
+   *       parses them correctly.
+   *
+   * Without this coverage of case (b), shielded outputs delivered by the
+   * websocket real-time path were left with base64 range_proof strings, which
+   * Buffer.from(..., 'hex') parses as garbage — causing the native rewind to
+   * throw "asset commitment verification failed" and the per-tx balance to
+   * read as -input with no credit for the decoded shielded outputs.
+   */
+  normalizeShieldedOutputs(tx: IHistoryTx): void {
+    if (!tx.shielded_outputs) {
+      // Case (a): nested in outputs[]. Extract and convert.
+      const shieldedEntries: IHistoryShieldedOutput[] = [];
+      const transparentOutputs: IHistoryOutput[] = [];
+      for (const output of tx.outputs) {
+        if (this.isShieldedOutputEntry(output)) {
+          shieldedEntries.push({
+            mode: output.asset_commitment
+              ? ShieldedOutputMode.FULLY_SHIELDED
+              : ShieldedOutputMode.AMOUNT_SHIELDED,
+            commitment: this.ensureHex(output.commitment),
+            range_proof: this.ensureHex(output.range_proof),
+            script: this.ensureHex(output.script),
+            token_data: output.token_data,
+            ephemeral_pubkey: this.ensureHex(output.ephemeral_pubkey),
+            decoded: output.decoded,
+            asset_commitment: output.asset_commitment
+              ? this.ensureHex(output.asset_commitment)
+              : undefined,
+            surjection_proof: output.surjection_proof
+              ? this.ensureHex(output.surjection_proof)
+              : undefined,
+            // hathor-core's `_shielded_output_to_json` (base_transaction.py)
+            // sets spent_by on shielded entries the same way it does for
+            // transparent outputs. Preserve it through the normalize so the
+            // wallet can use the canonical `output.spent_by !== null` check
+            // for both kinds of outputs.
+            spent_by: output.spent_by ?? null,
+          });
+        } else {
+          transparentOutputs.push(output);
+        }
+      }
+      if (shieldedEntries.length > 0) {
+        // eslint-disable-next-line no-param-reassign
+        tx.shielded_outputs = shieldedEntries;
+        // eslint-disable-next-line no-param-reassign
+        tx.outputs = transparentOutputs;
+      }
+      return;
+    }
+
+    // Case (b): shielded_outputs already populated. Convert any base64 fields
+    // to hex in place.
+    for (const so of tx.shielded_outputs) {
+      // eslint-disable-next-line no-param-reassign
+      so.commitment = this.ensureHex(so.commitment);
+      // eslint-disable-next-line no-param-reassign
+      so.range_proof = this.ensureHex(so.range_proof);
+      // eslint-disable-next-line no-param-reassign
+      so.script = this.ensureHex(so.script);
+      // eslint-disable-next-line no-param-reassign
+      so.ephemeral_pubkey = this.ensureHex(so.ephemeral_pubkey);
+      if (so.asset_commitment) {
+        // eslint-disable-next-line no-param-reassign
+        so.asset_commitment = this.ensureHex(so.asset_commitment);
+      }
+      if (so.surjection_proof) {
+        // eslint-disable-next-line no-param-reassign
+        so.surjection_proof = this.ensureHex(so.surjection_proof);
+      }
+    }
+  },
+
+  /**
+   * Return a hex-encoded copy of the input. If the input is already hex, it is
+   * returned unchanged. If it looks like base64 (contains characters outside
+   * 0-9a-fA-F or is padded with '='), it is decoded from base64 and re-encoded
+   * as hex. Idempotent for valid hex strings.
+   *
+   * Detection is character-set based: hex uses only [0-9a-fA-F]. Base64 uses
+   * [A-Za-z0-9+/=]. Any character outside the hex alphabet (e.g. '+', '/', '=',
+   * or lowercase letters g-z, or uppercase G-Z) means the string is base64.
+   */
+  ensureHex(value: string): string {
+    if (value.length === 0) return value;
+    // Fast path: plain hex strings are the expected already-normalized case.
+    if (/^[0-9a-fA-F]+$/.test(value)) return value;
+    // Anything else is treated as base64.
+    return Buffer.from(value, 'base64').toString('hex');
   },
 
   /**
@@ -175,6 +369,10 @@ const transaction = {
   ): Promise<ITxSignatureData> {
     const xprivstr = await storage.getMainXPrivKey(pinCode);
     const xprivkey = HDPrivateKey.fromString(xprivstr);
+
+    // Lazily load the spend key chain for shielded-spend addresses
+    let spendXprivkey: typeof xprivkey | null = null;
+
     const dataToSignHash = tx.getDataToSignHash();
     const signatures: IInputSignature[] = [];
     let ncCallerSignature: Buffer | null = null;
@@ -185,8 +383,23 @@ const transaction = {
         continue;
       }
 
-      const spentOut = spentTx.outputs[input.index];
-      if (!spentOut.decoded.address) {
+      // Resolve the spent output via the sparse-decode-aware helper. A
+      // positional `spentTx.outputs[input.index]` would return the wrong
+      // entry on a sparse-decoded parent and the signature would be
+      // computed for the wrong pubkey, failing OP_EQUALVERIFY at the
+      // fullnode with "Failed to verify if elements are equal".
+      let spentOut:
+        | { decoded?: { address?: string }; script?: string; value?: bigint }
+        | undefined = this.findSpentOutput(spentTx, input.index);
+      if (!spentOut) {
+        const utxo = await storage.getUtxo({ txId: input.hash, index: input.index });
+        if (!utxo) {
+          // Truly unknown — caller will surface this as an error elsewhere.
+          continue;
+        }
+        spentOut = { decoded: { address: utxo.address }, value: utxo.value };
+      }
+      if (!spentOut.decoded?.address) {
         // This is not a wallet output
         continue;
       }
@@ -195,12 +408,25 @@ const transaction = {
         // Not a wallet address
         continue;
       }
-      const xpriv = xprivkey.deriveNonCompliantChild(addressInfo.bip32AddressIndex);
+
+      let derivedKey;
+      if (addressInfo.addressType === 'shielded-spend') {
+        // Use spend key chain (m/44'/280'/2'/0) for shielded UTXO inputs
+        if (!spendXprivkey) {
+          const spendXprivStr = await storage.getSpendXPrivKey(pinCode);
+          spendXprivkey = HDPrivateKey.fromString(spendXprivStr);
+        }
+        derivedKey = spendXprivkey.deriveNonCompliantChild(addressInfo.bip32AddressIndex);
+      } else {
+        // Use legacy key chain (m/44'/280'/0'/0) for regular addresses
+        derivedKey = xprivkey.deriveNonCompliantChild(addressInfo.bip32AddressIndex);
+      }
+
       signatures.push({
         inputIndex,
         addressIndex: addressInfo.bip32AddressIndex,
-        signature: this.getSignature(dataToSignHash, xpriv.privateKey),
-        pubkey: xpriv.publicKey.toDER(),
+        signature: this.getSignature(dataToSignHash, derivedKey.privateKey),
+        pubkey: derivedKey.publicKey.toDER(),
       });
     }
 
@@ -430,23 +656,73 @@ const transaction = {
     }
 
     for (const input of tx.inputs) {
-      const { address } = input.decoded;
+      // Shielded inputs arrive without decoded/value/token (hidden in the
+      // commitment on-chain). Recover those fields from the stored origTx's
+      // decoded shielded output at input.index so wallet-owned shielded UTXOs
+      // are debited correctly.
+      let address = input.decoded?.address;
+      let inputToken = input.token;
+      let inputValue = input.value;
+      let inputTokenData = input.token_data;
+
+      if (!address || inputToken === undefined) {
+        // First try: the shielded UTXO is still in storage (e.g. processNewTx
+        // has not yet run on this tx, or the tx was loaded before its spend
+        // was processed).
+        const utxo = await storage.getUtxo({ txId: input.tx_id, index: input.index });
+        if (utxo && utxo.shielded) {
+          address = utxo.address;
+          inputToken = utxo.token;
+          inputValue = utxo.value;
+          inputTokenData = 0;
+        } else {
+          // Fallback: the UTXO has already been deleted (processNewTx deletes
+          // the spent shielded UTXO right after enriching the input). Look up
+          // the parent tx's decoded shielded outputs and match by absolute
+          // on-chain index. Without this fallback, a tx that spent a
+          // wallet-owned shielded UTXO whose enriched inputs weren't
+          // persisted reads back as `{tx_id, index}`-only here, the input
+          // gets silently skipped, and the per-tx delta credits outputs
+          // (change) without debiting the input — showing e.g. +8.5M on a
+          // tx that actually sent 500K.
+          const parentTx = await storage.getTx(input.tx_id);
+          if (!parentTx) continue;
+          const decoded = (parentTx.outputs ?? []).find(
+            o =>
+              this.isShieldedOutputEntry(o) &&
+              ((o as IShieldedOutputEntry & { onChainIndex?: number }).onChainIndex ===
+                input.index ||
+                // Older entries written before onChainIndex existed: fall back
+                // to matching directly by array position. Safe when the parent
+                // tx has been decoded with full coverage (one decoded entry
+                // per shielded output), and a no-op otherwise.
+                parentTx.outputs.indexOf(o) === input.index)
+          ) as IShieldedOutputEntry | undefined;
+          if (!decoded?.decoded?.address) continue;
+          if (!(await storage.isAddressMine(decoded.decoded.address))) continue;
+          address = decoded.decoded.address;
+          inputToken = decoded.token;
+          inputValue = decoded.value;
+          inputTokenData = decoded.token_data ?? 0;
+        }
+      }
+
       if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
-      if (!balance[input.token]) {
-        balance[input.token] = getEmptyBalance();
+      if (!balance[inputToken]) {
+        balance[inputToken] = getEmptyBalance();
       }
 
-      if (this.isAuthorityOutput(input)) {
-        if (this.isMint(input)) {
-          balance[input.token].authorities.mint.unlocked -= 1n;
+      if (this.isAuthorityOutput({ token_data: inputTokenData! })) {
+        if (this.isMint({ value: inputValue!, token_data: inputTokenData! })) {
+          balance[inputToken].authorities.mint.unlocked -= 1n;
         }
-        if (this.isMelt(input)) {
-          balance[input.token].authorities.melt.unlocked -= 1n;
+        if (this.isMelt({ value: inputValue!, token_data: inputTokenData! })) {
+          balance[inputToken].authorities.melt.unlocked -= 1n;
         }
       } else {
-        balance[input.token].tokens.unlocked -= input.value;
+        balance[inputToken].tokens.unlocked -= inputValue!;
       }
     }
 
@@ -564,20 +840,23 @@ const transaction = {
       const scriptData = new ScriptData(output.data);
       return scriptData.createScript();
     }
-    if (getAddressType(output.address, network) === 'p2sh') {
-      // P2SH
-      const address = new Address(output.address, { network });
-      // This will throw AddressError in case the address is invalid
-      address.validateAddress();
-      const p2sh = new P2SH(address, { timelock: output.timelock });
+    const addressObj = new Address(output.address, { network });
+    addressObj.validateAddress();
+    const addrType = addressObj.getType();
+    if (addrType === 'p2sh') {
+      const p2sh = new P2SH(addressObj, { timelock: output.timelock });
       return p2sh.createScript();
     }
-    if (getAddressType(output.address, network) === 'p2pkh') {
-      // P2PKH
-      const address = new Address(output.address, { network });
-      // This will throw AddressError in case the address is invalid
-      address.validateAddress();
-      const p2pkh = new P2PKH(address, { timelock: output.timelock });
+    if (addrType === 'p2pkh') {
+      const p2pkh = new P2PKH(addressObj, { timelock: output.timelock });
+      return p2pkh.createScript();
+    }
+    if (addrType === 'shielded') {
+      // Shielded addresses are a recipient-facing encoding of scan + spend
+      // public keys. On-chain, the transparent script is the P2PKH derived
+      // from the spend pubkey — same convention as createOutputScriptFromAddress.
+      const spendAddress = addressObj.getSpendAddress();
+      const p2pkh = new P2PKH(spendAddress, { timelock: output.timelock });
       return p2pkh.createScript();
     }
     throw new Error('Invalid output for creating script.');
@@ -621,18 +900,206 @@ const transaction = {
         ...options,
         tokenVersion: txData.tokenVersion,
       };
-      return new CreateTokenTransaction(
+      const ctTx = new CreateTokenTransaction(
         txData.name!,
         txData.symbol!,
         inputs,
         outputs,
         createTokenOptions
       );
+      // Attach shielded-related headers identically to the regular tx
+      // branch below so a TCT funded by shielded HTR carries the
+      // UnshieldBalanceHeader + MintHeader the fullnode requires
+      // (alpha-v3 lifted the TCT-can't-be-shielded restriction).
+      this._attachShieldedHeaders(ctTx, txData);
+      return ctTx;
     }
     if (options.version === DEFAULT_TX_VERSION) {
-      return new Transaction(inputs, outputs, options);
+      const tx = new Transaction(inputs, outputs, options);
+      this._attachShieldedHeaders(tx, txData);
+      return tx;
     }
     throw new ParseError('Invalid transaction version.');
+  },
+
+  /**
+   * Attach the shielded-related headers (ShieldedOutputsHeader,
+   * UnshieldBalanceHeader, MintHeader) onto a freshly-built tx based on
+   * what `txData` carries. Shared by both regular `Transaction` and
+   * `CreateTokenTransaction` paths — alpha-v3 unblocked TCT for shielded
+   * inputs so both flows now need the same headers.
+   *
+   * @param tx The Transaction (or CreateTokenTransaction) to attach to.
+   * @param txData The data the tx was built from.
+   */
+  _attachShieldedHeaders(tx: Transaction | CreateTokenTransaction, txData: IDataTx): void {
+    // Populate shielded outputs as a ShieldedOutputsHeader
+    if (txData.shieldedOutputs && txData.shieldedOutputs.length > 0) {
+      const shieldedModels = txData.shieldedOutputs.map(so => {
+        if (!so.commitment || !so.rangeProof || !so.script || !so.ephemeralPubkey) {
+          throw new Error(
+            'Shielded output missing required crypto fields (commitment, rangeProof, script, ephemeralPubkey)'
+          );
+        }
+        const tokenData = this.getTokenDataFromOutput(
+          {
+            type: 'p2pkh',
+            token: so.token,
+            value: so.value,
+            authorities: 0n,
+            address: so.address,
+            timelock: null,
+          },
+          txData.tokens
+        );
+
+        // assetCommitment / surjectionProof only exist on the FullShielded
+        // variant of the discriminated union — narrow with `shieldedMode`
+        // before reading them, otherwise tsc rejects the access.
+        const options =
+          so.shieldedMode === ShieldedOutputMode.FULLY_SHIELDED
+            ? { assetCommitment: so.assetCommitment, surjectionProof: so.surjectionProof }
+            : {};
+
+        return new ShieldedOutput(
+          so.shieldedMode,
+          so.commitment,
+          so.rangeProof,
+          tokenData,
+          Buffer.from(so.script, 'hex'),
+          so.ephemeralPubkey,
+          so.value,
+          options
+        );
+      });
+
+      // eslint-disable-next-line no-param-reassign
+      tx.shieldedOutputs = shieldedModels;
+      tx.headers.push(new ShieldedOutputsHeader(shieldedModels));
+    }
+
+    // Attach UnshieldBalanceHeader for pure-unshield txs. The fullnode
+    // requires it when a tx has shielded inputs and no shielded outputs
+    // (full unshield): the excess scalar closes the Pedersen balance
+    // equation. Mutually exclusive with shielded outputs — the caller must
+    // not set both, and we assert that here to surface the bug early
+    // instead of letting the fullnode reject the tx post-PoW.
+    if (txData.excessBlindingFactor) {
+      if (txData.shieldedOutputs && txData.shieldedOutputs.length > 0) {
+        throw new Error(
+          'A transaction cannot carry both shielded outputs and an excess ' +
+            'blinding factor (UnshieldBalanceHeader is mutually exclusive with ' +
+            'ShieldedOutputsHeader).'
+        );
+      }
+      tx.headers.push(new UnshieldBalanceHeader(txData.excessBlindingFactor));
+    }
+
+    // Mint/Melt headers for shielded txs (alpha-v3 protocol, RFC §4.1).
+    // The wallet MUST publicly declare any *real* supply change for a
+    // non-HTR token in a shielded tx. "Real" here means an explicit
+    // mint or melt authority is being exercised — a simple T→F or F→T
+    // shielding move preserves supply (the transparent surplus/deficit
+    // is balanced via Pedersen on the shielded side) and MUST NOT
+    // declare anything; otherwise the verifier's authority check
+    // (`_check_token_permissions`) demands the matching authority
+    // input we don't have and rejects with ForbiddenMint/ForbiddenMelt.
+    //
+    // Detection rule, per non-HTR token in `tokensArray`:
+    //   - createToken (CREATE_TOKEN_TX_VERSION): the tx itself
+    //     authorizes mint for the new token; declare the positive
+    //     transparent delta as MintHeader.
+    //   - regular tx: declare MintHeader iff inputs carry a mint
+    //     authority for the token AND transparent delta > 0;
+    //     symmetric for MeltHeader (melt authority + delta < 0).
+    //   - otherwise: no header.
+    //
+    // Pushed last so the canonical header-id-ascending order holds:
+    // Fee(0x11) ≤ Shielded(0x12) ≤ Unshield(0x13) ≤ Mint(0x14) ≤ Melt(0x15).
+    const isShieldedTx =
+      (txData.shieldedOutputs && txData.shieldedOutputs.length > 0) ||
+      !!txData.excessBlindingFactor;
+    if (isShieldedTx && !tx.headers.some(h => h instanceof MintHeader || h instanceof MeltHeader)) {
+      // For createToken the new token's outputs are
+      // `IDataOutputCreateToken` (no `token` field), and tokensArray
+      // on-chain is `[tx.hash]`. Use a sentinel locally and remap to
+      // tokenIndex=1.
+      const NEW_TOKEN_KEY = '__create_token__';
+      const isCreateToken = txData.version === CREATE_TOKEN_TX_VERSION;
+      const tokensArray: string[] = isCreateToken ? [NEW_TOKEN_KEY] : txData.tokens ?? [];
+      // Outputs from `prepareMintTxData` use `IDataOutputCreateToken`
+      // (no `token` field) for the minted token in BOTH createToken
+      // and mintTokens flows. Resolve "the implicit token" to either
+      // the sentinel new-token key (createToken) or the first entry
+      // of tokensArray (mintTokens).
+      const implicitTokenKey = isCreateToken ? NEW_TOKEN_KEY : tokensArray[0];
+
+      const tokenDelta = new Map<string, bigint>();
+      const mintAuthorityTokens = new Set<string>();
+      const meltAuthorityTokens = new Set<string>();
+      const bumpDelta = (token: string | undefined, delta: bigint) => {
+        if (!token) return;
+        if (token === NATIVE_TOKEN_UID) return;
+        if (tokensArray.indexOf(token) < 0) return;
+        tokenDelta.set(token, (tokenDelta.get(token) ?? 0n) + delta);
+      };
+
+      // Outputs add to amount; inputs subtract. Both transparent AND
+      // shielded sides count: the verifier (`_fold_mint_melt_entry` +
+      // `verify_balance` in hathor-core) injects synthetic unblinded
+      // `(amount, token)` entries from MeltHeader on the OUTPUT side
+      // and from MintHeader on the INPUT side, then sums *all*
+      // commitments — including shielded inputs/outputs that contribute
+      // `value · H_TOKEN + vbf · G`. So per-token net = total_in −
+      // total_out across both sides; positive ⇒ melt, negative ⇒ mint.
+      for (const out of txData.outputs) {
+        if (out.value <= 0n) continue;
+        if ((out.authorities ?? 0n) !== 0n) continue;
+        const token = 'token' in out ? out.token : implicitTokenKey;
+        bumpDelta(token, out.value);
+      }
+      for (const so of txData.shieldedOutputs ?? []) {
+        if (so.value <= 0n) continue;
+        bumpDelta(so.token, so.value);
+      }
+      for (const inp of txData.inputs) {
+        const auth = inp.authorities ?? 0n;
+        if (auth !== 0n) {
+          if ((auth & TOKEN_MINT_MASK) !== 0n) mintAuthorityTokens.add(inp.token);
+          if ((auth & TOKEN_MELT_MASK) !== 0n) meltAuthorityTokens.add(inp.token);
+          continue;
+        }
+        if (inp.value > 0n) bumpDelta(inp.token, -inp.value);
+      }
+
+      const mintEntries: Array<{ tokenIndex: number; amount: bigint }> = [];
+      const meltEntries: Array<{ tokenIndex: number; amount: bigint }> = [];
+      for (const token of tokensArray) {
+        const delta = tokenDelta.get(token) ?? 0n;
+        // For createToken the new token has no authority input (it's
+        // the genesis): the tx version itself authorizes mint, so we
+        // declare unconditionally on positive delta.
+        const canMint = isCreateToken || mintAuthorityTokens.has(token);
+        const canMelt = meltAuthorityTokens.has(token);
+        if (delta > 0n && canMint) {
+          mintEntries.push({
+            tokenIndex: tokensArray.indexOf(token) + 1,
+            amount: delta,
+          });
+        } else if (delta < 0n && canMelt) {
+          meltEntries.push({
+            tokenIndex: tokensArray.indexOf(token) + 1,
+            amount: -delta,
+          });
+        }
+      }
+      if (mintEntries.length > 0) {
+        tx.headers.push(new MintHeader(mintEntries));
+      }
+      if (meltEntries.length > 0) {
+        tx.headers.push(new MeltHeader(meltEntries));
+      }
+    }
   },
 
   /**
@@ -685,14 +1152,101 @@ const transaction = {
         }
       }
 
-      if (input.index >= spentTx.outputs.length) {
-        throw new Error(
-          `Index (${input.index}) outside of transaction output array bounds (${spentTx.outputs.length})`
-        );
+      // Detect whether the input references a shielded slot of the parent.
+      // The on-chain absolute index for a shielded output is
+      // `transparent_count + shielded_array_idx`, which may or may not equal
+      // its position in the wallet's stored `spentTx.outputs[]` (sparse
+      // decode shifts decoded entries DOWN when the wallet doesn't own
+      // every shielded output of the parent). Two cases produce a shielded
+      // slot:
+      //   (a) input.index >= spentTx.outputs.length — index is past the
+      //       wallet's stored entries (full-decode of fewer outputs than
+      //       actually exist on-chain).
+      //   (b) input.index < spentTx.outputs.length AND some shielded entry
+      //       claims this on-chain index (the sparse-decode case where the
+      //       wallet's outputs[] has room at this position but positional
+      //       lookup returns the wrong entry).
+      // In both cases, build the input from the saved UTXO (which carries
+      // the correct on-chain `index`, address, value, and token) so we sign
+      // with the right spend key and the fullnode resolves to the right
+      // output.
+      // A shielded slot is one where (a) input.index points past the
+      // wallet's stored outputs (full-decode of fewer than the on-chain
+      // count) OR (b) some decoded shielded entry's onChainIndex equals
+      // input.index (sparse-decode within the wallet's range). The helper
+      // returns the decoded shielded entry in case (b), so we use its
+      // result to detect both cases.
+      const resolvedSpent = this.findSpentOutput(spentTx, input.index);
+      const shieldedEntry =
+        resolvedSpent !== undefined && this.isShieldedOutputEntry(resolvedSpent)
+          ? (resolvedSpent as IShieldedOutputEntry)
+          : null;
+      const isShieldedSlot = shieldedEntry !== null || input.index >= spentTx.outputs.length;
+
+      if (isShieldedSlot) {
+        // The `type: 'shielded'` discriminator is required so the rest of
+        // wallet-lib (e.g. `getShieldedUnblindingForTx`, the WS-driven
+        // tx-history view, the signing key chain selection) routes this
+        // input through the shielded code paths.
+        if (shieldedEntry !== null) {
+          // Sparse-decode hit: the wallet's stored parent tx already
+          // carries a decoded shielded entry for this slot. Read
+          // value/token/decoded/script straight off that entry instead
+          // of touching the UTXO record — the entry survives the
+          // WebSocket-driven `processNewTx` UTXO deletion that races
+          // with this fire-and-forget local-insert call. Headless
+          // wallets pointed at a local fullnode hit that race almost
+          // every time (WS re-delivery wins, UTXO is gone before this
+          // function reaches its lookup) and the old code threw
+          // "no stored UTXO recovery for tx_id=…" on every send.
+          inputs.push({
+            type: 'shielded',
+            tx_id: input.hash,
+            index: input.index,
+            script: shieldedEntry.script ?? '',
+            decoded: shieldedEntry.decoded ?? {},
+            token_data: shieldedEntry.token_data ?? 0,
+            token: shieldedEntry.token ?? NATIVE_TOKEN_UID,
+            value: shieldedEntry.value,
+          });
+          continue;
+        }
+
+        // Full-decode mismatch (input.index ≥ spentTx.outputs.length):
+        // the wallet decoded fewer outputs than the parent has on-chain
+        // and this input references one of the missing slots. The only
+        // local source of truth is the UTXO record (saved at
+        // processNewTx time but never appended to outputs[]). Fall back
+        // to it. If both records are missing the wallet truly cannot
+        // reconstruct the input — that's a real error worth surfacing.
+        const utxo = await storage.getUtxo({ txId: input.hash, index: input.index });
+        if (!utxo) {
+          throw new Error(
+            `Input ${input.hash}:${input.index} references a shielded slot the wallet ` +
+              `has neither decoded into outputs[] (length ${spentTx.outputs.length}) ` +
+              `nor stored as a UTXO record — cannot reconstruct the sender-local insert.`
+          );
+        }
+        inputs.push({
+          type: 'shielded',
+          tx_id: input.hash,
+          index: input.index,
+          script: '',
+          decoded: { address: utxo.address, timelock: utxo.timelock ?? null },
+          token_data: 0,
+          token: utxo.token,
+          value: utxo.value,
+        });
+        continue;
       }
 
-      const spentOut = spentTx.outputs[input.index];
+      // Non-shielded slot: `resolvedSpent` is already the transparent
+      // output (helper returns undefined or transparent — never a
+      // shielded entry without onChainIndex match — by design).
+      const spentOut = resolvedSpent!;
+      const isShieldedSpend = false;
       inputs.push({
+        ...(isShieldedSpend ? { type: 'shielded' } : {}),
         tx_id: input.hash,
         index: input.index,
         script: spentOut.script,
@@ -719,6 +1273,31 @@ const transaction = {
       outputs.push(this.hydrateIOWithToken(out, tokensArray));
     }
 
+    // Emit shielded_outputs so the locally-pushed tx carries the same shape
+    // a websocket-delivered tx would. Without this, a shielded self-send
+    // writes a bare history entry (no shielded_outputs), and processNewTx's
+    // decryption gate is skipped entirely (shieldedCount=0) — the wallet
+    // debits the input but never credits back the self-sent shielded outputs,
+    // leaving the per-tx balance stuck at -input_value until a full
+    // processHistory reload. See TODO_FIX_33.
+    const shieldedOutputs: IHistoryShieldedOutput[] | undefined =
+      tx.shieldedOutputs && tx.shieldedOutputs.length > 0
+        ? tx.shieldedOutputs.map(so => {
+            const parsed = parseScript(so.script, storage.config.getNetwork());
+            return {
+              mode: so.mode,
+              commitment: so.commitment.toString('hex'),
+              range_proof: so.rangeProof.toString('hex'),
+              script: so.script.toString('hex'),
+              token_data: so.tokenData,
+              ephemeral_pubkey: so.ephemeralPubkey.toString('hex'),
+              asset_commitment: so.assetCommitment?.toString('hex'),
+              surjection_proof: so.surjectionProof?.toString('hex'),
+              decoded: (parsed?.toData() ?? {}) as IHistoryShieldedOutput['decoded'],
+            };
+          })
+        : undefined;
+
     const histTx: IHistoryTx = {
       tx_id: tx.hash,
       signalBits: tx.signalBits,
@@ -731,6 +1310,7 @@ const transaction = {
       outputs,
       parents: tx.parents,
       tokens: tx.tokens,
+      ...(shieldedOutputs ? { shielded_outputs: shieldedOutputs } : {}),
       // The missing fields below are metadata that cannot be inferred from the
       // Transaction instance.
       // height, first_block
@@ -780,6 +1360,106 @@ const transaction = {
       signTx: true,
       ...options,
     };
+
+    // Full-unshield detection for tx paths that don't go through
+    // SendTransaction.prepareTxData (notably `createNewToken` /
+    // `prepareCreateNewToken`, which build txData directly via tokens.ts).
+    // If the inputs include shielded UTXOs and the tx has no shielded
+    // outputs, we must attach an UnshieldBalanceHeader carrying the excess
+    // blinding factor so the fullnode's Pedersen balance check holds — same
+    // logic SendTransaction already runs for the send path. Skip if txData
+    // already carries excess (set upstream) or if there are shielded outputs
+    // (mutually exclusive with the header).
+    if (
+      !txData.excessBlindingFactor &&
+      (!txData.shieldedOutputs || txData.shieldedOutputs.length === 0)
+    ) {
+      const shieldedInputs: Array<{
+        value: bigint;
+        valueBlindingFactor: Buffer;
+        generatorBlindingFactor: Buffer;
+      }> = [];
+      const transparentInputs: Array<{
+        value: bigint;
+        valueBlindingFactor: Buffer;
+        generatorBlindingFactor: Buffer;
+      }> = [];
+      // The excess scalar in UnshieldBalanceHeader represents
+      // sum(r_in) - sum(r_out), independent of token (it lives on G).
+      // Include shielded inputs of every token so the G-term sum is
+      // correct; transparent inputs (valueBlindingFactor=0) contribute
+      // nothing to the sum but their value matters for the per-token
+      // balance the verifier checks separately.
+      for (const inp of txData.inputs) {
+        const utxo = await storage.getUtxo({ txId: inp.txId, index: inp.index });
+        if (!utxo) continue;
+        if (utxo.shielded) {
+          if (!utxo.blindingFactor) continue;
+          shieldedInputs.push({
+            value: utxo.value,
+            valueBlindingFactor: Buffer.from(utxo.blindingFactor, 'hex'),
+            generatorBlindingFactor: utxo.assetBlindingFactor
+              ? Buffer.from(utxo.assetBlindingFactor, 'hex')
+              : ZERO_TWEAK,
+          });
+        } else if ((utxo.authorities ?? 0n) === 0n && utxo.value > 0n) {
+          transparentInputs.push({
+            value: utxo.value,
+            valueBlindingFactor: ZERO_TWEAK,
+            generatorBlindingFactor: ZERO_TWEAK,
+          });
+        }
+      }
+
+      if (shieldedInputs.length > 0) {
+        const cryptoProvider = storage.shieldedCryptoProvider;
+        if (!cryptoProvider) {
+          throw new Error(
+            'Shielded crypto provider is not set. Cannot compute excess blinding ' +
+              'factor for a tx that spends shielded UTXOs without producing shielded outputs.'
+          );
+        }
+        const transparentOutputEntries: Array<{
+          value: bigint;
+          valueBlindingFactor: Buffer;
+          generatorBlindingFactor: Buffer;
+        }> = [];
+        // All outputs contribute (value, valueBlindingFactor=0,
+        // generatorBlindingFactor=0). Authority outputs are skipped because
+        // their `value` field is the authority mask, not a token amount the
+        // verifier sums.
+        for (const out of txData.outputs) {
+          if (out.value > 0n && (out.authorities ?? 0n) === 0n) {
+            transparentOutputEntries.push({
+              value: out.value,
+              valueBlindingFactor: ZERO_TWEAK,
+              generatorBlindingFactor: ZERO_TWEAK,
+            });
+          }
+        }
+        // Fee-header amounts (HTR fees + per-token fees) on the output side.
+        for (const header of txData.headers ?? []) {
+          if (header instanceof FeeHeader) {
+            for (const fee of header.entries) {
+              transparentOutputEntries.push({
+                value: fee.amount,
+                valueBlindingFactor: ZERO_TWEAK,
+                generatorBlindingFactor: ZERO_TWEAK,
+              });
+            }
+          }
+        }
+        const excess = await cryptoProvider.computeBalancingBlindingFactor(
+          0n,
+          ZERO_TWEAK,
+          [...shieldedInputs, ...transparentInputs],
+          transparentOutputEntries
+        );
+        // eslint-disable-next-line no-param-reassign
+        txData.excessBlindingFactor = excess;
+      }
+    }
+
     const network = storage.config.getNetwork();
     const tx = this.createTransactionFromData(txData, network);
     if (newOptions.signTx) {
@@ -849,11 +1529,18 @@ const transaction = {
     const rewardLock = storage.version?.reward_spend_min_blocks || 0;
     const nowTs = Math.floor(Date.now() / 1000);
     const tx = await storage.getTx(utxo.txId);
-    if (tx === null || (tx.outputs && tx.outputs.length <= utxo.index)) {
+    if (tx === null) {
       // This is not our utxo, so we cannot spend it.
       return false;
     }
-    const output = tx.outputs[utxo.index];
+    // Sparse-decode-aware lookup. Positional outputs[utxo.index] would
+    // return the wrong entry on a parent whose shielded outputs were only
+    // partially decoded, and `isOutputLocked` would check the wrong
+    // entry's timelock.
+    const output = this.findSpentOutput(tx, utxo.index);
+    if (!output) {
+      return false;
+    }
     const isTimelocked = this.isOutputLocked(output, { refTs: nowTs });
     const isHeightLocked = this.isHeightLocked(tx.height, currentHeight, rewardLock);
     const isSelectedAsInput = await storage.isUtxoSelectedAsInput(utxo);
@@ -935,10 +1622,15 @@ const transaction = {
     }
     const { tx, meta } = txResponse;
     const inputs: IHistoryInput[] = tx.inputs.map(i => {
-      const hydratedInput = this.hydrateIOWithToken(i, tx.tokens);
+      if (this.isShieldedInputEntry(i)) {
+        return i as unknown as IHistoryInput;
+      }
+      const hydratedInput = this.hydrateIOWithToken(i as { token_data: number }, tx.tokens);
       return hydratedInput as IHistoryInput;
     });
     const outputs: IHistoryOutput[] = tx.outputs.map(o => {
+      // Shielded outputs already have token populated after decryption
+      if (this.isShieldedOutputEntry(o)) return o;
       const hydratedoutput = this.hydrateIOWithToken(o, tx.tokens);
       return hydratedoutput as IHistoryOutput;
     });

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -581,12 +581,15 @@ const transaction = {
     // this loop an owned shielded RECEIVE would credit 0 in getTxHistory /
     // getTxById. Mirrors the transparent loop's authority/lock/value handling.
     for (const so of tx.shielded_outputs ?? []) {
+      // `value !== undefined` is the authoritative (and sole) ownership gate: it
+      // is written in place only when the wallet decrypts a shielded output it
+      // owns — the wire never carries a plaintext value, and the WS path wipes
+      // any incoming one. An extra isAddressMine(decoded.address) check would be
+      // redundant (the receive pipeline stores the spend-P2PKH whenever it
+      // decrypts), and worse: it would couple the credit to address-storage and
+      // throw if `decoded` were ever absent.
       if (so.value === undefined) {
         // Non-owned (or not-yet-decrypted) slot — excluded by the gate.
-        continue;
-      }
-      const { address } = so.decoded;
-      if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
       const isLocked = this.isOutputLocked(so, { refTs: nowTs }) || isHeightLocked;
@@ -608,10 +611,15 @@ const transaction = {
       // pipeline persists at receive time, via the SEPARATED-model resolver.
       // Without this the per-tx delta would credit change but never debit the
       // spend (e.g. +8.5M on a tx that actually sent 500K).
-      let address = input.decoded?.address;
+      const address = input.decoded?.address;
       let inputToken = input.token;
       let inputValue = input.value;
       let inputTokenData = input.token_data;
+      // Ownership of a bare shielded input is proven by its decrypted parent
+      // slot (`value !== undefined`, set only on outputs the wallet owns), so it
+      // does NOT need the isAddressMine gate below — that gate is for inline
+      // (transparent) inputs, whose ownership isn't otherwise established.
+      let owned = false;
 
       if (!address || inputToken === undefined || inputValue === undefined) {
         const spentTx = await storage.getTx(input.tx_id);
@@ -625,15 +633,17 @@ const transaction = {
           continue;
         }
         const so = resolved.output;
-        address = so.decoded?.address;
         // Token comes from the decrypted slot (an owned slot always carries it).
         // No NATIVE_TOKEN_UID fallback — that would mislabel a custom token as HTR.
         inputToken = so.token;
         inputValue = so.value;
         inputTokenData = so.token_data ?? 0;
+        owned = true;
       }
 
-      if (!(address && (await storage.isAddressMine(address)))) {
+      // Transparent inputs establish ownership via isAddressMine; a bare shielded
+      // input already established it via its decrypted parent slot (`owned`).
+      if (!owned && !(address && (await storage.isAddressMine(address)))) {
         continue;
       }
       // Inputs debit (sign -1n); a spent output is never locked.

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -854,10 +854,11 @@ const transaction = {
   },
 
   /**
-   * Build a `ShieldedOutput` model for each entry in `txData.shieldedOutputs`,
-   * set them on `tx.shieldedOutputs` (SEPARATED model — shielded outputs live
-   * apart from `tx.outputs`), and push a ShieldedOutputsHeader (0x12). No-op
-   * when the tx carries no shielded outputs.
+   * Build a `ShieldedOutput` model for each entry in `txData.shieldedOutputs`
+   * and push a ShieldedOutputsHeader (0x12) carrying them (SEPARATED model —
+   * shielded outputs live apart from `tx.outputs`, and the `tx.shieldedOutputs`
+   * getter reads them back from the header). No-op when the tx carries no
+   * shielded outputs.
    */
   _attachShieldedOutputsHeader(tx: Transaction | CreateTokenTransaction, txData: IDataTx): void {
     // Populate shielded outputs as a ShieldedOutputsHeader
@@ -900,8 +901,8 @@ const transaction = {
         );
       });
 
-      // eslint-disable-next-line no-param-reassign
-      tx.shieldedOutputs = shieldedModels;
+      // The ShieldedOutputsHeader owns the array; tx.shieldedOutputs is a getter
+      // that reads it back, so there is no separate field to assign.
       tx.headers.push(new ShieldedOutputsHeader(shieldedModels));
     }
   },

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -84,11 +84,26 @@ const transaction = {
   },
 
   /**
-   * Resolve the on-chain output of a parent tx that an input with absolute
+   * Shielded inputs arrive from the fullnode inline in tx.inputs[] with
+   * type='shielded' and only a commitment + range_proof — none of the
+   * token_data/decoded/tx_id fields that transparent inputs carry. Call sites
+   * that read those fields must filter these out first. The reload path
+   * (processHistory) also feeds bare {tx_id, index, type:'shielded'} inputs
+   * from address_history, which this detects so they can be debited.
+   */
+  isShieldedInputEntry(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    input: Record<string, any>
+  ): boolean {
+    return input != null && (input as { type?: string }).type === 'shielded';
+  },
+
+  /**
+   * Resolve the on-chain output of the spent tx that an input with absolute
    * on-chain index `idx` spends, using the SEPARATED / arithmetic model that
    * mirrors hathor-core (`base_transaction.py:347-363`).
    *
-   * The parent has `T = outputs.length` transparent outputs followed by
+   * The spent tx has `T = outputs.length` transparent outputs followed by
    * `S = shielded_outputs.length` shielded outputs. The on-chain absolute
    * index of `shielded_outputs[s]` is `T + s`. Resolution is pure arithmetic
    * — NO scan, NO commitment-match, NO `onChainIndex`:
@@ -105,14 +120,14 @@ const transaction = {
    * `idx - T` onto the wrong entry.
    */
   resolveSpentOutput(
-    parentTx: IHistoryTx,
+    spentTx: IHistoryTx,
     idx: number
   ):
     | { kind: 'transparent'; output: ITransparentOutput }
     | { kind: 'shielded'; sIndex: number; output: IHistoryShieldedOutput }
     | undefined {
-    const outputs = parentTx.outputs ?? [];
-    const shieldedOutputs = parentTx.shielded_outputs ?? [];
+    const outputs = spentTx.outputs ?? [];
+    const shieldedOutputs = spentTx.shielded_outputs ?? [];
     const T = outputs.length;
     const S = shieldedOutputs.length;
     if (idx < 0) return undefined;
@@ -540,36 +555,44 @@ const transaction = {
     const rewardLock = storage.version?.reward_spend_min_blocks;
     const isHeightLocked = this.isHeightLocked(tx.height, nowHeight, rewardLock);
 
+    // Accrue one output/input into the running balance. `sign` is +1n to credit
+    // (outputs) or -1n to debit (inputs): authority entries move by `sign`, token
+    // amounts by `sign * value`. Shared by the transparent-output, shielded-output
+    // and input loops below so the authority/lock/value handling lives in one place.
+    const accrue = (
+      token: string,
+      value: bigint,
+      tokenData: number,
+      isLocked: boolean,
+      sign: bigint
+    ): void => {
+      if (!balance[token]) {
+        balance[token] = getEmptyBalance();
+      }
+      const entry = balance[token];
+      if (this.isAuthorityOutput({ token_data: tokenData })) {
+        if (this.isMint({ value, token_data: tokenData })) {
+          if (isLocked) entry.authorities.mint.locked += sign;
+          else entry.authorities.mint.unlocked += sign;
+        }
+        if (this.isMelt({ value, token_data: tokenData })) {
+          if (isLocked) entry.authorities.melt.locked += sign;
+          else entry.authorities.melt.unlocked += sign;
+        }
+      } else if (isLocked) {
+        entry.tokens.locked += sign * value;
+      } else {
+        entry.tokens.unlocked += sign * value;
+      }
+    };
+
     for (const output of tx.outputs) {
       const { address } = output.decoded;
       if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
-      if (!balance[output.token]) {
-        balance[output.token] = getEmptyBalance();
-      }
       const isLocked = this.isOutputLocked(output, { refTs: nowTs }) || isHeightLocked;
-
-      if (this.isAuthorityOutput(output)) {
-        if (this.isMint(output)) {
-          if (isLocked) {
-            balance[output.token].authorities.mint.locked += 1n;
-          } else {
-            balance[output.token].authorities.mint.unlocked += 1n;
-          }
-        }
-        if (this.isMelt(output)) {
-          if (isLocked) {
-            balance[output.token].authorities.melt.locked += 1n;
-          } else {
-            balance[output.token].authorities.melt.unlocked += 1n;
-          }
-        }
-      } else if (isLocked) {
-        balance[output.token].tokens.locked += output.value;
-      } else {
-        balance[output.token].tokens.unlocked += output.value;
-      }
+      accrue(output.token, output.value, output.token_data, isLocked, 1n);
     }
 
     // CREDIT loop over shielded outputs (SEPARATED model). Owned shielded
@@ -586,35 +609,10 @@ const transaction = {
       if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
-      const token = so.token ?? NATIVE_TOKEN_UID;
-      if (!balance[token]) {
-        balance[token] = getEmptyBalance();
-      }
       const isLocked = this.isOutputLocked(so, { refTs: nowTs }) || isHeightLocked;
-
       // token_data on a shielded output may be undefined (FullShielded hides
       // the token); default to 0 so the authority check reads as funds.
-      const soForAuthority = { token_data: so.token_data ?? 0, value: so.value };
-      if (this.isAuthorityOutput(soForAuthority)) {
-        if (this.isMint(soForAuthority)) {
-          if (isLocked) {
-            balance[token].authorities.mint.locked += 1n;
-          } else {
-            balance[token].authorities.mint.unlocked += 1n;
-          }
-        }
-        if (this.isMelt(soForAuthority)) {
-          if (isLocked) {
-            balance[token].authorities.melt.locked += 1n;
-          } else {
-            balance[token].authorities.melt.unlocked += 1n;
-          }
-        }
-      } else if (isLocked) {
-        balance[token].tokens.locked += so.value;
-      } else {
-        balance[token].tokens.unlocked += so.value;
-      }
+      accrue(so.token ?? NATIVE_TOKEN_UID, so.value, so.token_data ?? 0, isLocked, 1n);
     }
 
     for (const input of tx.inputs) {
@@ -640,17 +638,17 @@ const transaction = {
         } else {
           // Fallback: the UTXO has already been deleted (processNewTx deletes
           // the spent shielded UTXO right after enriching the input). Resolve
-          // the parent tx's spent output by its absolute on-chain index via
-          // the SEPARATED-model resolver and read value/token/decoded off the
+          // the spent tx's output by its absolute on-chain index via the
+          // SEPARATED-model resolver and read value/token/decoded off the
           // shielded entry. Without this fallback, a tx that spent a
           // wallet-owned shielded UTXO whose enriched inputs weren't persisted
           // reads back as `{tx_id, index}`-only here, the input gets silently
           // skipped, and the per-tx delta credits outputs (change) without
           // debiting the input — showing e.g. +8.5M on a tx that actually
           // sent 500K. Never "skip if UTXO missing".
-          const parentTx = await storage.getTx(input.tx_id);
-          if (!parentTx) continue;
-          const resolved = this.resolveSpentOutput(parentTx, input.index);
+          const spentTx = await storage.getTx(input.tx_id);
+          if (!spentTx) continue;
+          const resolved = this.resolveSpentOutput(spentTx, input.index);
           if (!resolved || resolved.kind !== 'shielded') continue;
           const decoded = resolved.output;
           // Owned-marker gate: a non-owned slot has value === undefined.
@@ -671,20 +669,8 @@ const transaction = {
         // Defensive: a wallet-owned input must carry a token by this point.
         continue;
       }
-      if (!balance[inputToken]) {
-        balance[inputToken] = getEmptyBalance();
-      }
-
-      if (this.isAuthorityOutput({ token_data: inputTokenData! })) {
-        if (this.isMint({ value: inputValue!, token_data: inputTokenData! })) {
-          balance[inputToken].authorities.mint.unlocked -= 1n;
-        }
-        if (this.isMelt({ value: inputValue!, token_data: inputTokenData! })) {
-          balance[inputToken].authorities.melt.unlocked -= 1n;
-        }
-      } else {
-        balance[inputToken].tokens.unlocked -= inputValue!;
-      }
+      // Inputs debit (sign -1n); a spent output is never locked.
+      accrue(inputToken, inputValue!, inputTokenData!, false, -1n);
     }
 
     return balance;
@@ -870,8 +856,7 @@ const transaction = {
       );
       // Attach shielded-related headers identically to the regular tx
       // branch below so a TCT funded by shielded HTR carries the
-      // UnshieldBalanceHeader + MintHeader the fullnode requires
-      // (alpha-v3 lifted the TCT-can't-be-shielded restriction).
+      // UnshieldBalanceHeader + MintHeader the fullnode requires.
       this._attachShieldedHeaders(ctTx, txData);
       return ctTx;
     }
@@ -956,7 +941,7 @@ const transaction = {
       tx.headers.push(new UnshieldBalanceHeader(txData.excessBlindingFactor));
     }
 
-    // Mint/Melt headers for shielded txs (alpha-v3 protocol, RFC §4.1).
+    // Mint/Melt headers for shielded txs.
     // The wallet MUST publicly declare any *real* supply change for a
     // non-HTR token in a shielded tx. "Real" here means an explicit
     // mint or melt authority is being exercised — a simple T→F or F→T

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -309,30 +309,13 @@ const transaction = {
       // OP_EQUALVERIFY at the fullnode with "Failed to verify if elements are
       // equal".
       const resolved = this.resolveSpentOutput(spentTx, input.index);
-      let spentOut: { decoded?: { address?: string }; value?: bigint } | undefined =
-        resolved?.output;
-      // Fall back to the stored UTXO when the resolved output can't provide a
-      // wallet address: either the parent isn't in storage (resolved ===
-      // undefined) or it resolved to a shielded slot the wallet hasn't decoded
-      // (value undefined and no decoded.address). Keying off the address here
-      // — not the resolver kind — preserves signing of owned shielded inputs
-      // whose parent carries the decoded entry, while still recovering owned
-      // inputs whose parent slot is undecoded but whose UTXO is in storage.
-      const needsUtxoFallback =
-        resolved === undefined ||
-        (resolved.kind === 'shielded' &&
-          resolved.output.value === undefined &&
-          !resolved.output.decoded?.address);
-      if (needsUtxoFallback) {
-        const utxo = await storage.getUtxo({ txId: input.hash, index: input.index });
-        if (!utxo) {
-          // Truly unknown — caller will surface this as an error elsewhere.
-          continue;
-        }
-        spentOut = { decoded: { address: utxo.address }, value: utxo.value };
-      }
+      const spentOut = resolved?.output;
+      // A shielded output's spend-derived P2PKH (decoded.address) is on the wire
+      // for every output (owned or not) and persisted on the stored entry, so
+      // the resolver always supplies the address needed to select the signing
+      // key — no UTXO lookup required.
       if (!spentOut?.decoded?.address) {
-        // This is not a wallet output
+        // Not a wallet output (or an unresolvable index)
         continue;
       }
       const addressInfo = await storage.getAddressInfo(spentOut.decoded.address);
@@ -616,61 +599,39 @@ const transaction = {
     }
 
     for (const input of tx.inputs) {
-      // Shielded inputs arrive without decoded/value/token (hidden in the
-      // commitment on-chain). Recover those fields from the stored origTx's
-      // decoded shielded output at input.index so wallet-owned shielded UTXOs
-      // are debited correctly.
+      // Determine the spent value/token/address. Transparent (or already
+      // enriched) inputs carry these inline. A shielded input is bare — its
+      // amount is hidden in the on-chain commitment — so read them off the
+      // parent tx's owned, decrypted shielded output, which the receive
+      // pipeline persists at receive time, via the SEPARATED-model resolver.
+      // Without this the per-tx delta would credit change but never debit the
+      // spend (e.g. +8.5M on a tx that actually sent 500K).
       let address = input.decoded?.address;
       let inputToken = input.token;
       let inputValue = input.value;
       let inputTokenData = input.token_data;
 
-      if (!address || inputToken === undefined) {
-        // First try: the shielded UTXO is still in storage (e.g. processNewTx
-        // has not yet run on this tx, or the tx was loaded before its spend
-        // was processed).
-        const utxo = await storage.getUtxo({ txId: input.tx_id, index: input.index });
-        if (utxo && utxo.shielded) {
-          address = utxo.address;
-          inputToken = utxo.token;
-          inputValue = utxo.value;
-          inputTokenData = 0;
-        } else {
-          // Fallback: the UTXO has already been deleted (processNewTx deletes
-          // the spent shielded UTXO right after enriching the input). Resolve
-          // the spent tx's output by its absolute on-chain index via the
-          // SEPARATED-model resolver and read value/token/decoded off the
-          // shielded entry. Without this fallback, a tx that spent a
-          // wallet-owned shielded UTXO whose enriched inputs weren't persisted
-          // reads back as `{tx_id, index}`-only here, the input gets silently
-          // skipped, and the per-tx delta credits outputs (change) without
-          // debiting the input — showing e.g. +8.5M on a tx that actually
-          // sent 500K. Never "skip if UTXO missing".
-          const spentTx = await storage.getTx(input.tx_id);
-          if (!spentTx) continue;
-          const resolved = this.resolveSpentOutput(spentTx, input.index);
-          if (!resolved || resolved.kind !== 'shielded') continue;
-          const decoded = resolved.output;
-          // Owned-marker gate: a non-owned slot has value === undefined.
-          if (decoded.value === undefined) continue;
-          if (!decoded.decoded?.address) continue;
-          if (!(await storage.isAddressMine(decoded.decoded.address))) continue;
-          address = decoded.decoded.address;
-          inputToken = decoded.token ?? NATIVE_TOKEN_UID;
-          inputValue = decoded.value;
-          inputTokenData = decoded.token_data ?? 0;
+      if (!address || inputToken === undefined || inputValue === undefined) {
+        const spentTx = await storage.getTx(input.tx_id);
+        const resolved = spentTx ? this.resolveSpentOutput(spentTx, input.index) : undefined;
+        // Owned-marker gate: only a decrypted shielded slot (value defined) is
+        // a wallet spend we can debit; a non-owned/undecoded slot has value
+        // === undefined.
+        if (resolved?.kind !== 'shielded' || resolved.output.value === undefined) {
+          continue;
         }
+        const so = resolved.output;
+        address = so.decoded?.address;
+        inputToken = so.token ?? NATIVE_TOKEN_UID;
+        inputValue = so.value;
+        inputTokenData = so.token_data ?? 0;
       }
 
       if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
-      if (inputToken === undefined) {
-        // Defensive: a wallet-owned input must carry a token by this point.
-        continue;
-      }
       // Inputs debit (sign -1n); a spent output is never locked.
-      accrue(inputToken, inputValue!, inputTokenData!, false, -1n);
+      accrue(inputToken!, inputValue!, inputTokenData!, false, -1n);
     }
 
     return balance;

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1321,13 +1321,9 @@ const transaction = {
       }
 
       if (shieldedInputs.length > 0) {
-        const cryptoProvider = storage.shieldedCryptoProvider;
-        if (!cryptoProvider) {
-          throw new Error(
-            'Shielded crypto provider is not set. Cannot compute excess blinding ' +
-              'factor for a tx that spends shielded UTXOs without producing shielded outputs.'
-          );
-        }
+        // Spending shielded UTXOs without shielded outputs needs the provider to
+        // compute the excess blinding factor; fail loudly if it is missing.
+        const cryptoProvider = storage.getShieldedCryptoProvider();
         const transparentOutputEntries: Array<{
           value: bigint;
           valueBlindingFactor: Buffer;

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -91,11 +91,8 @@ const transaction = {
    * (processHistory) also feeds bare {tx_id, index, type:'shielded'} inputs
    * from address_history, which this detects so they can be debited.
    */
-  isShieldedInputEntry(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    input: Record<string, any>
-  ): boolean {
-    return input != null && (input as { type?: string }).type === 'shielded';
+  isShieldedInputEntry(input: { type?: string } | null | undefined): boolean {
+    return input != null && input.type === 'shielded';
   },
 
   /**

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -830,15 +830,30 @@ const transaction = {
   },
 
   /**
-   * Attach the shielded-related headers (ShieldedOutputsHeader,
-   * UnshieldBalanceHeader, MintHeader) onto a freshly-built tx based on
-   * what `txData` carries. Shared by both regular `Transaction` and
+   * Attach the shielded-related headers onto a freshly-built tx based on what
+   * `txData` carries. Shared by both regular `Transaction` and
    * `CreateTokenTransaction` paths, which need the same headers.
+   *
+   * Delegates to one helper per header, invoked in canonical header-id order so
+   * `tx.headers` stays sorted: Fee(0x11) ≤ Shielded(0x12) ≤ Unshield(0x13) ≤
+   * Mint(0x14) ≤ Melt(0x15).
    *
    * @param tx The Transaction (or CreateTokenTransaction) to attach to.
    * @param txData The data the tx was built from.
    */
   _attachShieldedHeaders(tx: Transaction | CreateTokenTransaction, txData: IDataTx): void {
+    this._attachShieldedOutputsHeader(tx, txData);
+    this._attachUnshieldBalanceHeader(tx, txData);
+    this._attachMintMeltHeaders(tx, txData);
+  },
+
+  /**
+   * Build a `ShieldedOutput` model for each entry in `txData.shieldedOutputs`,
+   * set them on `tx.shieldedOutputs` (SEPARATED model — shielded outputs live
+   * apart from `tx.outputs`), and push a ShieldedOutputsHeader (0x12). No-op
+   * when the tx carries no shielded outputs.
+   */
+  _attachShieldedOutputsHeader(tx: Transaction | CreateTokenTransaction, txData: IDataTx): void {
     // Populate shielded outputs as a ShieldedOutputsHeader
     if (txData.shieldedOutputs && txData.shieldedOutputs.length > 0) {
       const shieldedModels = txData.shieldedOutputs.map(so => {
@@ -883,7 +898,16 @@ const transaction = {
       tx.shieldedOutputs = shieldedModels;
       tx.headers.push(new ShieldedOutputsHeader(shieldedModels));
     }
+  },
 
+  /**
+   * Push an UnshieldBalanceHeader (0x13) for a full-unshield tx (shielded
+   * inputs, no shielded outputs): the excess scalar closes the Pedersen balance
+   * `sum(C_in) = sum(C_out) + excess·G`. Mutually exclusive with shielded
+   * outputs — asserts the caller never set both (surfaces the bug before PoW).
+   * No-op when there's no excess blinding factor.
+   */
+  _attachUnshieldBalanceHeader(tx: Transaction | CreateTokenTransaction, txData: IDataTx): void {
     // Attach UnshieldBalanceHeader for pure-unshield txs. The fullnode
     // requires it when a tx has shielded inputs and no shielded outputs
     // (full unshield): the excess scalar closes the Pedersen balance
@@ -900,7 +924,15 @@ const transaction = {
       }
       tx.headers.push(new UnshieldBalanceHeader(txData.excessBlindingFactor));
     }
+  },
 
+  /**
+   * Declare real supply changes for non-HTR tokens in a shielded tx via
+   * MintHeader (0x14) / MeltHeader (0x15). A pure shielding move (T↔F) preserves
+   * supply and declares nothing; a header is emitted only when an explicit
+   * mint/melt authority is exercised (see the detection rule in the body).
+   */
+  _attachMintMeltHeaders(tx: Transaction | CreateTokenTransaction, txData: IDataTx): void {
     // Mint/Melt headers for shielded txs.
     // The wallet MUST publicly declare any *real* supply change for a
     // non-HTR token in a shielded tx. "Real" here means an explicit

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -590,9 +590,14 @@ const transaction = {
         continue;
       }
       const isLocked = this.isOutputLocked(so, { refTs: nowTs }) || isHeightLocked;
-      // token_data on a shielded output may be undefined (FullShielded hides
-      // the token); default to 0 so the authority check reads as funds.
-      accrue(so.token ?? NATIVE_TOKEN_UID, so.value, so.token_data ?? 0, isLocked, 1n);
+      // An owned (decrypted) shielded slot always carries its token: decryption
+      // recovers value and tokenUid together (IDecryptedShieldedOutput), and the
+      // `value !== undefined` gate above already proved ownership. So read the
+      // token directly — no NATIVE_TOKEN_UID fallback, which would mislabel a
+      // custom token as HTR (mirrors the input-debit path below). token_data may
+      // still be undefined (FullShielded hides it); default to 0 so the
+      // authority check reads as plain funds.
+      accrue(so.token!, so.value, so.token_data ?? 0, isLocked, 1n);
     }
 
     for (const input of tx.inputs) {

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -833,8 +833,7 @@ const transaction = {
    * Attach the shielded-related headers (ShieldedOutputsHeader,
    * UnshieldBalanceHeader, MintHeader) onto a freshly-built tx based on
    * what `txData` carries. Shared by both regular `Transaction` and
-   * `CreateTokenTransaction` paths — alpha-v3 unblocked TCT for shielded
-   * inputs so both flows now need the same headers.
+   * `CreateTokenTransaction` paths, which need the same headers.
    *
    * @param tx The Transaction (or CreateTokenTransaction) to attach to.
    * @param txData The data the tx was built from.
@@ -1096,35 +1095,21 @@ const transaction = {
         continue;
       }
 
-      if (
-        (resolvedSpent === undefined && input.index >= spentTx.outputs.length) ||
-        resolvedSpent?.kind === 'shielded'
-      ) {
-        // The input references a shielded slot the wallet hasn't decoded into
-        // shielded_outputs[] (or the parent's shielded list is incomplete in
-        // storage). The only local source of truth is the UTXO record (saved
-        // at processNewTx time). Fall back to it. If it's also missing the
-        // wallet truly cannot reconstruct the input — a real error.
-        const utxo = await storage.getUtxo({ txId: input.hash, index: input.index });
-        if (!utxo) {
-          throw new Error(
-            `Input ${input.hash}:${input.index} references a shielded slot the wallet ` +
-              `has neither decoded into shielded_outputs[] ` +
-              `(length ${spentTx.shielded_outputs?.length ?? 0}) ` +
-              `nor stored as a UTXO record — cannot reconstruct the sender-local insert.`
-          );
-        }
-        inputs.push({
-          type: 'shielded',
-          tx_id: input.hash,
-          index: input.index,
-          script: '',
-          decoded: { address: utxo.address, timelock: utxo.timelock ?? null },
-          token_data: 0,
-          token: utxo.token,
-          value: utxo.value,
-        });
-        continue;
+      if (resolvedSpent === undefined || resolvedSpent.kind === 'shielded') {
+        // Reachable only if we're "spending" a shielded slot the wallet never
+        // decoded (value === undefined) or whose stored shielded list is too
+        // short to resolve. That is impossible for a real spend: a shielded
+        // input requires the spend key and unblinding factors the wallet only
+        // holds for outputs it OWNS, and an owned output is decoded + persisted
+        // on the parent at receive time — so reaching here means corrupted or
+        // incomplete storage. Don't paper over it with the racy UTXO record;
+        // surface it (the broadcast already happened — only the local insert
+        // fails, and the WS re-delivery still processes the tx correctly).
+        throw new Error(
+          `Input ${input.hash}:${input.index} spends a shielded slot with no decoded ` +
+            `entry on the spent tx (shielded_outputs length ` +
+            `${spentTx.shielded_outputs?.length ?? 0}) — cannot reconstruct the local insert.`
+        );
       }
 
       // Transparent slot: resolvedSpent is the transparent output.

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -55,6 +55,7 @@ import {
   AuthorityType,
 } from '../types';
 import { ShieldedOutputMode } from '../shielded/types';
+import { ensureHex } from './buffer';
 import Address from '../models/address';
 import P2PKH from '../models/p2pkh';
 import P2SH from '../models/p2sh';
@@ -80,37 +81,6 @@ const transaction = {
       tx.version === MERGED_MINED_BLOCK_VERSION ||
       tx.version === POA_BLOCK_VERSION
     );
-  },
-
-  /**
-   * Detect a shielded output delivered INLINE in `tx.outputs[]` on the wire.
-   *
-   * In the SEPARATED model `outputs[]` is transparent-only once normalized,
-   * but the fullnode/WS can still deliver shielded outputs nested inside
-   * `outputs[]` with `type: 'shielded'` (the legacy wire form, v3-compat).
-   * `normalizeShieldedOutputs` case-(a), `convertFullNodeTxToHistoryTx`, and
-   * `walletServiceStorageProxy` use this to detect and extract them. Returns a
-   * plain boolean; callers that need to read the inline wire fields cast the
-   * entry themselves.
-   */
-  isInlineShieldedWireEntry(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    output: IHistoryOutput | Record<string, any>
-  ): boolean {
-    return output != null && (output as { type?: string }).type === 'shielded';
-  },
-
-  /**
-   * Shielded inputs arrive from the fullnode inline in tx.inputs[] with
-   * type='shielded' and only a commitment + range_proof — none of the
-   * token_data/decoded/tx_id fields that transparent inputs carry. Call sites
-   * that read those fields must filter these out first.
-   */
-  isShieldedInputEntry(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    input: Record<string, any>
-  ): boolean {
-    return input != null && (input as { type?: string }).type === 'shielded';
   },
 
   /**
@@ -157,122 +127,46 @@ const transaction = {
   },
 
   /**
-   * Normalize a transaction's outputs by extracting shielded entries from outputs[]
-   * into a separate shielded_outputs[] array AND ensuring base64-encoded fields are
-   * converted to hex. Mutates the tx in place.
+   * Normalize a transaction's shielded outputs: convert any base64-encoded
+   * confidential fields (commitment / range_proof / script / ephemeral_pubkey /
+   * asset_commitment / surjection_proof) to hex in place. Mutates the tx.
    *
-   * This function is idempotent: running it multiple times on the same tx is a
-   * no-op on the second pass because the base64→hex conversion of an already-hex
-   * string is not valid base64 and would be detected. For that reason we only
-   * convert fields that still look like base64 (contain characters outside the
-   * hex alphabet).
+   * The fullnode delivers shielded outputs in a dedicated `shielded_outputs[]`
+   * field (the separated model). Over the websocket real-time path their buffer
+   * fields arrive base64-encoded; without this conversion `Buffer.from(value,
+   * 'hex')` downstream parses them as garbage — making the native rewind throw
+   * "asset commitment verification failed" and the per-tx balance read as
+   * -input with no credit for the decoded shielded outputs.
    *
-   * Two delivery shapes from the fullnode are handled:
-   *   (a) shielded entries nested inside outputs[] with type='shielded' — the
-   *       legacy wire form. Entries are extracted and base64 fields converted.
-   *   (b) shielded entries in a separate shielded_outputs[] field — what most
-   *       recent fullnodes send. No extraction needed, but base64 fields in
-   *       range_proof / surjection_proof / script must still be converted to
-   *       hex so downstream decryption (which uses Buffer.from(value, 'hex'))
-   *       parses them correctly.
-   *
-   * Without this coverage of case (b), shielded outputs delivered by the
-   * websocket real-time path were left with base64 range_proof strings, which
-   * Buffer.from(..., 'hex') parses as garbage — causing the native rewind to
-   * throw "asset commitment verification failed" and the per-tx balance to
-   * read as -input with no credit for the decoded shielded outputs.
+   * Idempotent: an already-hex field is left unchanged (ensureHex no-ops on it).
+   * The owned-marker fields (value / token / blindingFactor / assetBlindingFactor)
+   * are NOT on the wire — they are populated post-decryption on the slots the
+   * wallet owns — so this neither reads nor invents them.
    */
   normalizeShieldedOutputs(tx: IHistoryTx): void {
     if (!tx.shielded_outputs) {
-      // Case (a): nested in outputs[]. Extract and convert.
-      const shieldedEntries: IHistoryShieldedOutput[] = [];
-      const transparentOutputs: IHistoryOutput[] = [];
-      for (const output of tx.outputs) {
-        if (this.isInlineShieldedWireEntry(output)) {
-          // The inline wire entry carries the on-chain confidential fields,
-          // which are not part of `ITransparentOutput`; cast to read them.
-          const wire = output as unknown as IHistoryShieldedOutput;
-          shieldedEntries.push({
-            mode: wire.asset_commitment
-              ? ShieldedOutputMode.FULLY_SHIELDED
-              : ShieldedOutputMode.AMOUNT_SHIELDED,
-            commitment: this.ensureHex(wire.commitment),
-            range_proof: this.ensureHex(wire.range_proof),
-            script: this.ensureHex(wire.script),
-            token_data: wire.token_data,
-            ephemeral_pubkey: this.ensureHex(wire.ephemeral_pubkey),
-            decoded: wire.decoded,
-            asset_commitment: wire.asset_commitment
-              ? this.ensureHex(wire.asset_commitment)
-              : undefined,
-            surjection_proof: wire.surjection_proof
-              ? this.ensureHex(wire.surjection_proof)
-              : undefined,
-            // hathor-core's `_shielded_output_to_json` (base_transaction.py)
-            // sets spent_by on shielded entries the same way it does for
-            // transparent outputs. Preserve it through the normalize so the
-            // wallet can use the canonical `output.spent_by !== null` check
-            // for both kinds of outputs.
-            spent_by: wire.spent_by ?? null,
-            // Preserve any owned-marker fields already present on the inline
-            // wire entry (e.g. a re-delivered tx the wallet had decrypted).
-            // Stripping these would wipe owned data on every re-add.
-            value: wire.value,
-            token: wire.token,
-            blindingFactor: wire.blindingFactor,
-            assetBlindingFactor: wire.assetBlindingFactor,
-          });
-        } else {
-          transparentOutputs.push(output);
-        }
-      }
-      if (shieldedEntries.length > 0) {
-        // eslint-disable-next-line no-param-reassign
-        tx.shielded_outputs = shieldedEntries;
-        // eslint-disable-next-line no-param-reassign
-        tx.outputs = transparentOutputs;
-      }
+      // Transparent-only tx (no shielded_outputs) — nothing to normalize.
       return;
     }
 
-    // Case (b): shielded_outputs already populated. Convert any base64 fields
-    // to hex in place.
     for (const so of tx.shielded_outputs) {
       // eslint-disable-next-line no-param-reassign
-      so.commitment = this.ensureHex(so.commitment);
+      so.commitment = ensureHex(so.commitment);
       // eslint-disable-next-line no-param-reassign
-      so.range_proof = this.ensureHex(so.range_proof);
+      so.range_proof = ensureHex(so.range_proof);
       // eslint-disable-next-line no-param-reassign
-      so.script = this.ensureHex(so.script);
+      so.script = ensureHex(so.script);
       // eslint-disable-next-line no-param-reassign
-      so.ephemeral_pubkey = this.ensureHex(so.ephemeral_pubkey);
+      so.ephemeral_pubkey = ensureHex(so.ephemeral_pubkey);
       if (so.asset_commitment) {
         // eslint-disable-next-line no-param-reassign
-        so.asset_commitment = this.ensureHex(so.asset_commitment);
+        so.asset_commitment = ensureHex(so.asset_commitment);
       }
       if (so.surjection_proof) {
         // eslint-disable-next-line no-param-reassign
-        so.surjection_proof = this.ensureHex(so.surjection_proof);
+        so.surjection_proof = ensureHex(so.surjection_proof);
       }
     }
-  },
-
-  /**
-   * Return a hex-encoded copy of the input. If the input is already hex, it is
-   * returned unchanged. If it looks like base64 (contains characters outside
-   * 0-9a-fA-F or is padded with '='), it is decoded from base64 and re-encoded
-   * as hex. Idempotent for valid hex strings.
-   *
-   * Detection is character-set based: hex uses only [0-9a-fA-F]. Base64 uses
-   * [A-Za-z0-9+/=]. Any character outside the hex alphabet (e.g. '+', '/', '=',
-   * or lowercase letters g-z, or uppercase G-Z) means the string is base64.
-   */
-  ensureHex(value: string): string {
-    if (value.length === 0) return value;
-    // Fast path: plain hex strings are the expected already-normalized case.
-    if (/^[0-9a-fA-F]+$/.test(value)) return value;
-    // Anything else is treated as base64.
-    return Buffer.from(value, 'base64').toString('hex');
   },
 
   /**
@@ -1664,66 +1558,30 @@ const transaction = {
       throw new Error(`trying to convert a tx from a failed api request: ${txResponse.message}`);
     }
     const { tx, meta } = txResponse;
-    const inputs: IHistoryInput[] = tx.inputs.map(i => {
-      if (this.isShieldedInputEntry(i)) {
-        return i as unknown as IHistoryInput;
-      }
-      const hydratedInput = this.hydrateIOWithToken(i as { token_data: number }, tx.tokens);
-      return hydratedInput as IHistoryInput;
-    });
+    const inputs: IHistoryInput[] = tx.inputs.map(
+      i => this.hydrateIOWithToken(i as { token_data: number }, tx.tokens) as IHistoryInput
+    );
 
-    // SEPARATED model: `outputs[]` is transparent-only. The fullnode/WS may
-    // still deliver shielded outputs INLINE inside `outputs[]` (legacy wire
-    // form) and/or in a dedicated `shielded_outputs[]` field. Partition the
-    // wire outputs so transparent ones are hydrated into `outputs[]` while
-    // inline shielded ones are collected for `shielded_outputs[]`, then merge
-    // with any separately delivered list (in on-chain order: inline entries
-    // occupy the positions they had within outputs[]).
-    const outputs: IHistoryOutput[] = [];
-    const inlineShielded: IHistoryShieldedOutput[] = [];
-    for (const o of tx.outputs) {
-      if (this.isInlineShieldedWireEntry(o)) {
-        const wire = o as unknown as IHistoryShieldedOutput;
-        inlineShielded.push({
-          mode: wire.asset_commitment
-            ? ShieldedOutputMode.FULLY_SHIELDED
-            : ShieldedOutputMode.AMOUNT_SHIELDED,
-          commitment: this.ensureHex(wire.commitment),
-          range_proof: this.ensureHex(wire.range_proof),
-          script: this.ensureHex(wire.script),
-          token_data: wire.token_data,
-          ephemeral_pubkey: this.ensureHex(wire.ephemeral_pubkey),
-          decoded: wire.decoded,
-          asset_commitment: wire.asset_commitment
-            ? this.ensureHex(wire.asset_commitment)
-            : undefined,
-          surjection_proof: wire.surjection_proof
-            ? this.ensureHex(wire.surjection_proof)
-            : undefined,
-          spent_by: wire.spent_by ?? null,
-        });
-        continue;
-      }
-      outputs.push(this.hydrateIOWithToken(o, tx.tokens) as IHistoryOutput);
-    }
+    // SEPARATED model: `outputs[]` is transparent-only — hydrate each with its
+    // token. Shielded outputs arrive in a dedicated `shielded_outputs[]` field
+    // (passthrough — not in the zod schema); convert their base64 buffer fields
+    // to hex so downstream decryption (Buffer.from(value, 'hex')) parses them.
+    const outputs: IHistoryOutput[] = tx.outputs.map(
+      o => this.hydrateIOWithToken(o, tx.tokens) as IHistoryOutput
+    );
 
-    // A separately delivered shielded_outputs[] field (passthrough — not in
-    // the zod schema). Convert base64 fields to hex per entry.
     const separateShielded = (tx as { shielded_outputs?: IHistoryShieldedOutput[] })
       .shielded_outputs;
-    const shieldedOutputs: IHistoryShieldedOutput[] = [
-      ...inlineShielded,
-      ...(separateShielded ?? []).map(so => ({
-        ...so,
-        commitment: this.ensureHex(so.commitment),
-        range_proof: this.ensureHex(so.range_proof),
-        script: this.ensureHex(so.script),
-        ephemeral_pubkey: this.ensureHex(so.ephemeral_pubkey),
-        asset_commitment: so.asset_commitment ? this.ensureHex(so.asset_commitment) : undefined,
-        surjection_proof: so.surjection_proof ? this.ensureHex(so.surjection_proof) : undefined,
-        spent_by: so.spent_by ?? null,
-      })),
-    ];
+    const shieldedOutputs: IHistoryShieldedOutput[] = (separateShielded ?? []).map(so => ({
+      ...so,
+      commitment: ensureHex(so.commitment),
+      range_proof: ensureHex(so.range_proof),
+      script: ensureHex(so.script),
+      ephemeral_pubkey: ensureHex(so.ephemeral_pubkey),
+      asset_commitment: so.asset_commitment ? ensureHex(so.asset_commitment) : undefined,
+      surjection_proof: so.surjection_proof ? ensureHex(so.surjection_proof) : undefined,
+      spent_by: so.spent_by ?? null,
+    }));
 
     const histTx: IHistoryTx = {
       tx_id: tx.hash,

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -577,19 +577,19 @@ const transaction = {
 
     // CREDIT loop over shielded outputs (SEPARATED model). Owned shielded
     // outputs live in tx.shielded_outputs[] with their value/token decrypted
-    // IN PLACE; the single ownership gate is `value !== undefined`. Without
-    // this loop an owned shielded RECEIVE would credit 0 in getTxHistory /
-    // getTxById. Mirrors the transparent loop's authority/lock/value handling.
+    // IN PLACE. `value !== undefined` is the authoritative ownership gate — it
+    // is written only when the wallet decrypts a slot it owns (see the
+    // owned-marker note on IHistoryShieldedOutput) — and we additionally require
+    // isAddressMine(decoded.address), the same check the transparent loop uses;
+    // authority/lock/value handling mirrors that loop too. Without this loop an
+    // owned shielded RECEIVE would credit 0 in getTxHistory / getTxById.
     for (const so of tx.shielded_outputs ?? []) {
-      // `value !== undefined` is the authoritative (and sole) ownership gate: it
-      // is written in place only when the wallet decrypts a shielded output it
-      // owns — the wire never carries a plaintext value, and the WS path wipes
-      // any incoming one. An extra isAddressMine(decoded.address) check would be
-      // redundant (the receive pipeline stores the spend-P2PKH whenever it
-      // decrypts), and worse: it would couple the credit to address-storage and
-      // throw if `decoded` were ever absent.
       if (so.value === undefined) {
         // Non-owned (or not-yet-decrypted) slot — excluded by the gate.
+        continue;
+      }
+      const { address } = so.decoded;
+      if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
       const isLocked = this.isOutputLocked(so, { refTs: nowTs }) || isHeightLocked;
@@ -611,15 +611,10 @@ const transaction = {
       // pipeline persists at receive time, via the SEPARATED-model resolver.
       // Without this the per-tx delta would credit change but never debit the
       // spend (e.g. +8.5M on a tx that actually sent 500K).
-      const address = input.decoded?.address;
+      let address = input.decoded?.address;
       let inputToken = input.token;
       let inputValue = input.value;
       let inputTokenData = input.token_data;
-      // Ownership of a bare shielded input is proven by its decrypted parent
-      // slot (`value !== undefined`, set only on outputs the wallet owns), so it
-      // does NOT need the isAddressMine gate below — that gate is for inline
-      // (transparent) inputs, whose ownership isn't otherwise established.
-      let owned = false;
 
       if (!address || inputToken === undefined || inputValue === undefined) {
         const spentTx = await storage.getTx(input.tx_id);
@@ -633,17 +628,15 @@ const transaction = {
           continue;
         }
         const so = resolved.output;
+        address = so.decoded?.address;
         // Token comes from the decrypted slot (an owned slot always carries it).
         // No NATIVE_TOKEN_UID fallback — that would mislabel a custom token as HTR.
         inputToken = so.token;
         inputValue = so.value;
         inputTokenData = so.token_data ?? 0;
-        owned = true;
       }
 
-      // Transparent inputs establish ownership via isAddressMine; a bare shielded
-      // input already established it via its decrypted parent slot (`owned`).
-      if (!owned && !(address && (await storage.isAddressMine(address)))) {
+      if (!(address && (await storage.isAddressMine(address)))) {
         continue;
       }
       // Inputs debit (sign -1n); a spent output is never locked.

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -174,15 +174,10 @@ export class WalletServiceStorageProxy {
   private convertFullNodeToHistoryTx(fullTxResponse: FullNodeTxResponse): IHistoryTx {
     const { tx, meta } = fullTxResponse;
 
-    // SEPARATED model: keep `outputs[]` transparent-only. The wire may still
-    // deliver shielded outputs INLINE in `outputs[]` (legacy form); filter
-    // those out here so a downstream resolver doesn't treat them as
-    // transparent. The dedicated `shielded_outputs[]` field (passthrough — not
-    // on the FullNodeTx type) is threaded through unchanged so shielded spends
-    // can still resolve their parent slots via getUtxo/resolveSpentOutput.
-    const transparentOutputs = tx.outputs.filter(
-      output => !transactionUtils.isInlineShieldedWireEntry(output)
-    );
+    // SEPARATED model: `outputs[]` is transparent-only. The dedicated
+    // `shielded_outputs[]` field (passthrough — not on the FullNodeTx type) is
+    // threaded through unchanged so shielded spends can still resolve their
+    // parent slots via getUtxo/resolveSpentOutput.
     const shieldedOutputs = (tx as { shielded_outputs?: IHistoryTx['shielded_outputs'] })
       .shielded_outputs;
 
@@ -201,7 +196,7 @@ export class WalletServiceStorageProxy {
           type: input.decoded.type ?? undefined,
         },
       })) as IHistoryTx['inputs'],
-      outputs: transparentOutputs.map(output => ({
+      outputs: tx.outputs.map(output => ({
         ...output,
         decoded: {
           ...output.decoded,

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -174,6 +174,18 @@ export class WalletServiceStorageProxy {
   private convertFullNodeToHistoryTx(fullTxResponse: FullNodeTxResponse): IHistoryTx {
     const { tx, meta } = fullTxResponse;
 
+    // SEPARATED model: keep `outputs[]` transparent-only. The wire may still
+    // deliver shielded outputs INLINE in `outputs[]` (legacy form); filter
+    // those out here so a downstream resolver doesn't treat them as
+    // transparent. The dedicated `shielded_outputs[]` field (passthrough — not
+    // on the FullNodeTx type) is threaded through unchanged so shielded spends
+    // can still resolve their parent slots via getUtxo/resolveSpentOutput.
+    const transparentOutputs = tx.outputs.filter(
+      output => !transactionUtils.isInlineShieldedWireEntry(output)
+    );
+    const shieldedOutputs = (tx as { shielded_outputs?: IHistoryTx['shielded_outputs'] })
+      .shielded_outputs;
+
     return {
       tx_id: tx.hash,
       signalBits: 0, // Default value since fullnode tx doesn't include signal bits
@@ -189,22 +201,20 @@ export class WalletServiceStorageProxy {
           type: input.decoded.type ?? undefined,
         },
       })) as IHistoryTx['inputs'],
-      outputs: tx.outputs.map(output => {
-        if (transactionUtils.isShieldedOutputEntry(output)) return output;
-        return {
-          ...output,
-          decoded: {
-            ...output.decoded,
-            type: output.decoded.type ?? undefined,
-          },
-        };
-      }) as IHistoryTx['outputs'],
+      outputs: transparentOutputs.map(output => ({
+        ...output,
+        decoded: {
+          ...output.decoded,
+          type: output.decoded.type ?? undefined,
+        },
+      })) as IHistoryTx['outputs'],
       parents: tx.parents,
       tokens: tx.tokens.map(token => token.uid),
       height: meta.height,
       first_block: meta.first_block,
       token_name: tx.token_name ?? undefined,
       token_symbol: tx.token_symbol ?? undefined,
+      ...(shieldedOutputs ? { shielded_outputs: shieldedOutputs } : {}),
     };
   }
 }

--- a/src/wallet/walletServiceStorageProxy.ts
+++ b/src/wallet/walletServiceStorageProxy.ts
@@ -189,13 +189,16 @@ export class WalletServiceStorageProxy {
           type: input.decoded.type ?? undefined,
         },
       })) as IHistoryTx['inputs'],
-      outputs: tx.outputs.map(output => ({
-        ...output,
-        decoded: {
-          ...output.decoded,
-          type: output.decoded.type ?? undefined,
-        },
-      })) as IHistoryTx['outputs'],
+      outputs: tx.outputs.map(output => {
+        if (transactionUtils.isShieldedOutputEntry(output)) return output;
+        return {
+          ...output,
+          decoded: {
+            ...output.decoded,
+            type: output.decoded.type ?? undefined,
+          },
+        };
+      }) as IHistoryTx['outputs'],
       parents: tx.parents,
       tokens: tx.tokens.map(token => token.uid),
       height: meta.height,


### PR DESCRIPTION
## Description                                                                                                                                                              
                                                                                                                                                                              
  Third PR in the shielded-outputs stack. It adds the **transaction-utility layer**                                                                                           
  and the **SEPARATED-output history data model** that sit between the already-merged                                                                                         
  foundation (storage layer #1088, tx headers #1086, address derivation #1087, crypto                                                                                         
  provider) and the receive pipeline that consumes them (next PR).                                                                                                            
                                                                                                                                                                              
  **SEPARATED model:** a tx keeps transparent outputs in `tx.outputs[]` and shielded                                                                                          
  outputs in a separate `tx.shielded_outputs[]`. A shielded output's value/token are                                                                                          
  hidden on-chain; the owned-marker fields (`value`, `token`, `blindingFactor`,                                                                                               
  `assetBlindingFactor`) are populated only after the wallet decrypts an output it                                                                                            
  owns. The single ownership gate everywhere is `value !== undefined`.

## Acceptance Criteria
  - `resolveSpentOutput` maps an absolute on-chain index to a transparent output,
    a shielded slot, or `undefined`, for every slot regardless of decoded state,
    and returns `undefined` for out-of-range/negative indices.                          
  - `getTxBalance` credits owned shielded receives (`value !== undefined`), debits
    spent shielded inputs even after the UTXO is deleted (via the parent resolver),
    and ignores non-owned slots.                                                        
  - `getSignatureForTx` produces a valid signature for a shielded-spend input using
    the spend key chain (no positional-index mismatch).                                 
  - `normalizeShieldedOutputs` converts base64 confidential fields to hex, is
    idempotent on already-hex input, preserves owned-marker fields, and is a no-op      
    for transparent-only txs.               
  - Building a shielded tx attaches the correct headers in canonical id order; a        
    full-unshield tx (shielded inputs, no shielded outputs) carries an
    `UnshieldBalanceHeader`; mint/melt is declared only with the matching authority.    
  - A shielded output never carries both an excess blinding factor and shielded
    outputs (asserted at build time).                                                   
  - `npm run build`, `npm run lint`, and the unit tests pass
    (`__tests__/utils/transaction_shielded.test.ts`, `__tests__/models/transaction.test.ts`).

# Choose a pull request template

- [feature PR](?template=feature.md&quick_pull=1)
- [Release process](https://github.com/HathorNetwork/hathor-wallet-lib/compare/release...master?template=release.md&quick_pull=1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a read-only `shieldedOutputs` accessor on transactions and improved separated-model handling end-to-end (parsing, signing, balance, and history conversion).
  * Added shielded crypto provider access with validation, plus automatic shielded field normalization before persistence.

* **Bug Fixes**
  * Corrected shielded accounting and spend-output resolution across wallet flows; improved handling of shielded/unshield/mint/melt headers and conditional header attachment.

* **Documentation**
  * Clarified shielded `value` semantics (wallet-only, not serialized; excluded from weight-related calculations).

* **Tests**
  * Expanded shielded transaction utility, storage, and signature-key-chain coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->