### PR TITLE
test(integration): derive shielded fixture window + name the derivation-test timeout

### DIFF
--- a/__tests__/integration/configuration/precalculated-shielded-addresses.test.ts
+++ b/__tests__/integration/configuration/precalculated-shielded-addresses.test.ts
@@ -24,7 +24,9 @@ import { PRECALCULATED_SHIELDED_ADDRESSES } from './precalculated-shielded-addre
 import { NETWORK_NAME, WALLET_CONSTANTS } from './test-constants';
 import { multisigWalletsData } from '../helpers/wallet-precalculation.helper';
 
-const EXPECTED_WINDOW = 22; // mirrors the legacy precalculated address window
+// The shielded fixtures mirror the legacy precalculated address window, so the
+// expected count is exactly the number of legacy addresses per fixture wallet.
+const EXPECTED_WINDOW = WALLET_CONSTANTS.genesis.addresses.length;
 
 // Access-data generation is expensive under jest (hardened derivations +
 // PBKDF2) — do it once per seed, not once per compared index.

--- a/__tests__/utils/loadAddressesShielded.test.ts
+++ b/__tests__/utils/loadAddressesShielded.test.ts
@@ -11,6 +11,10 @@ import { loadAddresses, savePrecalculatedShieldedAddresses } from '../../src/uti
 import * as addressUtils from '../../src/utils/address';
 import { IPrecalculatedShieldedAddress } from '../../src/types';
 
+// These tests exercise real shielded EC derivation, which jest's vm sandbox
+// slows down enough that a full run can exceed jest's 5s default under load.
+const DEFAULT_DERIVATION_TEST_TIMEOUT = 30000;
+
 describe('loadAddresses — shielded chain derivation lifecycle', () => {
   // Shielded address derivation is pure-JS EC math that jest's vm sandbox slows
   // down dramatically, and loadAddresses re-walks from index 0 on every
@@ -61,91 +65,111 @@ describe('loadAddresses — shielded chain derivation lifecycle', () => {
     jest.restoreAllMocks();
   });
 
-  it('derives each index once and skips re-derivation on re-loads', async () => {
-    const storage = await makeStorage();
-    const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
+  it(
+    'derives each index once and skips re-derivation on re-loads',
+    async () => {
+      const storage = await makeStorage();
+      const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
 
-    const first = await loadAddresses(0, 5, storage);
-    expect(deriveSpy).toHaveBeenCalledTimes(5);
-    // 5 legacy + 5 spend-derived P2PKH addresses returned for subscription.
-    expect(first).toHaveLength(10);
+      const first = await loadAddresses(0, 5, storage);
+      expect(deriveSpy).toHaveBeenCalledTimes(5);
+      // 5 legacy + 5 spend-derived P2PKH addresses returned for subscription.
+      expect(first).toHaveLength(10);
 
-    deriveSpy.mockClear();
-    const saveSpy = jest.spyOn(storage, 'saveAddress');
-    const second = await loadAddresses(0, 5, storage);
-    // Re-walks (every sync/reload restarts at index 0) must not re-derive
-    // nor re-save — and must return the exact same list, including the paired
-    // spend base58s, so subscriptions stay identical.
-    expect(deriveSpy).not.toHaveBeenCalled();
-    expect(saveSpy).not.toHaveBeenCalled();
-    expect(second).toEqual(first);
-  }, 30000);
+      deriveSpy.mockClear();
+      const saveSpy = jest.spyOn(storage, 'saveAddress');
+      const second = await loadAddresses(0, 5, storage);
+      // Re-walks (every sync/reload restarts at index 0) must not re-derive
+      // nor re-save — and must return the exact same list, including the paired
+      // spend base58s, so subscriptions stay identical.
+      expect(deriveSpy).not.toHaveBeenCalled();
+      expect(saveSpy).not.toHaveBeenCalled();
+      expect(second).toEqual(first);
+    },
+    DEFAULT_DERIVATION_TEST_TIMEOUT
+  );
 
-  it('injected pre-calculated pairs skip derivation and match live-derived state', async () => {
-    // Reference: live derivation.
-    const liveStorage = await makeStorage();
-    const liveList = await loadAddresses(0, 4, liveStorage);
+  it(
+    'injected pre-calculated pairs skip derivation and match live-derived state',
+    async () => {
+      // Reference: live derivation.
+      const liveStorage = await makeStorage();
+      const liveList = await loadAddresses(0, 4, liveStorage);
 
-    // Same wallet, but with the pairs injected up front (what the wallet start
-    // does with preCalculatedShieldedAddresses).
-    const injectedStorage = await makeStorage();
-    await savePrecalculatedShieldedAddresses(injectedStorage, deriveEntries(4, injectedStorage));
+      // Same wallet, but with the pairs injected up front (what the wallet start
+      // does with preCalculatedShieldedAddresses).
+      const injectedStorage = await makeStorage();
+      await savePrecalculatedShieldedAddresses(injectedStorage, deriveEntries(4, injectedStorage));
 
-    const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
-    const injectedList = await loadAddresses(0, 4, injectedStorage);
-    expect(deriveSpy).not.toHaveBeenCalled();
-    expect(injectedList).toEqual(liveList);
+      const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
+      const injectedList = await loadAddresses(0, 4, injectedStorage);
+      expect(deriveSpy).not.toHaveBeenCalled();
+      expect(injectedList).toEqual(liveList);
 
-    // The stored records must be byte-identical to live derivation on BOTH
-    // chains — the receive pipeline reads bip32AddressIndex/addressType off
-    // these records, so any shape drift would break decryption.
-    for (let i = 0; i < 4; i++) {
-      const liveShielded = await liveStorage.getAddressAtIndex(i, { legacy: false });
-      const injectedShielded = await injectedStorage.getAddressAtIndex(i, { legacy: false });
-      expect(injectedShielded).toEqual(liveShielded);
-      const liveSpend = await liveStorage.store.getAddress(liveShielded!.ctMappingAddress!);
-      const injectedSpend = await injectedStorage.store.getAddress(
-        injectedShielded!.ctMappingAddress!
-      );
-      expect(injectedSpend).toEqual(liveSpend);
-    }
-  }, 30000);
+      // The stored records must be byte-identical to live derivation on BOTH
+      // chains — the receive pipeline reads bip32AddressIndex/addressType off
+      // these records, so any shape drift would break decryption.
+      for (let i = 0; i < 4; i++) {
+        const liveShielded = await liveStorage.getAddressAtIndex(i, { legacy: false });
+        const injectedShielded = await injectedStorage.getAddressAtIndex(i, { legacy: false });
+        expect(injectedShielded).toEqual(liveShielded);
+        const liveSpend = await liveStorage.store.getAddress(liveShielded!.ctMappingAddress!);
+        const injectedSpend = await injectedStorage.store.getAddress(
+          injectedShielded!.ctMappingAddress!
+        );
+        expect(injectedSpend).toEqual(liveSpend);
+      }
+    },
+    DEFAULT_DERIVATION_TEST_TIMEOUT
+  );
 
-  it('re-injection over existing storage is a no-op (wallet restart)', async () => {
-    const storage = await makeStorage();
-    const entries = deriveEntries(3, storage);
-    await savePrecalculatedShieldedAddresses(storage, entries);
-    // A wallet restart without cleanStorage re-runs the start() injection over
-    // the same storage — saveAddress throws on duplicates, so this must guard.
-    await expect(savePrecalculatedShieldedAddresses(storage, entries)).resolves.toBeUndefined();
-  }, 30000);
+  it(
+    're-injection over existing storage is a no-op (wallet restart)',
+    async () => {
+      const storage = await makeStorage();
+      const entries = deriveEntries(3, storage);
+      await savePrecalculatedShieldedAddresses(storage, entries);
+      // A wallet restart without cleanStorage re-runs the start() injection over
+      // the same storage — saveAddress throws on duplicates, so this must guard.
+      await expect(savePrecalculatedShieldedAddresses(storage, entries)).resolves.toBeUndefined();
+    },
+    DEFAULT_DERIVATION_TEST_TIMEOUT
+  );
 
-  it('derives live past the injected window (fallback stays exercised)', async () => {
-    const storage = await makeStorage();
-    await savePrecalculatedShieldedAddresses(storage, deriveEntries(2, storage));
-    const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
+  it(
+    'derives live past the injected window (fallback stays exercised)',
+    async () => {
+      const storage = await makeStorage();
+      await savePrecalculatedShieldedAddresses(storage, deriveEntries(2, storage));
+      const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
 
-    await loadAddresses(0, 4, storage);
-    // Indexes 0-1 injected (skipped), 2-3 derived live.
-    expect(deriveSpy).toHaveBeenCalledTimes(2);
-    const info = await storage.getAddressAtIndex(3, { legacy: false });
-    expect(info?.addressType).toBe('shielded');
-    expect(info?.ctMappingAddress).toBeTruthy();
-  }, 30000);
+      await loadAddresses(0, 4, storage);
+      // Indexes 0-1 injected (skipped), 2-3 derived live.
+      expect(deriveSpy).toHaveBeenCalledTimes(2);
+      const info = await storage.getAddressAtIndex(3, { legacy: false });
+      expect(info?.addressType).toBe('shielded');
+      expect(info?.ctMappingAddress).toBeTruthy();
+    },
+    DEFAULT_DERIVATION_TEST_TIMEOUT
+  );
 
-  it('wallets without shielded keys never touch the shielded chain', async () => {
-    const storage = new Storage(new MemoryStore());
-    await storage.saveAccessData({
-      ...accessData,
-      scanXpubkey: undefined,
-      spendXpubkey: undefined,
-    });
-    const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
+  it(
+    'wallets without shielded keys never touch the shielded chain',
+    async () => {
+      const storage = new Storage(new MemoryStore());
+      await storage.saveAccessData({
+        ...accessData,
+        scanXpubkey: undefined,
+        spendXpubkey: undefined,
+      });
+      const deriveSpy = jest.spyOn(addressUtils, 'deriveShieldedAddressPair');
 
-    const list = await loadAddresses(0, 3, storage);
-    expect(deriveSpy).not.toHaveBeenCalled();
-    // Legacy-only: one address per index, no shielded entries.
-    expect(list).toHaveLength(3);
-    expect(await storage.getAddressAtIndex(0, { legacy: false })).toBeNull();
-  }, 30000);
+      const list = await loadAddresses(0, 3, storage);
+      expect(deriveSpy).not.toHaveBeenCalled();
+      // Legacy-only: one address per index, no shielded entries.
+      expect(list).toHaveLength(3);
+      expect(await storage.getAddressAtIndex(0, { legacy: false })).toBeNull();
+    },
+    DEFAULT_DERIVATION_TEST_TIMEOUT
+  );
 });


### PR DESCRIPTION
### Summary

Post-merge review follow-ups on #1122 (precalculated shielded addresses for
integration tests). Two test-only cleanups requested in review.

### Acceptance Criteria
-  Derive the shielded-fixture expected window from the fixture data
      (`WALLET_CONSTANTS.genesis.addresses.length`) rather than a hardcoded literal.
- Extract the repeated per-test derivation timeout into a named
      `DEFAULT_DERIVATION_TEST_TIMEOUT` constant.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage to match the current wallet fixture data automatically, reducing the chance of brittle test failures.
  * Standardized a shared timeout value across shielded address derivation tests for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->