### PR TITLE
chore: raise itest CI timeout 50->70 minutes

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   itest:
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 50
+    timeout-minutes: 70
 
     strategy:
       matrix:


### PR DESCRIPTION
Raises the `itest` job's `timeout-minutes` from 50 to 70 in `integration-test.yml`, giving the integration suite more headroom before CI force-fails a slow run.

The motivation is the amount of failed CI runs from PRs #1077, #1078, #1079

**Acceptance Criteria**
- The integration-test workflow's job timeout is 70 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted integration test timeout to allow longer execution windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->