### PR TITLE
fix: align tx-query error paths across both facades

### DIFF
--- a/__tests__/api/txApi.test.ts
+++ b/__tests__/api/txApi.test.ts
@@ -1,0 +1,144 @@
+import MockAdapter from 'axios-mock-adapter';
+import axios from 'axios';
+import txApi from '../../src/api/txApi';
+
+/**
+ * Every txApi method follows the same shape: it takes a `resolve` callback for
+ * the success path and returns a promise that must reject when the request
+ * itself fails, so the caller can tell a transport failure apart from an
+ * API-level one.
+ *
+ * These cases drive the rejection handlers directly. The wallet-facing tests in
+ * __tests__/new/hathorwallet.test.ts spy on txApi itself, which replaces the
+ * handlers under test here.
+ */
+describe('transport error propagation', () => {
+  let axiosMock;
+  const resolve = jest.fn();
+
+  beforeEach(() => {
+    axiosMock = new MockAdapter(axios);
+    resolve.mockClear();
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+  });
+
+  /**
+   * Each entry names one rejection handler in src/api/txApi.ts, the endpoint it
+   * calls, and how to invoke it. Kept exhaustive on purpose: the handlers are
+   * identical by convention rather than by construction, so a table is what
+   * stops a single one from drifting.
+   */
+  const HANDLERS: { name: string; endpoint: string; method?: 'post'; call: () => Promise<void> }[] =
+    [
+      {
+        name: 'getTransaction',
+        endpoint: 'transaction',
+        call: () => txApi.getTransaction('tx1', resolve),
+      },
+      {
+        name: 'getTransactions',
+        endpoint: 'transaction',
+        call: () => txApi.getTransactions('tx', 10, null, null, null, resolve),
+      },
+      {
+        name: 'getConfirmationData',
+        endpoint: 'transaction_acc_weight',
+        call: () => txApi.getConfirmationData('tx1', resolve),
+      },
+      {
+        name: 'decodeTx',
+        endpoint: 'decode_tx',
+        call: () => txApi.decodeTx('cafe', resolve),
+      },
+      {
+        name: 'pushTx',
+        endpoint: 'push_tx',
+        method: 'post',
+        call: () => txApi.pushTx('cafe', false, resolve),
+      },
+      {
+        name: 'getDashboardTx',
+        endpoint: 'dashboard_tx',
+        call: () => txApi.getDashboardTx(1, 1, resolve),
+      },
+      {
+        name: 'getGraphviz',
+        endpoint: 'graphviz/dot',
+        call: () => txApi.getGraphviz('graphviz/dot', resolve),
+      },
+      {
+        name: 'getGraphvizNeighbors',
+        endpoint: 'graphviz/neighbours.dot',
+        call: () => txApi.getGraphvizNeighbors('tx1', 'funds', 1, resolve),
+      },
+    ];
+
+  const mockFailure = (handler: (typeof HANDLERS)[number], kind: 'http500' | 'network') => {
+    const scope =
+      handler.method === 'post'
+        ? axiosMock.onPost(handler.endpoint)
+        : axiosMock.onGet(handler.endpoint);
+    return kind === 'http500' ? scope.reply(500) : scope.networkError();
+  };
+
+  test.each(HANDLERS)('$name does not resolve on HTTP 500', async handler => {
+    mockFailure(handler, 'http500');
+
+    await expect(handler.call()).rejects.toBeDefined();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  test.each(HANDLERS)('$name does not resolve when the request never lands', async handler => {
+    mockFailure(handler, 'network');
+
+    await expect(handler.call()).rejects.toBeDefined();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The table above asserts only that the chain rejects, because `getTransaction`
+   * passes a zod schema into `transformResponse`, which parses the error body and
+   * throws a ZodError before the rejection handler is reached. The handlers below
+   * take no schema, so the caller receives the axios error itself.
+   */
+  describe('the axios error reaches the caller', () => {
+    test.each([
+      {
+        name: 'getConfirmationData',
+        endpoint: 'transaction_acc_weight',
+        call: () => txApi.getConfirmationData('tx1', resolve),
+      },
+      {
+        name: 'getGraphvizNeighbors',
+        endpoint: 'graphviz/neighbours.dot',
+        call: () => txApi.getGraphvizNeighbors('tx1', 'funds', 1, resolve),
+      },
+    ])('$name rejects with the axios error on HTTP 500', async handler => {
+      axiosMock.onGet(handler.endpoint).reply(500);
+
+      await expect(handler.call()).rejects.toMatchObject({
+        isAxiosError: true,
+        response: { status: 500 },
+      });
+    });
+  });
+
+  /**
+   * Regression guard for the specific defect: getConfirmationData used to
+   * evaluate `Promise.reject(res)` without returning it, so the chain resolved
+   * with undefined and the real error was dropped on an unhandled rejection.
+   */
+  test('getConfirmationData settles as rejected, never as resolved', async () => {
+    axiosMock.onGet('transaction_acc_weight').reply(500);
+
+    const settled = await txApi
+      .getConfirmationData('tx1', resolve)
+      .then(() => 'resolved')
+      .catch(() => 'rejected');
+
+    expect(settled).toStrictEqual('rejected');
+  });
+});

--- a/__tests__/wallet/api/walletApi.test.ts
+++ b/__tests__/wallet/api/walletApi.test.ts
@@ -3,7 +3,7 @@ import walletApi from '../../../src/wallet/api/walletApi';
 import Network from '../../../src/models/network';
 import HathorWalletServiceWallet from '../../../src/wallet/wallet';
 import config from '../../../src/config';
-import { WalletRequestError } from '../../../src/errors';
+import { TxNotFoundError, WalletRequestError } from '../../../src/errors';
 
 const seed =
   'connect sunny silent cabin leopard start turtle tortoise dial timber woman genre pave tuna rice indicate gown draft palm collect retreat meadow assume spray';
@@ -837,5 +837,58 @@ describe('walletApi', () => {
     } as AxiosResponse);
 
     await expect(walletApi.getHasTxOutsideFirstAddress(wallet)).rejects.toThrow();
+  });
+
+  /**
+   * The three proxied fullnode queries share one error contract: whatever the
+   * status code, an `error: 'tx-not-found'` body has to surface as
+   * TxNotFoundError so callers can branch on it, rather than as the generic
+   * WalletRequestError.
+   */
+  describe('proxied fullnode queries surface tx-not-found', () => {
+    const txId = 'tx1';
+    const notFoundBody = { success: false, error: 'tx-not-found' };
+
+    const QUERIES = [
+      {
+        name: 'getFullTxById',
+        call: () => walletApi.getFullTxById(wallet, txId),
+      },
+      {
+        name: 'getTxConfirmationData',
+        call: () => walletApi.getTxConfirmationData(wallet, txId),
+      },
+      {
+        name: 'graphvizNeighborsQuery',
+        call: () => walletApi.graphvizNeighborsQuery(wallet, txId, 'funds', 1),
+      },
+    ];
+
+    test.each(QUERIES)('$name throws TxNotFoundError on a 200 body', async query => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        status: 200,
+        data: notFoundBody,
+      } as AxiosResponse);
+
+      await expect(query.call()).rejects.toThrow(TxNotFoundError);
+    });
+
+    test.each(QUERIES)('$name throws TxNotFoundError on a non-200 response', async query => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        status: 404,
+        data: notFoundBody,
+      } as AxiosResponse);
+
+      await expect(query.call()).rejects.toThrow(TxNotFoundError);
+    });
+
+    test.each(QUERIES)('$name still throws WalletRequestError otherwise', async query => {
+      mockAxiosInstance.get.mockResolvedValueOnce({
+        status: 503,
+        data: { success: false },
+      } as AxiosResponse);
+
+      await expect(query.call()).rejects.toThrow(WalletRequestError);
+    });
   });
 });

--- a/__tests__/wallet/walletSchemas.test.ts
+++ b/__tests__/wallet/walletSchemas.test.ts
@@ -493,6 +493,20 @@ describe('Wallet API Schemas', () => {
       expect(() => fullNodeTxConfirmationDataResponseSchema.parse(validData)).not.toThrow();
     });
 
+    it('should accept a response without stop_value', () => {
+      // The fullnode only computes stop_value once the transaction has a
+      // first_block, so it is absent for any not-yet-confirmed transaction.
+      const dataWithoutStopValue = {
+        success: true,
+        accumulated_weight: 1,
+        accumulated_bigger: true,
+        confirmation_level: 1,
+      };
+      expect(() =>
+        fullNodeTxConfirmationDataResponseSchema.parse(dataWithoutStopValue)
+      ).not.toThrow();
+    });
+
     it('should reject invalid full node tx confirmation data response', () => {
       const invalidData = {
         success: true,

--- a/src/api/txApi.ts
+++ b/src/api/txApi.ts
@@ -103,7 +103,7 @@ const txApi = {
           resolve(res.data);
         },
         res => {
-          Promise.reject(res);
+          return Promise.reject(res);
         }
       );
   },

--- a/src/wallet/api/schemas/walletApi.ts
+++ b/src/wallet/api/schemas/walletApi.ts
@@ -391,7 +391,9 @@ export const fullNodeTxResponseSchema = baseResponseSchema.extend({
 export const fullNodeTxConfirmationDataResponseSchema = baseResponseSchema.extend({
   accumulated_weight: z.number(),
   accumulated_bigger: z.boolean(),
-  stop_value: z.number(),
+  // Optional to match the fullnode contract (TransactionAccWeightSuccess in
+  // src/api/schemas/txApi.ts): only present once the tx has a first_block.
+  stop_value: z.number().optional(),
   confirmation_level: z.number(),
 });
 

--- a/src/wallet/api/walletApi.ts
+++ b/src/wallet/api/walletApi.ts
@@ -426,6 +426,8 @@ const walletApi = {
       return response.data;
     }
 
+    walletApi._txNotFoundGuard(response.data);
+
     throw new WalletRequestError(
       `Error getting neighbors data for ${txId} from the proxied fullnode.`,
       {

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -821,7 +821,9 @@ export interface FullNodeTxConfirmationDataResponse {
   success: boolean;
   accumulated_weight: number;
   accumulated_bigger: boolean;
-  stop_value: number;
+  // Optional on the fullnode contract too (TransactionAccWeightSuccess in
+  // src/api/schemas/txApi.ts): only present once the tx has a first_block.
+  stop_value?: number;
   confirmation_level: number;
 }
 


### PR DESCRIPTION
Closes HathorNetwork/hathor-wallet-lib#1153
Closes HathorNetwork/hathor-wallet-lib#1148
Closes HathorNetwork/hathor-wallet-lib#1149

## Motivation

Three defects in the error paths of the same three methods — `getFullTxById`, `getTxConfirmationData` and `graphvizNeighborsQuery` — found while reviewing the migration in HathorNetwork/hathor-wallet-lib#1150. They are bundled because they share one contract: these methods exist on both facades, and each defect is a place where one implementation departs from it. Reviewing them together means loading that context once.

Four lines of production code, one commit per issue.

| Issue | Facade | Defect | Fix |
|---|---|---|---|
| 1153 | fullnode | `getConfirmationData` drops its axios rejection | return it |
| 1148 | wallet-service | proxy schema requires `stop_value`, fullnode makes it optional | `.optional()` |
| 1149 | wallet-service | `graphvizNeighborsQuery` skips `_txNotFoundGuard` on non-200 | move to fallthrough |

## What changed

### `src/api/txApi.ts` — the dropped rejection

The handler evaluated `Promise.reject(res)` without returning it, so the `.then(onFulfilled, onRejected)` chain resolved with `undefined`. Two consequences: the caller got `API client did not use the callback` from the wrapper's impossible branch instead of the transport error, and the orphaned rejection went unhandled.

That second consequence is worth stating precisely, because it turned out to be more than theoretical — running the new suite against the unfixed code does not report a failure, it terminates the process:

```
node:internal/process/promises:394
    triggerUncaughtException(err, true /* fromPromise */);
```

Under Node's default `--unhandled-rejections=throw`, any non-2xx on `GET /transaction_acc_weight` can take down a long-lived consumer. It was the only one of the 19 `Promise.reject` sites in `src/` missing its `return`.

### `src/wallet/api/schemas/walletApi.ts` — `stop_value`

The fullnode computes `stop_value` only once a transaction has a `first_block`, and its own type declares it optional. The proxy schema required it, so confirmation data for a not-yet-confirmed transaction threw a `ZodError` on the wallet-service facade while the fullnode facade returned normally.

### `src/wallet/api/walletApi.ts` — the guard

`graphvizNeighborsQuery` nested `_txNotFoundGuard` inside its `status === 200` branch; the two sibling methods call it on the fallthrough. A caller branching on `TxNotFoundError` therefore handled two of the three methods correctly. The 200 branch keeps its own guard call, because the success check is structural there — this endpoint returns a string on success, so it tests for the presence of a `success` key rather than its value.

## Type-level impact

`FullNodeTxConfirmationDataResponse.stop_value` becomes optional, so TypeScript consumers reading it without a guard will need one.

Worth a maintainer's call on how to classify it. It is a source-compatibility break in the strict sense, but the previous type was describing a response the library could not actually deliver — a required `stop_value` is exactly what made the call throw. It also brings the wallet-service type in line with the fullnode's `TransactionAccWeightSuccess`, which has always declared the field optional.

## Tests

`__tests__/api/txApi.test.ts` is new. There was no unit coverage at this layer at all: the existing tests spy on `txApi` itself (`__tests__/new/hathorwallet.test.ts:104`), which replaces the very handlers that were broken. The suite drives all eight entry points through both an HTTP 500 and a network error, so the convention the other handlers follow is now enforced rather than assumed.

Each fix was verified by reverting it and confirming exactly one new test fails (the `txApi` one crashes the worker, as above).

One deliberate omission: the table asserts only that each chain rejects, not that it rejects with the `AxiosError`. `getTransaction` passes a zod schema into `transformResponse`, which parses the error body and throws a `ZodError` before the rejection handler runs — a separate pre-existing behaviour, left alone here. The two schema-free handlers are asserted on the axios error itself.

## Acceptance Criteria

- A failed request to any `txApi` endpoint rejects the returned promise and never invokes the success callback.
- Confirmation data parses on both facades whether or not `stop_value` is present.
- All three proxied fullnode queries raise `TxNotFoundError` for a `tx-not-found` body regardless of status code, and `WalletRequestError` otherwise.

## Notes for the reviewer

- The three unit failures in `__tests__/utils/storage.test.ts` (`_updateTokensData` backoff timers) are pre-existing on `origin/master` at `e369ae84`; verified against a clean worktree, unrelated to this branch.
- No integration tests were added. The transport-error path is deterministic to drive with a mocked adapter and does not need the private network.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed transaction confirmation requests so server and network errors are correctly reported as failures.
  * Improved handling of transaction-not-found responses across wallet transaction queries.
  * Updated confirmation data handling to support responses where `stop_value` is not provided.
  * Ensured transaction errors preserve useful request details and display consistently across related endpoints.
  * Improved reliability when processing incomplete or unsuccessful transaction confirmation responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->