### PR TITLE
fix(itest): stabilize flaky beforeAll setups (wallet-service UTXO lag + blueprint timestamp collision)

### DIFF
--- a/__tests__/integration/adapters/service.adapter.ts
+++ b/__tests__/integration/adapters/service.adapter.ts
@@ -16,6 +16,7 @@ import {
   initializeServiceGlobalConfigs,
   pollForTx,
   pollForTokenDetails,
+  pollForUtxoConsistency,
   pollUntilCondition,
   retryOnTransientWalletInit,
 } from '../helpers/service-facade.helper';
@@ -252,6 +253,17 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
     if (recvWallet) {
       await pollForTx(this.concrete(recvWallet), txId);
     }
+  }
+
+  /**
+   * Waits until the wallet-service's UTXO index fully reflects `tx` (spent inputs
+   * gone, own output available). Use between consecutive sends whose input
+   * selection depends on the previous send's outputs — the service's UTXO index
+   * lags its tx index, so `waitForTx` alone is not enough. See
+   * {@link pollForUtxoConsistency}.
+   */
+  async waitForUtxoConsistency(wallet: FuzzyWalletType, tx: Transaction): Promise<void> {
+    await pollForUtxoConsistency(this.concrete(wallet), tx);
   }
 
   getPrecalculatedWallet(): Promise<PrecalculatedWalletData> {

--- a/__tests__/integration/helpers/service-facade.helper.ts
+++ b/__tests__/integration/helpers/service-facade.helper.ts
@@ -174,12 +174,21 @@ export async function pollForUtxoConsistency(
   wallet: HathorWalletServiceWallet,
   tx: { hash?: string | null; inputs: { hash: string; index: number }[] }
 ): Promise<void> {
+  // A mined tx is required: without a hash there is no tx to reflect, and the
+  // predicate below could never become true — fail fast instead of exhausting
+  // every retry only to throw a generic timeout.
+  if (tx.hash == null) {
+    throw new Error(
+      'pollForUtxoConsistency requires a mined tx: tx.hash is missing (call after the send resolves)'
+    );
+  }
+  const txHash = tx.hash;
   const spent = new Set(tx.inputs.map(input => `${input.hash}:${input.index}`));
   await pollUntilCondition(
     async () => {
       const { utxos } = await wallet.getUtxos();
       const noStaleInput = utxos.every(utxo => !spent.has(`${utxo.tx_id}:${utxo.index}`));
-      const ownOutputAvailable = tx.hash != null && utxos.some(utxo => utxo.tx_id === tx.hash);
+      const ownOutputAvailable = utxos.some(utxo => utxo.tx_id === txHash);
       return noStaleInput && ownOutputAvailable;
     },
     'wallet-service UTXO index reflects sent tx',

--- a/__tests__/integration/helpers/service-facade.helper.ts
+++ b/__tests__/integration/helpers/service-facade.helper.ts
@@ -153,6 +153,42 @@ export async function pollForTx(walletForPolling: HathorWalletServiceWallet, txI
 }
 
 /**
+ * Polls the wallet-service until its UTXO index fully reflects `tx`: the UTXOs
+ * `tx` spends are no longer offered as available, AND `tx`'s own (wallet-owned)
+ * output has become available.
+ *
+ * `pollForTx` only confirms a tx is INDEXED; the service updates its UTXO index
+ * in a separate, non-atomic step. Issuing the next send before that catch-up
+ * makes input selection either pick an already-spent UTXO — rejected as the
+ * generic `Error sending tx proposal` — or find nothing yet — `No UTXOs
+ * available for the token ...`. Both are the same lag, and both are `beforeAll`
+ * failures that jest.retryTimes cannot recover.
+ *
+ * Requires `tx` to have at least one wallet-owned output (e.g. a change output),
+ * which holds for the change-producing sends this guards.
+ *
+ * @param wallet Service wallet to poll
+ * @param tx The just-sent transaction whose effects must be reflected
+ */
+export async function pollForUtxoConsistency(
+  wallet: HathorWalletServiceWallet,
+  tx: { hash?: string | null; inputs: { hash: string; index: number }[] }
+): Promise<void> {
+  const spent = new Set(tx.inputs.map(input => `${input.hash}:${input.index}`));
+  await pollUntilCondition(
+    async () => {
+      const { utxos } = await wallet.getUtxos();
+      const noStaleInput = utxos.every(utxo => !spent.has(`${utxo.tx_id}:${utxo.index}`));
+      const ownOutputAvailable = tx.hash != null && utxos.some(utxo => utxo.tx_id === tx.hash);
+      return noStaleInput && ownOutputAvailable;
+    },
+    'wallet-service UTXO index reflects sent tx',
+    20,
+    500
+  );
+}
+
+/**
  * Backoff sequence between retry attempts on a transient `wallet/init` failure.
  * 4 total attempts (initial + 3 backoffs), ~3.5s worst-case added latency.
  */

--- a/__tests__/integration/service-specific/utxos.test.ts
+++ b/__tests__/integration/service-specific/utxos.test.ts
@@ -48,12 +48,16 @@ describe('[Service] getUtxos', () => {
       pinCode: adapter.defaultPinCode,
       changeAddress: addr0,
     });
-    await adapter.waitForTx(wallet, tx2.hash!);
+    // The wallet-service's UTXO index lags its tx index, so waiting for the tx
+    // alone lets the next send select an already-spent (or not-yet-available)
+    // UTXO — surfaced as `Error sending tx proposal` or `No UTXOs available`.
+    // Wait until the index fully reflects each send before issuing the next.
+    await adapter.waitForUtxoConsistency(wallet, tx2);
     const tx3 = await wallet.sendTransaction(addr2, 30n, {
       pinCode: adapter.defaultPinCode,
       changeAddress: addr0,
     });
-    await adapter.waitForTx(wallet, tx3.hash!);
+    await adapter.waitForUtxoConsistency(wallet, tx3);
 
     // Creating a 200n custom token on addr1 burns 2n HTR (1% deposit) from the
     // 20n input, leaving 18n change at addr1 — the small UTXO the range filter

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -17,7 +17,7 @@ import {
   precalculationHelpers, WalletPrecalculationHelper
 } from './__tests__/integration/helpers/wallet-precalculation.helper';
 import { GenesisWalletHelper } from './__tests__/integration/helpers/genesis-wallet.helper';
-import { generateWalletHelper, waitNextBlock, waitTxConfirmed } from './__tests__/integration/helpers/wallet.helper';
+import { generateWalletHelper, waitNextBlock, waitTxConfirmed, waitUntilNextTimestamp } from './__tests__/integration/helpers/wallet.helper';
 import { stopGLLBackgroundTask } from './src/sync/gll';
 import Transaction from './src/models/transaction';
 
@@ -57,16 +57,26 @@ async function createOCBs(sharedState) {
   const codeBet = fs.readFileSync('./__tests__/integration/configuration/blueprints/bet.py', 'utf8');
   const txBet = await ocbWallet.createAndSendOnChainBlueprintTransaction(codeBet, address0);
   await waitTxConfirmed(ocbWallet, txBet.hash, null);
+  // Advance the wall clock past this blueprint tx before creating the next one.
+  // The blueprint txs are created back-to-back and each may select the previous
+  // as a DAG parent; a tx may not share its parent's timestamp (1-second
+  // granularity), so without this the fullnode intermittently rejects the next
+  // tx with "full validation failed: tx.timestamp == parent.timestamp". Waiting
+  // for the confirming block is not enough — the dev miner can confirm within the
+  // same second.
+  await waitUntilNextTimestamp(ocbWallet, txBet.hash);
   sharedState.blueprintIds.BET_BLUEPRINT_ID = txBet.hash;
 
   const codeAuthority = fs.readFileSync('./__tests__/integration/configuration/blueprints/authority.py', 'utf8');
   const txAuthority = await ocbWallet.createAndSendOnChainBlueprintTransaction(codeAuthority, address0);
   await waitTxConfirmed(ocbWallet, txAuthority.hash, null);
+  await waitUntilNextTimestamp(ocbWallet, txAuthority.hash);
   sharedState.blueprintIds.AUTHORITY_BLUEPRINT_ID = txAuthority.hash;
 
   const codeFull = fs.readFileSync('./__tests__/integration/configuration/blueprints/full_blueprint.py', 'utf8');
   const txFull = await ocbWallet.createAndSendOnChainBlueprintTransaction(codeFull, address0);
   await waitTxConfirmed(ocbWallet, txFull.hash, null);
+  await waitUntilNextTimestamp(ocbWallet, txFull.hash);
   sharedState.blueprintIds.FULL_BLUEPRINT_ID = txFull.hash;
 
   const codeParent = fs.readFileSync(
@@ -76,6 +86,7 @@ async function createOCBs(sharedState) {
 
   const txParent = await ocbWallet.createAndSendOnChainBlueprintTransaction(codeParent, address0);
   await waitTxConfirmed(ocbWallet, txParent.hash);
+  await waitUntilNextTimestamp(ocbWallet, txParent.hash);
   sharedState.blueprintIds.PARENT_BLUEPRINT_ID = txParent.hash;
 
   const codeChildren = fs.readFileSync(
@@ -87,6 +98,7 @@ async function createOCBs(sharedState) {
     address0
   );
   await waitTxConfirmed(ocbWallet, txChildren.hash);
+  await waitUntilNextTimestamp(ocbWallet, txChildren.hash);
   sharedState.blueprintIds.CHILDREN_BLUEPRINT_ID = txChildren.hash;
 
   const codeFee = fs.readFileSync(
@@ -95,6 +107,7 @@ async function createOCBs(sharedState) {
   );
   const txFee = await ocbWallet.createAndSendOnChainBlueprintTransaction(codeFee, address0);
   await waitTxConfirmed(ocbWallet, txFee.hash, null);
+  await waitUntilNextTimestamp(ocbWallet, txFee.hash);
   sharedState.blueprintIds.FEE_BLUEPRINT_ID = txFee.hash;
 
   const codeUpgradeV1 = fs.readFileSync(
@@ -106,6 +119,7 @@ async function createOCBs(sharedState) {
     address0
   );
   await waitTxConfirmed(ocbWallet, txUpgradeV1.hash, null);
+  await waitUntilNextTimestamp(ocbWallet, txUpgradeV1.hash);
   sharedState.blueprintIds.UPGRADE_TEST_V1_BLUEPRINT_ID = txUpgradeV1.hash;
 
   const codeUpgradeV2 = fs.readFileSync(
@@ -117,6 +131,7 @@ async function createOCBs(sharedState) {
     address0
   );
   await waitTxConfirmed(ocbWallet, txUpgradeV2.hash, null);
+  await waitUntilNextTimestamp(ocbWallet, txUpgradeV2.hash);
   sharedState.blueprintIds.UPGRADE_TEST_V2_BLUEPRINT_ID = txUpgradeV2.hash;
 }
 


### PR DESCRIPTION
### Motivation

The integration suite fails intermittently in CI with errors that are **not product bugs** — they're timing races in one-time `beforeAll` setup code. Because they happen in a hook (not an `it()` body), `jest.retryTimes(2)` cannot recover them, so a single flaky setup send fails an entire test file. Both issues are pre-existing on `master` and affect every PR's CI equally; there are **no `src/` changes** in this PR (integration-test infrastructure only).

### Root cause 1 — wallet-service UTXO-index lag (the CI blocker)

`service-specific/utxos.test.ts` → `[Service] getUtxos` `beforeAll` issues two consecutive service sends whose input selection depends on the previous send's change output. `waitForTx` (→ `pollForTx`) only confirms a tx is **indexed** by the wallet-service; the service updates its **UTXO index** in a separate, non-atomic step. Sending the next tx before that catch-up makes input selection either:

- pick an already-spent UTXO → `Error sending tx proposal` (`sendTransactionWalletService.ts:962`) — seen in CI, or
- find nothing yet → `No UTXOs available for the token …` (`:459`).

Both are the same lag.

**Fix:** `pollForUtxoConsistency(wallet, tx)` — polls `getUtxos()` until the tx's spent inputs are gone **and** its own output is available — exposed as `adapter.waitForUtxoConsistency(...)` and used between the setup's consecutive sends.

## Root cause 2 — createOCBs blueprint timestamp collision

`createOCBs` (one-time `beforeAll` in `setupTests-integration.js`) deploys ~8 on-chain-blueprint txs back-to-back, spaced only by `waitTxConfirmed` (block confirmation, which the dev miner delivers sub-second). Occasionally two land in the same wall-clock second; the child selects the parent and the fullnode rejects it: `full validation failed: tx.timestamp == parent.timestamp`.

**Fix:** `waitUntilNextTimestamp` after each blueprint tx so every subsequent one lands in a strictly later second.

### Acceptance Criteria
-  Add `pollForUtxoConsistency` + `adapter.waitForUtxoConsistency`, and use it between the consecutive service sends in the `[Service] getUtxos` setup so it no longer selects a stale or not-yet-available UTXO.
- Space `createOCBs` blueprint deploys with `waitUntilNextTimestamp` so consecutive blueprint txs cannot share a wall-clock second.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved integration test synchronization by waiting for wallet-service UTXO indexing consistency after each send.
  - Added polling logic to ensure spent inputs disappear from the UTXO set and new transaction outputs become available before continuing.
  - Coordinated timestamps between on-chain blueprint transactions to enhance reliability.

- **Bug Fixes**
  - Reduced intermittent integration-test failures caused by stale UTXO data and edge cases involving transactions with identical timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->