### PR TITLE
chore: bumps version to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hathor/wallet-lib",
-      "version": "3.2.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@hathor/ct-crypto-provider": "0.0.1-shielded",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hathor/wallet-lib",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Library used by Hathor Wallet",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
### Acceptance Criteria
- Bump package to v4.0.0

This is a **major** release. It ships the same set of PRs as the `v3.2.0` pre-release, promoted to `v4.0.0` because the release changes the public TypeScript surface in two backward-incompatible ways. Existing transparent wallets remain **runtime-compatible** (byte-identical behavior to `v3.1.1`), but the following consumers must update at compile time: (1) code that inspects `WalletRequestError.cause`, and (2) code that implements a custom `IStore` / `IStorage`.

### Breaking Changes

From **#1081 — feat(errors): type `WalletRequestError.cause` as a discriminated union**:

`WalletRequestError.cause` is no longer typed as `unknown`. It is now `WalletRequestErrorCause | undefined`, a discriminated union with three mutually exclusive variants:

- `{ status: number; data: unknown }` — HTTP failure (axios response)
- `{ state: unknown }` — app-level rejection (HTTP succeeded, wallet reported a non-success state)
- `{ source: WalletRequestError }` — chained failure wrapping a prior error (e.g. polling timeouts)

Any code that catches `WalletRequestError` and reads fields off `err.cause` must narrow on a discriminant before accessing variant fields:

```ts
// Before
if (err instanceof WalletRequestError) {
  const status = (err.cause as any)?.status;
  const body = (err.cause as any)?.data;
}

// After
if (err instanceof WalletRequestError && err.cause) {
  if ('status' in err.cause) {
    const status = err.cause.status; // number
    const body = err.cause.data;     // unknown
  } else if ('state' in err.cause) {
    const state = err.cause.state;   // unknown — wallet-reported failure state
  } else if ('source' in err.cause) {
    const inner = err.cause.source;  // WalletRequestError — chained failure
  }
}
```

Chained errors are now wrapped in `{ source }` instead of being assigned the inner error directly:

```ts
// Before
const inner = err.cause as WalletRequestError;

// After
if (err.cause && 'source' in err.cause) {
  const inner = err.cause.source;
}
```

`cause` may still be `undefined`, so always guard with a truthiness check before narrowing. No runtime behavior changed beyond the polling-timeout site, which now consistently attaches `{ source }` (last seen error) or `{ state }` (last seen wallet state) instead of occasionally producing `cause: undefined`.

From the **shielded-address feature (#1085, #1086, #1087, #1088)** — new required members on `IStore` / `IStorage`:

The shielded feature is purely runtime-additive for existing transparent wallets, but it widened the storage interfaces. Consumers that implement a **custom `IStore`** (e.g. IndexedDB / SQLite stores) must add the new required method:

- `getUtxo(utxoId: IUtxoId): Promise<IUtxo | null>` — direct UTXO lookup

Consumers that implement **`IStorage`** directly must additionally add the shielded-key accessors below. Note that most consumers use the concrete `Storage` class and are **not** affected:

- `setShieldedCryptoProvider(provider?: IShieldedCryptoProvider): void`
- `getScanXPrivKey(pinCode: string): Promise<string>`
- `getSpendXPrivKey(pinCode: string): Promise<string>`
- `getScanXPubKey(): Promise<string | undefined>`
- `getSpendXPubKey(): Promise<string | undefined>`

The existing address-chain and history methods (`addressIter`, `getAddressAtIndex`, `addressCount`, `getCurrentAddress`, `historyIter`, the last-loaded/last-used/current index getters and setters, etc.) gained **optional** parameters (`opts?: IAddressChainOptions`, `options?: { order?: 'asc' | 'desc' }`). These are backward-compatible — omitting them preserves the previous legacy-chain / newest-first behavior.

> **Note:** the `@hathor/ct-crypto-node` native addon required for shielded crypto is intentionally **not** a declared dependency of wallet-lib (the package is still WIP). Transparent-only consumers are unaffected; consumers that use shielded crypto install it themselves. The `require()` is lazy and throws a clear remediation message if the addon is missing at runtime.

### What's included

| PR | Type | Title |
|---|---|---|
| #1106 | feat | support multisig (P2SH) wallets in manual stream sync |
| #1088 | feat | shielded — data model + storage layer for shielded addresses |
| #1087 | feat | shielded — address derivation, network version byte, key chains |
| #1086 | feat | shielded — transaction headers (shielded outputs, unshield balance, mint/melt) |
| #1085 | feat | shielded — crypto provider interface and send-side primitives |
| #1081 | feat | type `WalletRequestError.cause` as a discriminated union |
| #1078 | test | shared UTXO query tests for both facades |
| #1076 | test | shared create-token tests for both facades |
| #1109 | chore | raise itest CI timeout 50→70 minutes |

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.