### PR TITLE
ci(itest): increase timeout from 90 to 150 minutes

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,7 +20,7 @@ jobs:
   itest:
     runs-on: 'ubuntu-latest'
     # Temporary bump; the integration suite is slow (speed fix in another PR).
-    timeout-minutes: 90
+    timeout-minutes: 150
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Increases the integration test job timeout from 90 to 150 minutes. The integration suite is slow (speed fix tracked separately), and 90 minutes has been insufficient.

Previous iterations of this timeout increase:
- #1109 
- #1116

## Changes

- `.github/workflows/integration-test.yml`: `timeout-minutes: 90` → `150`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the allowed runtime for integration tests, reducing the chance of timeouts during longer test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->