### PR TITLE
test(itest): fund integration tests via the helper service

### DIFF
--- a/__tests__/integration/adapters/fullnode.adapter.ts
+++ b/__tests__/integration/adapters/fullnode.adapter.ts
@@ -202,9 +202,14 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
   /**
    * Sends funds to an address whose wallet has not started yet.
    *
-   * Cannot delegate to {@link injectFunds} because that method polls both the
-   * genesis and the destination wallet for tx confirmation — but the destination
-   * wallet isn't running yet, so polling it would hang or fail.
+   * Cannot delegate to {@link injectFunds} because that method waits for the
+   * destination wallet to observe the tx — but that wallet isn't running yet,
+   * so the wait would hang or fail.
+   *
+   * Note this path still broadcasts from the locally-synced genesis wallet
+   * rather than the helper's /fund. The helper runs the same genesis seed and
+   * reserves from the same UTXO set on background timers, so the two are
+   * concurrent spenders; migrating this is tracked separately.
    */
   async injectFundsBeforeStart(address: string, amount: bigint): Promise<string> {
     const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();

--- a/__tests__/integration/adapters/service.adapter.ts
+++ b/__tests__/integration/adapters/service.adapter.ts
@@ -241,10 +241,11 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
   /**
    * Sends funds to an address whose wallet has not started yet.
    *
-   * Cannot delegate to {@link injectFunds} because that method passes the
-   * destination wallet to the helper so it polls for tx confirmation on both
-   * sides — but the destination wallet isn't running yet, so polling it would
-   * hang or fail. Omitting the destination wallet makes the helper skip that poll.
+   * Cannot delegate to {@link injectFunds} because that method polls the
+   * destination wallet for tx confirmation — but that wallet isn't running yet,
+   * so polling it would hang or fail. Omitting the destination wallet makes
+   * the funding helper fall back to polling the genesis wallet instead, so the
+   * tx is still confirmed as indexed before this returns.
    */
   async injectFundsBeforeStart(address: string, amount: bigint): Promise<string> {
     const fundTx = await GenesisWalletServiceHelper.injectFunds(address, amount);

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -243,9 +243,28 @@ services:
       ${HATHOR_LIB_INTEGRATION_TESTS_WALLET_PROVIDER_IMAGE:-hathornetwork/hathor-integration-test-helper:0.0.2}
     ports:
       - "3020:3020"
+    environment:
+      # Funding on: the helper syncs the genesis wallet, splits the pool, and
+      # serves /fund. Points at this compose's private network.
+      FUNDING_ENABLED: "true"
+      HATHOR_NODE_URL: http://fullnode:8080/v1a/
+      TX_MINING_URL: http://tx-mining-service:8035/
+      TX_MIN_WEIGHT: "1"
+    depends_on:
+      fullnode:
+        condition: service_healthy
+      tx-mining-service:
+        condition: service_started
     networks:
       - hathor-privnet
-    # TODO: add a healthcheck once the ITH exposes a readiness endpoint.
+    healthcheck:
+      # /ready gates the suite: 503 until genesis syncs + pool splits, then 200.
+      # Wide retries window covers genesis reward-lock maturity on a fresh net.
+      # Uses `bun`, not `curl` — the helper image is a Bun runtime with no curl.
+      test: ["CMD", "bun", "-e", "fetch('http://127.0.0.1:3020/ready').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
 
 networks:
   hathor-privnet:

--- a/__tests__/integration/configuration/docker-compose.yml
+++ b/__tests__/integration/configuration/docker-compose.yml
@@ -233,19 +233,16 @@ services:
     networks:
       - hathor-privnet
 
-  # Wallet Provider section
-  # Serves precalculated wallets on demand (GET /simpleWallet), replacing the
-  # former static precalculated-wallets.json. ADDRESS_COUNT defaults to 22 in
-  # the image, matching the old static set.
+  # ITH section
+  # Serves the helper endpoints the suite depends on: pre-calculated wallets and
+  # race-free genesis funding.
   # https://github.com/HathorNetwork/hathor-integration-test-helper
-  wallet-provider:
+  integration-test-helper:
     image:
       ${HATHOR_LIB_INTEGRATION_TESTS_WALLET_PROVIDER_IMAGE:-hathornetwork/hathor-integration-test-helper:0.0.2}
     ports:
       - "3020:3020"
     environment:
-      # Funding on: the helper syncs the genesis wallet, splits the pool, and
-      # serves /fund. Points at this compose's private network.
       FUNDING_ENABLED: "true"
       HATHOR_NODE_URL: http://fullnode:8080/v1a/
       TX_MINING_URL: http://tx-mining-service:8035/

--- a/__tests__/integration/fullnode-specific/history-query.test.ts
+++ b/__tests__/integration/fullnode-specific/history-query.test.ts
@@ -93,17 +93,22 @@ describe('[Fullnode] getTxById', () => {
     expect(firstTokenDetails.tokenSymbol).toStrictEqual('HTR');
     expect(firstTokenDetails.balance).toStrictEqual(10n);
 
+    // injectFunds now returns a minimal { hash } — funding is delegated to the
+    // helper's /fund — so fetch the full tx to build a realistic malformed-tx
+    // mock for the token_data validation below.
+    const { tx: fullTx1 } = await hWallet.getFullTxById(tx1.hash);
+
     // throw error if token uid not found in tokens list
     jest.spyOn(hWallet, 'getFullTxById').mockResolvedValue({
       success: true,
       tx: {
-        ...tx1,
+        ...fullTx1,
         // impossible token_data
-        inputs: [{ ...tx1.inputs[0], token_data: -1 }],
+        inputs: [{ ...fullTx1.inputs[0], token_data: -1 }],
       },
     });
     await expect(hWallet.getTxById(tx1.hash)).rejects.toThrow(
-      'Invalid token_data undefined, token not found in tokens list'
+      'Invalid token_data -1, token not found in tokens list'
     );
     jest.spyOn(hWallet, 'getFullTxById').mockRestore();
 

--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -17,7 +17,7 @@ import { OutputValueType } from '../../../src/types';
 import Transaction from '../../../src/models/transaction';
 import { HathorWalletServiceWallet } from '../../../src';
 import { buildWalletInstance, pollForTx } from './service-facade.helper';
-import { ithService } from './ith-service';
+import { ithService, IthServiceError } from './ith-service';
 
 interface InjectFundsOptions {
   waitTimeout?: number;
@@ -92,27 +92,42 @@ export class GenesisWalletHelper {
     value: OutputValueType,
     options: InjectFundsOptions = {}
   ): Promise<Transaction> {
+    // Captured outside the try so the catch can tell "the helper never funded"
+    // apart from "it funded and our wallet never saw the tx".
+    let fundedTxId: string | undefined;
     try {
       // Funding is delegated to the helper's race-free /fund endpoint rather
       // than broadcast from a locally-synced genesis wallet. The helper returns
       // once the tx is broadcast; we then wait until the destination wallet
       // observes it, which is the guarantee callers actually rely on.
-      const { txId } = await ithService.fund(address, value);
-      const result = { hash: txId } as unknown as SuccessfulInjectTransaction;
+      fundedTxId = (await ithService.fund(address, value)).txId;
+      const result = { hash: fundedTxId } as unknown as SuccessfulInjectTransaction;
 
       if (options.waitTimeout === 0) {
         return result;
       }
 
-      await waitForTxReceived(destinationWallet, txId, options.waitTimeout);
+      await waitForTxReceived(destinationWallet, fundedTxId, options.waitTimeout);
       // Timestamps are per-second and a tx must be timestamped strictly after
       // its parent. Without this wait, a test that spends the just-funded UTXO
       // within the same second collides with the funding tx and flakes. Applied
       // via the destination wallet, which is the one that now has the tx.
-      await waitUntilNextTimestamp(destinationWallet, txId);
+      await waitUntilNextTimestamp(destinationWallet, fundedTxId);
       return result;
     } catch (e) {
-      loggers.test!.error(`Failed to inject funds: ${(e as Error).message}`);
+      // Delegating the broadcast created a failure mode that did not exist
+      // before: the helper funded successfully and our wallet never observed
+      // the tx. Without txId that is indistinguishable in the log from "the
+      // helper refused to fund", and there is nothing to cross-reference
+      // against the helper's own logs or the fullnode.
+      const cause =
+        e instanceof IthServiceError
+          ? `${e.code} (HTTP ${e.status}, retryable=${e.retryable}): ${e.message}`
+          : (e as Error).message;
+      loggers.test!.error(
+        `Failed to inject funds: address=${address} value=${value} ` +
+          `txId=${fundedTxId ?? 'not-broadcast'} — ${cause}`
+      );
       throw e;
     }
   }
@@ -236,9 +251,19 @@ export class GenesisWalletServiceHelper {
     const { txId } = await ithService.fund(address, amount);
     const fundTx = { hash: txId } as unknown as Transaction;
 
-    // Ensure the destination wallet is also aware of the transaction
     if (destinationWallet) {
+      // Ensure the destination wallet is also aware of the transaction.
       await pollForTx(destinationWallet, txId);
+    } else {
+      // No destination wallet to observe with — but returning on the helper's
+      // HTTP 200 alone would only mean "broadcast to the fullnode", with
+      // wallet-service ingestion still pending. Callers like
+      // injectFundsBeforeStart then start a wallet and assert on its history,
+      // which becomes a race against the indexer. Poll the genesis wallet
+      // instead: it spends the pool UTXO, so it sees the same tx, and this is
+      // the guarantee the pre-delegation code provided.
+      const gWallet = await GenesisWalletServiceHelper.getSingleton();
+      await pollForTx(gWallet, txId);
     }
 
     return fundTx;

--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -18,6 +18,7 @@ import Transaction from '../../../src/models/transaction';
 import { HathorWalletServiceWallet } from '../../../src';
 import { buildWalletInstance, pollForTx } from './service-facade.helper';
 import { ithService, IthServiceError } from './ith-service';
+import { waitPastTxTimestamp } from '../utils/fullnode.util';
 
 interface InjectFundsOptions {
   waitTimeout?: number;
@@ -246,8 +247,7 @@ export class GenesisWalletServiceHelper {
     amount: bigint,
     destinationWallet?: HathorWalletServiceWallet
   ): Promise<Transaction> {
-    // Delegated to the helper's /fund, same as the fullnode path above. No
-    // timestamp wait here: the Wallet Service handles ordering itself.
+    // Delegated to the helper's /fund, same as the fullnode path above.
     const { txId } = await ithService.fund(address, amount);
     const fundTx = { hash: txId } as unknown as Transaction;
 
@@ -265,6 +265,18 @@ export class GenesisWalletServiceHelper {
       const gWallet = await GenesisWalletServiceHelper.getSingleton();
       await pollForTx(gWallet, txId);
     }
+
+    // Timestamps are per-second and a transaction may not share its parent's.
+    // Callers routinely fund an address and immediately spend that UTXO, and the
+    // fullnode rejects the pair with "full validation failed: tx=… timestamp=N,
+    // spent_tx=… timestamp=N" when both land in the same second.
+    //
+    // The wallet service does NOT order this for us -- the fullnode enforces it.
+    //
+    // Read from the fullnode rather than the wallet: HathorWalletServiceWallet
+    // throws `Not implemented` for getTx, so waitUntilNextTimestamp cannot be
+    // used on this path.
+    await waitPastTxTimestamp(txId);
 
     return fundTx;
   }

--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -17,6 +17,7 @@ import { OutputValueType } from '../../../src/types';
 import Transaction from '../../../src/models/transaction';
 import { HathorWalletServiceWallet } from '../../../src';
 import { buildWalletInstance, pollForTx } from './service-facade.helper';
+import { ithService } from './ith-service';
 
 interface InjectFundsOptions {
   waitTimeout?: number;
@@ -84,6 +85,7 @@ export class GenesisWalletHelper {
    * @returns {Promise<Transaction>}
    * @private
    */
+  // eslint-disable-next-line class-methods-use-this -- funding is delegated to ithService; kept as an instance method to preserve call sites
   async _injectFunds(
     destinationWallet: HathorWallet,
     address: string,
@@ -91,21 +93,23 @@ export class GenesisWalletHelper {
     options: InjectFundsOptions = {}
   ): Promise<Transaction> {
     try {
-      const result = (await this.hWallet.sendTransaction(address, value, {
-        changeAddress: WALLET_CONSTANTS.genesis.addresses[0],
-      })) as SuccessfulInjectTransaction;
+      // Funding is delegated to the helper's race-free /fund endpoint rather
+      // than broadcast from a locally-synced genesis wallet. The helper returns
+      // once the tx is broadcast; we then wait until the destination wallet
+      // observes it, which is the guarantee callers actually rely on.
+      const { txId } = await ithService.fund(address, value);
+      const result = { hash: txId } as unknown as SuccessfulInjectTransaction;
 
       if (options.waitTimeout === 0) {
         return result;
       }
 
-      if (!result.hash) {
-        throw new Error('Transaction had no hash');
-      }
-
-      await waitForTxReceived(this.hWallet, result.hash, options.waitTimeout);
-      await waitForTxReceived(destinationWallet, result.hash, options.waitTimeout);
-      await waitUntilNextTimestamp(this.hWallet, result.hash);
+      await waitForTxReceived(destinationWallet, txId, options.waitTimeout);
+      // Timestamps are per-second and a tx must be timestamped strictly after
+      // its parent. Without this wait, a test that spends the just-funded UTXO
+      // within the same second collides with the funding tx and flakes. Applied
+      // via the destination wallet, which is the one that now has the tx.
+      await waitUntilNextTimestamp(destinationWallet, txId);
       return result;
     } catch (e) {
       loggers.test!.error(`Failed to inject funds: ${(e as Error).message}`);
@@ -227,17 +231,14 @@ export class GenesisWalletServiceHelper {
     amount: bigint,
     destinationWallet?: HathorWalletServiceWallet
   ): Promise<Transaction> {
-    const gWallet = await GenesisWalletServiceHelper.getSingleton();
-    const fundTx = await gWallet.sendTransaction(address, amount, {
-      pinCode: GenesisWalletServiceHelper.pinCode,
-    });
-
-    // Ensure the transaction was sent from the Genesis perspective
-    await pollForTx(gWallet, fundTx.hash!);
+    // Delegated to the helper's /fund, same as the fullnode path above. No
+    // timestamp wait here: the Wallet Service handles ordering itself.
+    const { txId } = await ithService.fund(address, amount);
+    const fundTx = { hash: txId } as unknown as Transaction;
 
     // Ensure the destination wallet is also aware of the transaction
     if (destinationWallet) {
-      await pollForTx(destinationWallet, fundTx.hash!);
+      await pollForTx(destinationWallet, txId);
     }
 
     return fundTx;

--- a/__tests__/integration/utils/fullnode.util.ts
+++ b/__tests__/integration/utils/fullnode.util.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import txApi from '../../../src/api/txApi';
+import { delay } from './time.util';
+
+/**
+ * Wait until the wall clock is strictly past `txId`'s timestamp second.
+ *
+ * Transaction timestamps have one-second granularity and the fullnode rejects a
+ * transaction that shares its parent's timestamp, with
+ * `full validation failed: tx=… timestamp=N, spent_tx=… timestamp=N`. A test
+ * that funds an address and immediately spends that UTXO hits this whenever
+ * both land inside the same second.
+ *
+ * The fullnode-based counterpart of `waitUntilNextTimestamp`, which reads
+ * `wallet.getTx()` — unavailable on the wallet-service facade, where `getTx`
+ * throws `Not implemented`. Reading the timestamp from the fullnode also asks
+ * the authority that actually enforces the rule.
+ */
+export async function waitPastTxTimestamp(txId: string): Promise<void> {
+  const timestamp = await new Promise<number | undefined>(resolve => {
+    txApi
+      .getTransaction(txId, response => resolve(response?.tx?.timestamp))
+      .catch(() => resolve(undefined));
+  });
+
+  if (timestamp === undefined) {
+    // Nothing to order against; the caller's own wait already covers arrival.
+    return;
+  }
+
+  const nextValidMs = (timestamp + 1) * 1000;
+  const remaining = nextValidMs - Date.now();
+  if (remaining > 0) {
+    await delay(remaining + 10);
+  }
+}


### PR DESCRIPTION
Part 2 of 9. Base: `ith/1-client`.

Both funding paths stop broadcasting from a locally-synced genesis wallet and delegate to the helper's `POST /fund`, which reserves a UTXO from a pool instead of racing other callers for the genesis funds. This removes the last place where the suite and the helper spent the same UTXO set concurrently.

Two behaviours are preserved explicitly rather than assumed:

**Timestamp ordering.** Transaction timestamps have one-second granularity and the fullnode rejects a transaction sharing its parent's timestamp. Tests routinely fund an address and immediately spend that UTXO, and delegating to `/fund` made the two land closer together — measured at roughly one failure in three on `service-specific/authority-utxos`. `waitUntilNextTimestamp` can't be reused on the service path: it reads `wallet.getTx()`, which `HathorWalletServiceWallet` does not implement. The new `waitPastTxTimestamp` reads the timestamp from the fullnode, which is also the party that enforces the rule.

**Funding confirmation.** `/fund` returns on broadcast, not on ingestion. Where no destination wallet is passed there was no longer any confirmation that a party had observed the transaction, so a caller that starts a wallet immediately afterwards raced the indexer. The poll is restored, scoped to that case so the common path keeps the saving.

The funding failure path also now reports address, value, txId and the full error contract — delegation created a failure mode that did not exist before (the helper funded, our wallet never saw the transaction) which was otherwise indistinguishable in the log from a refusal to fund.

### Acceptance Criteria
- Funding no longer broadcasts from the local genesis wallet on either facade.
- A funded UTXO can be spent immediately without hitting a timestamp collision.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
