### PR TITLE
fix(websocket): close socket on every reconnect, add reconnect backoff

### DIFF
--- a/__tests__/websocket/socketLeak.test.ts
+++ b/__tests__/websocket/socketLeak.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for the WebSocket socket leak + reconnect backoff.
+ *
+ * Bug: GenericWebSocket.closeWs() only called ws.close() when
+ * readyState === OPEN. A socket killed while still CONNECTING (TCP established,
+ * HTTP 101 upgrade not yet received) was dereferenced WITHOUT being closed, so
+ * the underlying connection lingered ESTABLISHED. Under reconnect churn against
+ * a connection-capped server, every retry leaked one ESTABLISHED socket.
+ */
+
+import http from 'http';
+import net, { AddressInfo } from 'net';
+import GenericWebSocket from '../../src/websocket/index';
+
+/** Internal members we need to reach for white-box assertions. */
+interface SocketView {
+  ws: { readyState: number };
+  getReconnectDelay(): number;
+}
+
+/** Poll a predicate until it's true, or reject after `timeout` ms. */
+function waitFor(pred: () => boolean, timeout = 2000, interval = 20): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const start = Date.now();
+    const tick = (): void => {
+      if (pred()) {
+        resolve();
+        return;
+      }
+      if (Date.now() - start > timeout) {
+        reject(new Error('waitFor: condition not met within timeout'));
+        return;
+      }
+      setTimeout(tick, interval);
+    };
+    tick();
+  });
+}
+
+describe('BaseWebSocket socket leak (closeWs on a CONNECTING socket)', () => {
+  it('tears down the underlying socket even when it is still CONNECTING', async () => {
+    // Server that accepts the TCP connection and the upgrade request but never
+    // writes the 101 response and never destroys the socket — so the client
+    // stays in CONNECTING. Mirrors a fullnode whose nginx per-IP cap accepts the
+    // TCP connect but stalls/rejects the WS upgrade.
+    let tcpConnected = false;
+    const held: net.Socket[] = [];
+    const server = http.createServer();
+    server.on('connection', () => {
+      tcpConnected = true;
+    });
+    // Hold the upgrade open: no 101, no destroy (a missing 'upgrade' listener
+    // would make Node close the socket, which we explicitly do NOT want here).
+    server.on('upgrade', (_req: http.IncomingMessage, socket: net.Socket) => {
+      held.push(socket);
+    });
+
+    await new Promise<void>(resolve => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const ws = new GenericWebSocket({ wsURL: `ws://127.0.0.1:${port}/` });
+    ws.setup();
+    const sock = (ws as unknown as SocketView).ws; // underlying isomorphic-ws
+
+    // TCP is established but the handshake never completes -> CONNECTING (0).
+    await waitFor(() => tcpConnected);
+    expect(sock.readyState).toBe(0); // WebSocket.CONNECTING
+
+    // The fix under test: closeWs() must close/terminate regardless of
+    // readyState. Without it, a CONNECTING socket is only dereferenced and the
+    // underlying connection is leaked.
+    ws.closeWs();
+
+    // With the fix the socket is terminated -> readyState reaches CLOSED (3).
+    // Without the fix it stays CONNECTING (0) forever -> this times out.
+    await waitFor(() => sock.readyState === 3); // WebSocket.CLOSED
+    expect(sock.readyState).toBe(3);
+
+    ws.close();
+    held.forEach(s => {
+      try {
+        s.destroy();
+      } catch (_e) {
+        // already destroyed
+      }
+    });
+    await new Promise<void>(resolve => {
+      server.close(() => resolve());
+    });
+  });
+});
+
+describe('BaseWebSocket reconnect backoff', () => {
+  it('uses capped exponential backoff with jitter (not a flat interval)', () => {
+    const base = 100;
+    const max = 1000;
+    const ws = new GenericWebSocket({
+      wsURL: 'ws://127.0.0.1:1/',
+      retryConnectionInterval: base,
+      maxRetryConnectionInterval: max,
+    });
+    const view = ws as unknown as SocketView;
+
+    const delays = Array.from({ length: 10 }, () => view.getReconnectDelay());
+
+    // First retry ~ base (+ up to 25% jitter).
+    expect(delays[0]).toBeGreaterThanOrEqual(base);
+    expect(delays[0]).toBeLessThanOrEqual(base * 1.25 + 1);
+    // Grows over the first attempts (exponential).
+    expect(delays[2]).toBeGreaterThan(delays[0]);
+    // Never exceeds the cap (+ jitter).
+    delays.forEach(d => {
+      expect(d).toBeLessThanOrEqual(max * 1.25 + 1);
+    });
+    // Reaches the cap region by later attempts.
+    expect(delays[9]).toBeGreaterThanOrEqual(max);
+
+    ws.close();
+  });
+});

--- a/__tests__/websocket/socketLeak.test.ts
+++ b/__tests__/websocket/socketLeak.test.ts
@@ -2,84 +2,104 @@
  * Regression tests for the WebSocket socket leak + reconnect backoff.
  *
  * Bug: GenericWebSocket.closeWs() only called ws.close() when
- * readyState === OPEN. A socket killed while still CONNECTING (TCP established,
- * HTTP 101 upgrade not yet received) was dereferenced WITHOUT being closed, so
- * the underlying connection lingered ESTABLISHED. Under reconnect churn against
- * a connection-capped server, every retry leaked one ESTABLISHED socket.
+ * readyState === OPEN. A socket retired while still CONNECTING (TCP established,
+ * HTTP 101 upgrade not yet received) — or CLOSING — was dereferenced WITHOUT
+ * being closed, so the underlying connection lingered ESTABLISHED on the OS
+ * until keepalive eventually reaped it. Under reconnect churn against a
+ * connection-capped server (e.g. nginx limit_conn accepting the TCP connect but
+ * never completing the upgrade), every retry leaked one ESTABLISHED socket — a
+ * self-reinforcing loop that saturated the per-IP cap.
  */
 
 import http from 'http';
 import net, { AddressInfo } from 'net';
+import _WebSocket from 'isomorphic-ws';
 import GenericWebSocket from '../../src/websocket/index';
 
-/** Internal members we need to reach for white-box assertions. */
+/** A socket we can inspect/tear down regardless of which platform `ws` we got. */
+interface RawSocket {
+  readyState: number;
+  terminate?: () => void;
+  close: (code?: number, reason?: string) => void;
+}
+
+/** Internal members we override/read for the assertions. */
 interface SocketView {
-  ws: { readyState: number };
+  WebSocket: unknown;
   getReconnectDelay(): number;
 }
 
-/** Poll a predicate until it's true, or reject after `timeout` ms. */
-function waitFor(pred: () => boolean, timeout = 2000, interval = 20): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const start = Date.now();
-    const tick = (): void => {
-      if (pred()) {
-        resolve();
-        return;
-      }
-      if (Date.now() - start > timeout) {
-        reject(new Error('waitFor: condition not met within timeout'));
-        return;
-      }
-      setTimeout(tick, interval);
-    };
-    tick();
+function delay(ms: number): Promise<void> {
+  return new Promise<void>(resolve => {
+    setTimeout(resolve, ms);
   });
 }
 
-describe('BaseWebSocket socket leak (closeWs on a CONNECTING socket)', () => {
-  it('tears down the underlying socket even when it is still CONNECTING', async () => {
-    // Server that accepts the TCP connection and the upgrade request but never
-    // writes the 101 response and never destroys the socket — so the client
-    // stays in CONNECTING. Mirrors a fullnode whose nginx per-IP cap accepts the
-    // TCP connect but stalls/rejects the WS upgrade.
-    let tcpConnected = false;
-    const held: net.Socket[] = [];
+describe('BaseWebSocket socket leak under reconnect churn (integration)', () => {
+  it('closes every retired socket instead of accumulating them', async () => {
+    // A real server that accepts the TCP connection and the upgrade request but
+    // never writes the 101 response and never destroys the socket — so every
+    // client connection stays CONNECTING. This mirrors a fullnode whose nginx
+    // per-IP cap accepts the TCP connect but stalls/rejects the WS upgrade.
+    const heldUpgrades: net.Socket[] = [];
     const server = http.createServer();
-    server.on('connection', () => {
-      tcpConnected = true;
-    });
-    // Hold the upgrade open: no 101, no destroy (a missing 'upgrade' listener
-    // would make Node close the socket, which we explicitly do NOT want here).
     server.on('upgrade', (_req: http.IncomingMessage, socket: net.Socket) => {
-      held.push(socket);
+      heldUpgrades.push(socket);
     });
-
     await new Promise<void>(resolve => {
       server.listen(0, '127.0.0.1', () => resolve());
     });
     const { port } = server.address() as AddressInfo;
 
-    const ws = new GenericWebSocket({ wsURL: `ws://127.0.0.1:${port}/` });
+    // Track every underlying socket the library opens, so we can count — with
+    // real OS sockets — how many are left alive at the end.
+    const opened: RawSocket[] = [];
+    const WsCtor = _WebSocket as unknown as { new (url: string): RawSocket };
+    class TrackingWebSocket extends WsCtor {
+      constructor(url: string) {
+        super(url);
+        opened.push(this);
+      }
+    }
+
+    const ws = new GenericWebSocket({
+      wsURL: `ws://127.0.0.1:${port}/`,
+      retryConnectionInterval: 20,
+    });
+    (ws as unknown as SocketView).WebSocket = TrackingWebSocket;
+
+    // Open a connection, then retire-and-reopen several times — the churn an
+    // unhealthy/capped connection produces. endConnection() runs the same
+    // closeWs() teardown the reconnect path (onClose) uses.
     ws.setup();
-    const sock = (ws as unknown as SocketView).ws; // underlying isomorphic-ws
+    await delay(40);
+    const CYCLES = 8;
+    for (let i = 0; i < CYCLES; i += 1) {
+      ws.endConnection();
+      ws.setup();
+      await delay(40);
+    }
+    await delay(120);
 
-    // TCP is established but the handshake never completes -> CONNECTING (0).
-    await waitFor(() => tcpConnected);
-    expect(sock.readyState).toBe(0); // WebSocket.CONNECTING
-
-    // The fix under test: closeWs() must close/terminate regardless of
-    // readyState. Without it, a CONNECTING socket is only dereferenced and the
-    // underlying connection is leaked.
-    ws.closeWs();
-
-    // With the fix the socket is terminated -> readyState reaches CLOSED (3).
-    // Without the fix it stays CONNECTING (0) forever -> this times out.
-    await waitFor(() => sock.readyState === 3); // WebSocket.CLOSED
-    expect(sock.readyState).toBe(3);
+    // A socket still CONNECTING (0) or OPEN (1) is alive on the OS. With the fix
+    // only the final, current connection may be alive; every retired socket has
+    // been terminated. Without the fix retired CONNECTING sockets are merely
+    // dereferenced (never closed), so all of them stay alive and accumulate.
+    const alive = opened.filter(s => s.readyState === 0 || s.readyState === 1);
 
     ws.close();
-    held.forEach(s => {
+    opened.forEach(s => {
+      try {
+        if (typeof s.terminate === 'function') {
+          s.terminate();
+        } else {
+          s.close();
+        }
+      } catch (_e) {
+        // already gone
+      }
+    });
+    heldUpgrades.forEach(s => {
       try {
         s.destroy();
       } catch (_e) {
@@ -89,6 +109,11 @@ describe('BaseWebSocket socket leak (closeWs on a CONNECTING socket)', () => {
     await new Promise<void>(resolve => {
       server.close(() => resolve());
     });
+
+    // The churn actually happened: one initial + one per cycle.
+    expect(opened.length).toBe(CYCLES + 1);
+    // No accumulation: at most the single current connection is still alive.
+    expect(alive.length).toBeLessThanOrEqual(1);
   });
 });
 

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -14,6 +14,7 @@ export const DEFAULT_WS_OPTIONS = {
   heartbeatInterval: 3000,
   connectionTimeout: 5000,
   retryConnectionInterval: 1000,
+  maxRetryConnectionInterval: 30000,
   openConnectionTimeout: 20000,
   logger: getDefaultLogger(),
 };
@@ -23,6 +24,7 @@ export type WsOptions = {
   heartbeatInterval?: number;
   connectionTimeout?: number;
   retryConnectionInterval?: number;
+  maxRetryConnectionInterval?: number;
   openConnectionTimeout?: number;
   logger: ILogger;
 };
@@ -63,6 +65,14 @@ abstract class BaseWebSocket extends EventEmitter {
   // Retry connection interval in milliseconds
   private retryConnectionInterval: number;
 
+  // Maximum retry connection interval in milliseconds. The reconnection delay
+  // grows exponentially from retryConnectionInterval and is capped at this value.
+  private maxRetryConnectionInterval: number;
+
+  // Number of consecutive reconnection attempts since the last successful open.
+  // Drives the exponential backoff; reset to 0 in onOpen().
+  private retryAttempt: number;
+
   // Open connection timeout in milliseconds
   private openConnectionTimeout: number;
 
@@ -100,6 +110,7 @@ abstract class BaseWebSocket extends EventEmitter {
       heartbeatInterval,
       connectionTimeout,
       retryConnectionInterval,
+      maxRetryConnectionInterval,
       openConnectionTimeout,
       logger,
     } = {
@@ -115,6 +126,8 @@ abstract class BaseWebSocket extends EventEmitter {
     this.heartbeatInterval = heartbeatInterval;
     this.connectionTimeout = connectionTimeout;
     this.retryConnectionInterval = retryConnectionInterval;
+    this.maxRetryConnectionInterval = maxRetryConnectionInterval;
+    this.retryAttempt = 0;
     this.openConnectionTimeout = openConnectionTimeout;
     this.connectedDate = null;
     this.latestSetupDate = null;
@@ -187,8 +200,28 @@ abstract class BaseWebSocket extends EventEmitter {
     this.ws.onerror = () => {};
     this.ws.onmessage = () => {};
 
-    if (this.ws.readyState === _WebSocket.OPEN) {
-      this.ws.close();
+    // Always tear down the underlying socket, regardless of readyState. A socket
+    // still CONNECTING (TCP established, HTTP 101 upgrade not yet completed) — or
+    // CLOSING — was previously only dereferenced (this.ws = null) without being
+    // closed when readyState !== OPEN. The OS keeps that socket ESTABLISHED until
+    // keepalive eventually reaps it (can be hours), so under reconnect churn
+    // against a connection-capped server (e.g. nginx limit_conn rejecting the
+    // upgrade after the TCP connect) each retry leaks one ESTABLISHED connection,
+    // which in turn consumes more of the cap — a self-reinforcing loop.
+    try {
+      const sock = this.ws as unknown as {
+        terminate?: () => void;
+        close: (code?: number, reason?: string) => void;
+      };
+      if (typeof sock.terminate === 'function') {
+        // node 'ws': forcibly destroys the socket, including CONNECTING/half-open.
+        sock.terminate();
+      } else {
+        // browser WebSocket: close() also aborts an in-progress CONNECTING handshake.
+        sock.close();
+      }
+    } catch (err) {
+      this.logger.warn('Error while closing websocket', { error: `${err}` });
     }
 
     this.ws = null;
@@ -229,6 +262,9 @@ abstract class BaseWebSocket extends EventEmitter {
       return;
     }
 
+    // Connection established: reset the reconnection backoff so the next
+    // unexpected drop retries quickly again.
+    this.retryAttempt = 0;
     this.connected = true;
     this.connectedDate = new Date();
     this.heartbeat = setInterval(() => {
@@ -267,6 +303,24 @@ abstract class BaseWebSocket extends EventEmitter {
   }
 
   /**
+   * Compute the next reconnection delay using exponential backoff with jitter,
+   * capped at maxRetryConnectionInterval. A flat retry interval hammers a down
+   * or connection-capped server at a fixed rate with no relief; backoff lets the
+   * server recover and de-synchronizes many clients sharing one egress IP.
+   */
+  getReconnectDelay() {
+    const exp = Math.min(
+      this.maxRetryConnectionInterval,
+      this.retryConnectionInterval * 2 ** this.retryAttempt,
+    );
+    // Full jitter on the top quarter of the interval keeps a healthy floor while
+    // spreading retries out across clients.
+    const jitter = Math.floor(Math.random() * (exp / 4));
+    this.retryAttempt += 1;
+    return exp + jitter;
+  }
+
+  /**
    * Method called when websocket connection is closed
    */
   onClose() {
@@ -279,7 +333,7 @@ abstract class BaseWebSocket extends EventEmitter {
 
     this.clearSetupTimer();
     this.clearPongTimeoutTimer();
-    this.setupTimer = setTimeout(() => this.setup(), this.retryConnectionInterval);
+    this.setupTimer = setTimeout(() => this.setup(), this.getReconnectDelay());
     clearInterval(this.heartbeat || undefined); // XXX: We should probably handle a missing heartbeat
   }
 

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -311,7 +311,7 @@ abstract class BaseWebSocket extends EventEmitter {
   getReconnectDelay() {
     const exp = Math.min(
       this.maxRetryConnectionInterval,
-      this.retryConnectionInterval * 2 ** this.retryAttempt,
+      this.retryConnectionInterval * 2 ** this.retryAttempt
     );
     // Full jitter on the top quarter of the interval keeps a healthy floor while
     // spreading retries out across clients.


### PR DESCRIPTION
### Problem
`GenericWebSocket.closeWs()` only calls `ws.close()` when `readyState === OPEN`:

```js
if (this.ws.readyState === _WebSocket.OPEN) {
  this.ws.close();
}
this.ws = null;
```
A socket killed while still CONNECTING (TCP established, HTTP 101 not yet
received) -- or CLOSING -- is dereferenced (this.ws = null) without being
closed, so the underlying connection stays ESTABLISHED on the OS until keepalive
reaps it (can be hours).

Reconnect is a flat 1s retry with no backoff, and three paths funnel into it
(onError, ping-timeout onConnectionDown, and a normal close). Against a
connection-capped server (e.g. nginx limit_conn rejecting the upgrade after
the TCP connect, so the socket is still CONNECTING), every retry leaks one
ESTABLISHED socket, which consumes more of the per-IP cap and causes more
rejected upgrades: a self-reinforcing loop that ratchets a single client up to
the cap and parks there.

Observed in production: one active wallet-headless held ~40 ESTABLISHED
connections to the fullnode (an idle wallet that never reconnects stayed at 1).


### Acceptance Criteria

- closeWs() always tears the socket down, regardless of readyState:
terminate() on node's ws (force-destroys CONNECTING/half-open sockets),
close() in browsers (aborts a CONNECTING handshake).
- Reconnect uses capped exponential backoff with jitter instead of a flat
1s retry, reset on a successful open. New option maxRetryConnectionInterval
(default 30000).

### Behavior change

Reconnect timing changes from a flat retryConnectionInterval (1s) to
exponential backoff from retryConnectionInterval up to
maxRetryConnectionInterval, reset on each successful connection. Defaults are
backward compatible (base still 1s); only the escalation on repeated failures
is new.

Refs #112.

# Choose a pull request template

- [feature PR](?template=feature.md&quick_pull=1)
- [Release process](https://github.com/HathorNetwork/hathor-wallet-lib/compare/release...master?template=release.md&quick_pull=1)
