### PR TITLE
feat(shielded): validate inputs and harden error handling in createShieldedOutputs

### DIFF
--- a/__tests__/shielded/creation.test.ts
+++ b/__tests__/shielded/creation.test.ts
@@ -86,9 +86,15 @@ describe('createShieldedOutputs', () => {
     });
     const proposals = [makeProposal(), makeProposal()];
 
-    await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow(
-      'crypto failure on output 0'
-    );
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network
+    ).catch(e => e);
+    // VULN-1: the provider error is preserved as `cause`, NOT flattened into
+    // `.message` (which would re-leak provider-supplied strings to logs).
+    expect(err).toBeInstanceOf(Error);
+    expect(err.cause?.message).toContain('crypto failure on output 0');
   });
 
   it('should propagate crypto provider error on second output', async () => {
@@ -109,9 +115,12 @@ describe('createShieldedOutputs', () => {
     });
     const proposals = [makeProposal({ value: 60n }), makeProposal({ value: 40n })];
 
-    await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow(
-      'crypto failure on output 1'
-    );
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network
+    ).catch(e => e);
+    expect(err.cause?.message).toContain('crypto failure on output 1');
   });
 
   it('should create FullShielded outputs with surjection proofs', async () => {
@@ -161,8 +170,9 @@ describe('createShieldedOutputs validation guards', () => {
     // scanPubkey length guard.
     const proposals = [makeProposal({ scanPubkey: '02aa' /* 2 bytes */ }), makeProposal()];
 
+    // INP-02: the canonical-hex guard fires first for a non-66-hex string.
     await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow(
-      /scanPubkey must be 33 bytes, got 2/
+      /scanPubkey must be 66 hex characters/
     );
     // Crypto provider must not have been called for the invalid input.
     expect(provider.createAmountShieldedOutput).not.toHaveBeenCalled();
@@ -224,9 +234,13 @@ describe('createShieldedOutputs validation guards', () => {
       makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED, value: 40n }),
     ];
 
-    await expect(
-      createShieldedOutputs(proposals, provider, network, [{ tokenUid: '00' }])
-    ).rejects.toThrow(/no assetBlindingFactor for FullShielded output/);
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network,
+      [{ tokenUid: '00' }]
+    ).catch(e => e);
+    expect(err.cause?.message).toMatch(/no assetBlindingFactor for FullShielded output/);
   });
 
   it('rejects when provider returns FullShielded result without assetBlindingFactor (last)', async () => {
@@ -254,9 +268,13 @@ describe('createShieldedOutputs validation guards', () => {
       makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED, value: 40n }),
     ];
 
-    await expect(
-      createShieldedOutputs(proposals, provider, network, [{ tokenUid: '00' }])
-    ).rejects.toThrow(/no assetBlindingFactor for FullShielded output/);
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network,
+      [{ tokenUid: '00' }]
+    ).catch(e => e);
+    expect(err.cause?.message).toMatch(/no assetBlindingFactor for FullShielded output/);
   });
 
   it('rejects when provider returns FullShielded result without assetCommitment', async () => {
@@ -280,8 +298,150 @@ describe('createShieldedOutputs validation guards', () => {
       makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED, value: 40n }),
     ];
 
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network,
+      [{ tokenUid: '00' }]
+    ).catch(e => e);
+    expect(err.cause?.message).toMatch(/no assetCommitment for FullShielded output/);
+  });
+});
+
+describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REVIEW)', () => {
+  const SECRET_TOKEN = 'ab'.repeat(32); // 32-byte FullShielded token UID (the hidden secret)
+
+  // VULN-1
+  it('redacts the hidden token UID in a FullShielded build error (cause preserved)', async () => {
+    const provider = makeMockProvider({
+      createShieldedOutputWithBothBlindings: jest
+        .fn()
+        .mockRejectedValue(new Error('inner crypto failure')),
+    });
+    const proposals = [
+      makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED, token: SECRET_TOKEN }),
+      makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED, token: SECRET_TOKEN }),
+    ];
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network,
+      [{ tokenUid: SECRET_TOKEN }]
+    ).catch(e => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).not.toContain(SECRET_TOKEN);
+    expect(err.message).toContain('<hidden>');
+    expect(err.cause).toBeInstanceOf(Error); // full inner error still available locally
+  });
+
+  it('still surfaces the (public) token for an AmountShielded build error', async () => {
+    const provider = makeMockProvider({
+      createAmountShieldedOutput: jest.fn().mockRejectedValue(new Error('inner')),
+    });
+    const proposals = [makeProposal({ token: '00' }), makeProposal({ token: '00' })];
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network
+    ).catch(e => e);
+    expect(err.message).toContain('token=00');
+  });
+
+  // VULN-2 / DISC-02
+  it.each([
+    ['zero', 0n],
+    ['negative', -1n],
+    ['exactly 2^40', 1n << 40n],
+    ['above 2^40', (1n << 40n) + 7n],
+  ])('rejects out-of-range value (%s)', async (_label, value) => {
+    const provider = makeMockProvider();
+    const proposals = [makeProposal({ value }), makeProposal()];
+    await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow(
+      'value must be in [1, 2^40)'
+    );
+  });
+
+  it('accepts a value just below 2^40', async () => {
+    const provider = makeMockProvider();
+    const proposals = [makeProposal({ value: (1n << 40n) - 1n }), makeProposal({ value: 1n })];
+    await expect(createShieldedOutputs(proposals, provider, network)).resolves.toHaveLength(2);
+  });
+
+  // CRY-01
+  it('rejects an oversized surjection domain before the uncatchable native abort', async () => {
+    const provider = makeMockProvider();
+    const proposals = [
+      makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED }),
+      makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED }),
+    ];
+    const inputGenerators = Array.from({ length: 257 }, () => ({ tokenUid: '00' }));
     await expect(
-      createShieldedOutputs(proposals, provider, network, [{ tokenUid: '00' }])
-    ).rejects.toThrow(/no assetCommitment for FullShielded output/);
+      createShieldedOutputs(proposals, provider, network, inputGenerators)
+    ).rejects.toThrow('surjection-proof');
+  });
+
+  // INP-02
+  it('rejects a truncated scanPubkey that still decodes to a valid byte length', async () => {
+    const provider = makeMockProvider();
+    // TEST_SCAN_PUBKEY is valid 66-hex; trailing 'zz' makes Buffer.from truncate
+    // back to the valid 33 bytes (the old length-only gate passed), but it is not
+    // canonical 66-hex → must be rejected (would otherwise be unspendable).
+    const proposals = [makeProposal({ scanPubkey: `${TEST_SCAN_PUBKEY}zz` }), makeProposal()];
+    await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow(
+      'hex characters'
+    );
+  });
+
+  // INP-03
+  it('rejects more than MAX_SHIELDED_OUTPUTS (32) proposals', async () => {
+    const provider = makeMockProvider();
+    const proposals = Array.from({ length: 33 }, () => makeProposal());
+    await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow('At most 32');
+  });
+
+  // INP-04
+  it.each([
+    ['too large', 2 ** 32],
+    ['negative', -1],
+    ['non-integer', 1.5],
+  ])('rejects invalid timelock (%s)', async (_label, timelock) => {
+    const provider = makeMockProvider();
+    const proposals = [makeProposal({ timelock }), makeProposal()];
+    await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow('timelock');
+  });
+
+  // INP-07
+  it('rejects a wrong-length assetBlindingFactor in inputGenerators', async () => {
+    const provider = makeMockProvider();
+    const proposals = [
+      makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED }),
+      makeProposal({ shieldedMode: ShieldedOutputMode.FULLY_SHIELDED }),
+    ];
+    await expect(
+      createShieldedOutputs(proposals, provider, network, [
+        { tokenUid: '00', assetBlindingFactor: Buffer.alloc(16) }, // 16 != 32
+      ])
+    ).rejects.toThrow('assetBlindingFactor must be 32');
+  });
+
+  // SUP-02
+  it('rejects provider output with a wrong-length commitment', async () => {
+    const provider = makeMockProvider({
+      createAmountShieldedOutput: jest.fn().mockResolvedValue({
+        ephemeralPubkey: Buffer.alloc(33, 0x02),
+        commitment: Buffer.alloc(10, 0x03), // wrong: should be 33
+        rangeProof: Buffer.alloc(100, 0x04),
+        blindingFactor: Buffer.alloc(32, 0x05),
+      }),
+    });
+    const proposals = [makeProposal(), makeProposal()];
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network
+    ).catch(e => e);
+    // The provider-shape error is thrown inside the per-output try → rewrapped;
+    // the original is preserved as `cause`.
+    expect(err.cause?.message ?? err.message).toContain('commitment');
   });
 });

--- a/__tests__/shielded/creation.test.ts
+++ b/__tests__/shielded/creation.test.ts
@@ -91,7 +91,7 @@ describe('createShieldedOutputs', () => {
       provider,
       network
     ).catch(e => e);
-    // VULN-1: the provider error is preserved as `cause`, NOT flattened into
+    // The provider error is preserved as `cause`, NOT flattened into
     // `.message` (which would re-leak provider-supplied strings to logs).
     expect(err).toBeInstanceOf(Error);
     expect(err.cause?.message).toContain('crypto failure on output 0');
@@ -170,7 +170,7 @@ describe('createShieldedOutputs validation guards', () => {
     // scanPubkey length guard.
     const proposals = [makeProposal({ scanPubkey: '02aa' /* 2 bytes */ }), makeProposal()];
 
-    // INP-02: the canonical-hex guard fires first for a non-66-hex string.
+    // The canonical-hex guard fires first for a non-66-hex string.
     await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow(
       /scanPubkey must be 66 hex characters/
     );
@@ -308,10 +308,9 @@ describe('createShieldedOutputs validation guards', () => {
   });
 });
 
-describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REVIEW)', () => {
+describe('createShieldedOutputs — security hardening', () => {
   const SECRET_TOKEN = 'ab'.repeat(32); // 32-byte FullShielded token UID (the hidden secret)
 
-  // VULN-1
   it('redacts the hidden token UID in a FullShielded build error (cause preserved)', async () => {
     const provider = makeMockProvider({
       createShieldedOutputWithBothBlindings: jest
@@ -347,7 +346,6 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     expect(err.message).toContain('token=00');
   });
 
-  // VULN-2 / DISC-02
   it.each([
     ['zero', 0n],
     ['negative', -1n],
@@ -367,7 +365,6 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     await expect(createShieldedOutputs(proposals, provider, network)).resolves.toHaveLength(2);
   });
 
-  // CRY-01
   it('rejects an oversized surjection domain before the uncatchable native abort', async () => {
     const provider = makeMockProvider();
     const proposals = [
@@ -380,7 +377,6 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     ).rejects.toThrow('surjection-proof');
   });
 
-  // INP-02
   it('rejects a truncated scanPubkey that still decodes to a valid byte length', async () => {
     const provider = makeMockProvider();
     // TEST_SCAN_PUBKEY is valid 66-hex; trailing 'zz' makes Buffer.from truncate
@@ -392,14 +388,12 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     );
   });
 
-  // INP-03
   it('rejects more than MAX_SHIELDED_OUTPUTS (32) proposals', async () => {
     const provider = makeMockProvider();
     const proposals = Array.from({ length: 33 }, () => makeProposal());
     await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow('At most 32');
   });
 
-  // INP-04
   it.each([
     ['too large', 2 ** 32],
     ['negative', -1],
@@ -410,7 +404,6 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     await expect(createShieldedOutputs(proposals, provider, network)).rejects.toThrow('timelock');
   });
 
-  // INP-07
   it('rejects a wrong-length assetBlindingFactor in inputGenerators', async () => {
     const provider = makeMockProvider();
     const proposals = [
@@ -424,7 +417,6 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     ).rejects.toThrow('assetBlindingFactor must be 32');
   });
 
-  // SUP-02
   it('rejects provider output with a wrong-length commitment', async () => {
     const provider = makeMockProvider({
       createAmountShieldedOutput: jest.fn().mockResolvedValue({
@@ -443,5 +435,42 @@ describe('createShieldedOutputs — security hardening (CREATION_TS_SECURITY_REV
     // The provider-shape error is thrown inside the per-output try → rewrapped;
     // the original is preserved as `cause`.
     expect(err.cause?.message ?? err.message).toContain('commitment');
+  });
+
+  it('rejects provider output whose commitment is a right-length string (not a byte view)', async () => {
+    // A length-only guard would wave a 33-char string through; the type gate
+    // rejects anything that is not a Buffer/Uint8Array.
+    const provider = makeMockProvider({
+      createAmountShieldedOutput: jest.fn().mockResolvedValue({
+        ephemeralPubkey: Buffer.alloc(33, 0x02),
+        commitment: 'a'.repeat(33), // 33 chars, but a string — not a byte view
+        rangeProof: Buffer.alloc(100, 0x04),
+        blindingFactor: Buffer.alloc(32, 0x05),
+      }),
+    });
+    const proposals = [makeProposal(), makeProposal()];
+    const err: Error & { cause?: Error } = await createShieldedOutputs(
+      proposals,
+      provider,
+      network
+    ).catch(e => e);
+    expect(err.cause?.message ?? err.message).toContain('commitment');
+  });
+
+  it('accepts provider output returned as Uint8Array rather than Buffer', async () => {
+    // A structurally-conformant provider (e.g. the wasm backend) may hand back
+    // Uint8Array instead of Buffer; the guard must accept it (a Buffer IS a
+    // Uint8Array), not reject it as Buffer.isBuffer would.
+    const u8 = (len: number, fill: number) => Uint8Array.from(Buffer.alloc(len, fill));
+    const provider = makeMockProvider({
+      createAmountShieldedOutput: jest.fn().mockResolvedValue({
+        ephemeralPubkey: u8(33, 0x02),
+        commitment: u8(33, 0x03),
+        rangeProof: u8(10, 0x04),
+        blindingFactor: u8(32, 0x05),
+      }),
+    });
+    const proposals = [makeProposal(), makeProposal()];
+    await expect(createShieldedOutputs(proposals, provider, network)).resolves.toHaveLength(2);
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -278,6 +278,27 @@ export const MAX_SURJECTION_PROOF_SIZE: number = 4096;
 export const MAX_SHIELDED_OUTPUT_SCRIPT_SIZE: number = 1024;
 
 /**
+ * Maximum surjection-proof domain size (one entry per input generator).
+ * secp256k1-zkp aborts UNCATCHABLY (SIGABRT) past this limit, so the wallet
+ * must reject oversized domains before calling the prover.
+ */
+export const MAX_SURJECTION_DOMAIN: number = 256;
+
+/**
+ * Exclusive upper bound for a shielded output value. The shipped range proof
+ * (`@hathor/ct-crypto-node`, min_bits=40) covers `[1, 2^40)`; the fullnode
+ * enforces no explicit value ceiling (only a range-proof byte-size cap), so the
+ * wallet is the only place an over-cap value can be caught (balance is verified
+ * by commitment, never by cleartext value).
+ */
+export const MAX_SHIELDED_OUTPUT_VALUE: OutputValueType = 1n << 40n;
+
+/**
+ * Byte length of a secp256k1 scalar (a blinding factor / tweak).
+ */
+export const BLINDING_FACTOR_SIZE_BYTES: number = 32;
+
+/**
  * Maximum number of fee entries in a FeeHeader
  */
 export const MAX_FEE_HEADER_ENTRIES: number = 16;

--- a/src/shielded/creation.ts
+++ b/src/shielded/creation.ts
@@ -56,16 +56,23 @@ interface FullShieldedBuildContext extends ShieldedOutputBuildContext {
   inputGenerators: InputGeneratorInfo[];
 }
 
-// ─── provider-output shape checks (SUP-02) ─────────────────────────────────
+// ─── provider-output shape checks ──────────────────────────────────────────
 //
 // We trust the crypto provider's MATH (re-verifying every proof would double
 // the cost and the provider is pinned), but a buggy or version-skewed provider
-// returning a wrong-size buffer would serialize to invalid wire data the
-// fullnode rejects only post-PoW. These cheap length asserts fail loud at the
-// boundary instead.
+// returning a wrong-size or wrong-type value would serialize to invalid wire
+// data the fullnode rejects only post-PoW. These cheap type+length asserts fail
+// loud at the boundary instead.
+//
+// The type gate is `instanceof Uint8Array`, not `Buffer.isBuffer`: a real Buffer
+// IS a Uint8Array (so the native and mobile providers pass), but a provider that
+// returns a bare Uint8Array — a structurally-conformant shape the wasm provider
+// already produces — is still accepted, while a string / plain object of the
+// right `.length` (which a length-only check would wave through) is rejected.
+// Downstream serialization (Buffer.concat / .length) accepts any Uint8Array.
 
 function assertProviderBuffer(buf: Buffer | undefined, expectedLen: number, name: string): void {
-  if (!buf || buf.length !== expectedLen) {
+  if (!(buf instanceof Uint8Array) || buf.length !== expectedLen) {
     throw new Error(
       `Crypto provider returned ${name} of ${buf?.length ?? 0} bytes, expected ${expectedLen}`
     );
@@ -73,7 +80,7 @@ function assertProviderBuffer(buf: Buffer | undefined, expectedLen: number, name
 }
 
 function assertProviderProof(buf: Buffer | undefined, maxLen: number, name: string): void {
-  if (!buf || buf.length < 1 || buf.length > maxLen) {
+  if (!(buf instanceof Uint8Array) || buf.length < 1 || buf.length > maxLen) {
     throw new Error(
       `Crypto provider returned ${name} of ${buf?.length ?? 0} bytes, expected [1, ${maxLen}]`
     );
@@ -128,7 +135,7 @@ async function buildAmountShieldedOutput(
     );
   }
 
-  // SUP-02: shape-check the provider output before it reaches the wire.
+  // Shape-check the provider output before it reaches the wire.
   assertProviderBuffer(
     cryptoResult.ephemeralPubkey,
     COMPRESSED_PUBKEY_SIZE_BYTES,
@@ -249,7 +256,7 @@ async function buildFullShieldedOutput(
     throw new Error('Crypto provider returned no assetCommitment for FullShielded output');
   }
 
-  // SUP-02: shape-check the provider output before it reaches the wire.
+  // Shape-check the provider output before it reaches the wire.
   assertProviderBuffer(
     cryptoResult.ephemeralPubkey,
     COMPRESSED_PUBKEY_SIZE_BYTES,
@@ -328,7 +335,7 @@ export async function createShieldedOutputs(
       'At least 2 shielded outputs are required (hathor-core trivial-commitment rule)'
     );
   }
-  // INP-03: bound the count up front. The build loop is synchronous-ish work
+  // Bound the count up front. The build loop is synchronous-ish work
   // per output; without this an oversized batch stalls the event loop on work
   // the fullnode rejects anyway (it enforces the same MAX_SHIELDED_OUTPUTS).
   if (proposals.length > MAX_SHIELDED_OUTPUTS) {
@@ -341,7 +348,7 @@ export async function createShieldedOutputs(
   // Validate inputs upfront before expensive crypto work
   const hasFullShielded = proposals.some(p => p.shieldedMode === ShieldedOutputMode.FULLY_SHIELDED);
   for (const [idx, proposal] of proposals.entries()) {
-    // INP-02: reject a truncated/typo'd scanPubkey. `Buffer.from(hex)` silently
+    // Reject a truncated/typo'd scanPubkey. `Buffer.from(hex)` silently
     // truncates at the first non-hex pair (e.g. '02'+…+'zz' decodes to a
     // length-valid-but-WRONG key), so check the source string is canonical
     // 66-hex AND a real on-curve compressed point. A length-only gate would
@@ -366,15 +373,16 @@ export async function createShieldedOutputs(
       );
     }
 
-    // VULN-2 / DISC-02: bound the value to the range proof's domain. The
-    // fullnode enforces no explicit value ceiling (only a proof byte-size cap),
-    // so an over-cap value would build a node-accepted protocol violation and
-    // leak the amount magnitude via the on-wire proof length.
+    // Bound the value to the range proof's domain. The fullnode enforces no
+    // explicit value ceiling (only a proof byte-size cap), so an over-cap value
+    // would build a node-accepted protocol violation and leak the amount
+    // magnitude via the on-wire proof length. The error must not echo the value
+    // itself — it is exactly the secret a shielded output hides.
     if (proposal.value < 1n || proposal.value >= MAX_SHIELDED_OUTPUT_VALUE) {
-      throw new Error(`Shielded output ${idx}: value must be in [1, 2^40), got ${proposal.value}`);
+      throw new Error(`Shielded output ${idx}: value must be in [1, 2^40)`);
     }
 
-    // INP-04: timelock is silently coerced (setUint32, mod 2^32) into the
+    // Timelock is silently coerced (setUint32, mod 2^32) into the
     // on-chain script downstream; reject out-of-range values up front.
     if (
       proposal.timelock != null &&
@@ -392,7 +400,13 @@ export async function createShieldedOutputs(
       'FullShielded outputs require at least one input token UID for surjection proof domain'
     );
   }
-  // CRY-01: the surjection-proof domain has one entry per input generator;
+  // This inputGenerators validation is intentionally NOT gated behind
+  // `hasFullShielded`. The send path builds inputGenerators from every
+  // token-bearing input regardless of output mode, and rejecting malformed
+  // crypto-domain metadata at the boundary is the correct fail-loud behavior
+  // even for a batch that happens not to consume it.
+  //
+  // The surjection-proof domain has one entry per input generator;
   // exceeding the prover's limit triggers an UNCATCHABLE native abort (SIGABRT),
   // so reject an oversized domain here, before any crypto runs.
   if (inputGenerators.length > MAX_SURJECTION_DOMAIN) {
@@ -416,7 +430,7 @@ export async function createShieldedOutputs(
         `inputGenerators[${idx}]: token UID must be ${TX_HASH_SIZE_BYTES} bytes, got ${inputTokenBuf.length}`
       );
     }
-    // INP-07: a wrong-length assetBlindingFactor would feed a garbage scalar
+    // A wrong-length assetBlindingFactor would feed a garbage scalar
     // into createAssetCommitment; validate length symmetric with the token
     // check. (Its *correctness* vs the real tx input is the caller's job —
     // creation.ts has no access to the transaction's inputs.)
@@ -480,7 +494,7 @@ export async function createShieldedOutputs(
       createdOutputs.push(built.createdEntry);
     } catch (e) {
       const mode = ShieldedOutputMode[proposal.shieldedMode];
-      // VULN-1: the token UID is precisely the secret a FullShielded output
+      // The token UID is precisely the secret a FullShielded output
       // hides (it has no on-chain slot — it lives only inside asset_commitment).
       // Never leak it into the error MESSAGE (which flows to logs/telemetry):
       // redact it for FullShielded. The full inner error is preserved via

--- a/src/shielded/creation.ts
+++ b/src/shielded/creation.ts
@@ -6,13 +6,20 @@
  */
 
 import {
+  BLINDING_FACTOR_SIZE_BYTES,
   COMPRESSED_PUBKEY_SIZE_BYTES,
+  MAX_RANGE_PROOF_SIZE,
+  MAX_SHIELDED_OUTPUT_VALUE,
+  MAX_SHIELDED_OUTPUTS,
+  MAX_SURJECTION_DOMAIN,
+  MAX_SURJECTION_PROOF_SIZE,
   NATIVE_TOKEN_UID,
   NATIVE_TOKEN_UID_HEX,
   TX_HASH_SIZE_BYTES,
   ZERO_TWEAK,
 } from '../constants';
 import { getAddressType } from '../utils/address';
+import { assertValidCompressedPubkey } from '../utils/shieldedAddress';
 import transactionUtils from '../utils/transaction';
 import Network from '../models/network';
 import {
@@ -47,6 +54,30 @@ interface ShieldedOutputBuildContext {
 
 interface FullShieldedBuildContext extends ShieldedOutputBuildContext {
   inputGenerators: InputGeneratorInfo[];
+}
+
+// ─── provider-output shape checks (SUP-02) ─────────────────────────────────
+//
+// We trust the crypto provider's MATH (re-verifying every proof would double
+// the cost and the provider is pinned), but a buggy or version-skewed provider
+// returning a wrong-size buffer would serialize to invalid wire data the
+// fullnode rejects only post-PoW. These cheap length asserts fail loud at the
+// boundary instead.
+
+function assertProviderBuffer(buf: Buffer | undefined, expectedLen: number, name: string): void {
+  if (!buf || buf.length !== expectedLen) {
+    throw new Error(
+      `Crypto provider returned ${name} of ${buf?.length ?? 0} bytes, expected ${expectedLen}`
+    );
+  }
+}
+
+function assertProviderProof(buf: Buffer | undefined, maxLen: number, name: string): void {
+  if (!buf || buf.length < 1 || buf.length > maxLen) {
+    throw new Error(
+      `Crypto provider returned ${name} of ${buf?.length ?? 0} bytes, expected [1, ${maxLen}]`
+    );
+  }
 }
 
 // ─── per-mode helpers ──────────────────────────────────────────────────────
@@ -96,6 +127,16 @@ async function buildAmountShieldedOutput(
       vbf
     );
   }
+
+  // SUP-02: shape-check the provider output before it reaches the wire.
+  assertProviderBuffer(
+    cryptoResult.ephemeralPubkey,
+    COMPRESSED_PUBKEY_SIZE_BYTES,
+    'ephemeralPubkey'
+  );
+  assertProviderBuffer(cryptoResult.commitment, COMPRESSED_PUBKEY_SIZE_BYTES, 'commitment');
+  assertProviderBuffer(cryptoResult.blindingFactor, BLINDING_FACTOR_SIZE_BYTES, 'blindingFactor');
+  assertProviderProof(cryptoResult.rangeProof, MAX_RANGE_PROOF_SIZE, 'rangeProof');
 
   return {
     createdEntry: {
@@ -208,6 +249,26 @@ async function buildFullShieldedOutput(
     throw new Error('Crypto provider returned no assetCommitment for FullShielded output');
   }
 
+  // SUP-02: shape-check the provider output before it reaches the wire.
+  assertProviderBuffer(
+    cryptoResult.ephemeralPubkey,
+    COMPRESSED_PUBKEY_SIZE_BYTES,
+    'ephemeralPubkey'
+  );
+  assertProviderBuffer(cryptoResult.commitment, COMPRESSED_PUBKEY_SIZE_BYTES, 'commitment');
+  assertProviderBuffer(cryptoResult.blindingFactor, BLINDING_FACTOR_SIZE_BYTES, 'blindingFactor');
+  assertProviderProof(cryptoResult.rangeProof, MAX_RANGE_PROOF_SIZE, 'rangeProof');
+  assertProviderBuffer(
+    cryptoResult.assetCommitment,
+    COMPRESSED_PUBKEY_SIZE_BYTES,
+    'assetCommitment'
+  );
+  assertProviderBuffer(
+    cryptoResult.assetBlindingFactor,
+    BLINDING_FACTOR_SIZE_BYTES,
+    'assetBlindingFactor'
+  );
+
   const codomainTag = await cryptoProvider.deriveTag(tokenUidBuf);
   const domain = await buildSurjectionDomain(inputGenerators, cryptoProvider);
   const surjectionProof = await cryptoProvider.createSurjectionProof(
@@ -215,6 +276,7 @@ async function buildFullShieldedOutput(
     cryptoResult.assetBlindingFactor,
     domain
   );
+  assertProviderProof(surjectionProof, MAX_SURJECTION_PROOF_SIZE, 'surjectionProof');
 
   return {
     createdEntry: {
@@ -266,16 +328,34 @@ export async function createShieldedOutputs(
       'At least 2 shielded outputs are required (hathor-core trivial-commitment rule)'
     );
   }
+  // INP-03: bound the count up front. The build loop is synchronous-ish work
+  // per output; without this an oversized batch stalls the event loop on work
+  // the fullnode rejects anyway (it enforces the same MAX_SHIELDED_OUTPUTS).
+  if (proposals.length > MAX_SHIELDED_OUTPUTS) {
+    throw new Error(
+      `At most ${MAX_SHIELDED_OUTPUTS} shielded outputs are allowed, got ${proposals.length} ` +
+        `(hathor-core consensus limit)`
+    );
+  }
 
   // Validate inputs upfront before expensive crypto work
   const hasFullShielded = proposals.some(p => p.shieldedMode === ShieldedOutputMode.FULLY_SHIELDED);
   for (const [idx, proposal] of proposals.entries()) {
-    const pubkeyBuf = Buffer.from(proposal.scanPubkey, 'hex');
-    if (pubkeyBuf.length !== COMPRESSED_PUBKEY_SIZE_BYTES) {
+    // INP-02: reject a truncated/typo'd scanPubkey. `Buffer.from(hex)` silently
+    // truncates at the first non-hex pair (e.g. '02'+…+'zz' decodes to a
+    // length-valid-but-WRONG key), so check the source string is canonical
+    // 66-hex AND a real on-curve compressed point. A length-only gate would
+    // build an output nobody can spend (silent fund loss).
+    if (!/^[0-9a-fA-F]{66}$/.test(proposal.scanPubkey)) {
       throw new Error(
-        `Shielded output ${idx}: scanPubkey must be ${COMPRESSED_PUBKEY_SIZE_BYTES} bytes, got ${pubkeyBuf.length}`
+        `Shielded output ${idx}: scanPubkey must be ${COMPRESSED_PUBKEY_SIZE_BYTES * 2} hex characters`
       );
     }
+    assertValidCompressedPubkey(
+      Buffer.from(proposal.scanPubkey, 'hex'),
+      `shielded output ${idx} scanPubkey`
+    );
+
     const tokenBuf = Buffer.from(
       proposal.token === NATIVE_TOKEN_UID ? NATIVE_TOKEN_UID_HEX : proposal.token,
       'hex'
@@ -285,10 +365,40 @@ export async function createShieldedOutputs(
         `Shielded output ${idx}: token UID must be ${TX_HASH_SIZE_BYTES} bytes, got ${tokenBuf.length}`
       );
     }
+
+    // VULN-2 / DISC-02: bound the value to the range proof's domain. The
+    // fullnode enforces no explicit value ceiling (only a proof byte-size cap),
+    // so an over-cap value would build a node-accepted protocol violation and
+    // leak the amount magnitude via the on-wire proof length.
+    if (proposal.value < 1n || proposal.value >= MAX_SHIELDED_OUTPUT_VALUE) {
+      throw new Error(`Shielded output ${idx}: value must be in [1, 2^40), got ${proposal.value}`);
+    }
+
+    // INP-04: timelock is silently coerced (setUint32, mod 2^32) into the
+    // on-chain script downstream; reject out-of-range values up front.
+    if (
+      proposal.timelock != null &&
+      (!Number.isInteger(proposal.timelock) ||
+        proposal.timelock < 0 ||
+        proposal.timelock > 0xffffffff)
+    ) {
+      throw new Error(
+        `Shielded output ${idx}: timelock must be an integer in [0, 2^32), got ${proposal.timelock}`
+      );
+    }
   }
   if (hasFullShielded && inputGenerators.length === 0) {
     throw new Error(
       'FullShielded outputs require at least one input token UID for surjection proof domain'
+    );
+  }
+  // CRY-01: the surjection-proof domain has one entry per input generator;
+  // exceeding the prover's limit triggers an UNCATCHABLE native abort (SIGABRT),
+  // so reject an oversized domain here, before any crypto runs.
+  if (inputGenerators.length > MAX_SURJECTION_DOMAIN) {
+    throw new Error(
+      `inputGenerators length ${inputGenerators.length} exceeds the surjection-proof ` +
+        `domain limit of ${MAX_SURJECTION_DOMAIN}`
     );
   }
   // Validate inputGenerators tokenUid length up front for the same reason
@@ -304,6 +414,19 @@ export async function createShieldedOutputs(
     if (inputTokenBuf.length !== TX_HASH_SIZE_BYTES) {
       throw new Error(
         `inputGenerators[${idx}]: token UID must be ${TX_HASH_SIZE_BYTES} bytes, got ${inputTokenBuf.length}`
+      );
+    }
+    // INP-07: a wrong-length assetBlindingFactor would feed a garbage scalar
+    // into createAssetCommitment; validate length symmetric with the token
+    // check. (Its *correctness* vs the real tx input is the caller's job —
+    // creation.ts has no access to the transaction's inputs.)
+    if (
+      info.assetBlindingFactor &&
+      info.assetBlindingFactor.length !== BLINDING_FACTOR_SIZE_BYTES
+    ) {
+      throw new Error(
+        `inputGenerators[${idx}]: assetBlindingFactor must be ${BLINDING_FACTOR_SIZE_BYTES} bytes, ` +
+          `got ${info.assetBlindingFactor.length}`
       );
     }
   }
@@ -357,8 +480,16 @@ export async function createShieldedOutputs(
       createdOutputs.push(built.createdEntry);
     } catch (e) {
       const mode = ShieldedOutputMode[proposal.shieldedMode];
+      // VULN-1: the token UID is precisely the secret a FullShielded output
+      // hides (it has no on-chain slot — it lives only inside asset_commitment).
+      // Never leak it into the error MESSAGE (which flows to logs/telemetry):
+      // redact it for FullShielded. The full inner error is preserved via
+      // `cause` for local debugging, so dropping the `${e}` interpolation (which
+      // also crossed the message boundary) loses no diagnostics.
+      const tokenLabel =
+        proposal.shieldedMode === ShieldedOutputMode.FULLY_SHIELDED ? '<hidden>' : proposal.token;
       throw new Error(
-        `Failed to create shielded output ${i}/${proposals.length} (mode=${mode}, token=${proposal.token}): ${e}`,
+        `Failed to create shielded output ${i}/${proposals.length} (mode=${mode}, token=${tokenLabel})`,
         { cause: e }
       );
     }


### PR DESCRIPTION
### Description

Hardens the input-validation and error-disclosure boundary of the shielded-output build path (createShieldedOutputs). The cryptographic core is unchanged; this adds upfront input bounds, crypto-provider output shape checks, and stops the build-error message from leaking secrets. createShieldedOutputs has no production caller yet, so every guard lands ahead of the send path that will wire it up.

### Acceptance Criteria
- Bound a shielded output's value to [1, 2^40) (the range proof's domain; the fullnode enforces no value ceiling).
- Add a surjection-proof domain cap (≤ 256 input generators) to prevent the uncatchable native abort.
- Validate the recipient scanPubkey is canonical hex and a real on-curve compressed point (a truncated/typo'd key would otherwise build an unspendable output).
- Cap the number of shielded outputs per transaction at 32 (consensus limit).
- Validate the output timelock range ([0, 2^32)).
- Length-check input generators' assetBlindingFactor.
- Add crypto-provider output shape (length) checks before serialization.
- Redact the FullShielded hidden token UID — and the raw inner-error string — from the build-error message (preserve the inner error via the Error cause).

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened shielded output creation with stricter canonical pubkey validation, timelock/value bounds, batch size limits, and blinding-factor size checks.
  * Added validation of cryptographic provider responses (buffer/proof shapes and lengths) before emitting outputs.
  * Improved error reporting: preserves the underlying cause for debugging while redacting sensitive token UID details in full-shielded failures.
* **Tests**
  * Expanded coverage for validation, error causality, and accepted provider return types (e.g., `Uint8Array`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->