### PR TITLE
test(itest): gate the integration suite on helper readiness

### DIFF
--- a/__tests__/integration/configuration/global-setup.ts
+++ b/__tests__/integration/configuration/global-setup.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Hathor Labs and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Jest globalSetup for the integration suite — blocks until the
+ * integration-test-helper reports ready.
+ *
+ * `npm run test_network_up` is `docker compose up -d`, which returns as soon as
+ * containers *start*. Nothing declares `depends_on: wallet-provider`, so the
+ * helper's own healthcheck gates nothing outside compose's internal ordering
+ * and jest can otherwise begin while the helper is still answering 503. Gating
+ * here also covers the case where the helper was started outside compose.
+ *
+ * Runs once for the whole suite, before any test file is loaded.
+ */
+import { ithService } from '../helpers/ith-service';
+
+export default async function globalSetup(): Promise<void> {
+  const startedAt = Date.now();
+  const status = await ithService.waitUntilReady();
+  const waitedMs = Date.now() - startedAt;
+
+  // globalSetup runs before the winston test loggers exist, so this is console
+  // by necessity. Kept to one line, and only on success — the failure path
+  // throws with its own detail and aborts the run.
+  // eslint-disable-next-line no-console
+  console.log(
+    `[itest] integration-test-helper ready after ${waitedMs}ms ` +
+      `(testUtxos: ${status.testUtxos ?? 'n/a'})`
+  );
+}

--- a/__tests__/integration/configuration/global-setup.ts
+++ b/__tests__/integration/configuration/global-setup.ts
@@ -19,7 +19,40 @@
  */
 import { ithService } from '../helpers/ith-service';
 
+/**
+ * Fail fast, and accurately, if anything in this file's import graph pulled in
+ * bitcore-lib.
+ *
+ * Jest builds every test environment *after* globalSetup returns, copying own
+ * properties off the real global into each new context. bitcore-lib refuses to
+ * evaluate a second time against a global already carrying its marker, and each
+ * test file gets a fresh module registry — so it evaluates again and throws.
+ * The registry resets per file; `global._bitcore` does not.
+ *
+ * The rule this enforces: **this file must not transitively import `src/`,
+ * `bitcore-lib` or `bitcore-mnemonic`.** `src/models/network.ts` imports
+ * bitcore-lib legitimately, so any import from `src/` is enough to trip it.
+ * That is why `delay` comes from `utils/time.util` and not `utils/core.util`,
+ * which reaches bitcore through its key-derivation helpers.
+ *
+ * Without this check the symptom is every suite failing before a single test
+ * runs, carrying bitcore's own message blaming duplicate installs — which sends
+ * you hunting for a second copy in node_modules that does not exist.
+ */
+function assertGlobalSetupStayedLight(): void {
+  if ((global as unknown as Record<string, unknown>)._bitcore) {
+    throw new Error(
+      'Integration globalSetup loaded bitcore-lib. Something in its import graph ' +
+        'reaches src/ or bitcore-*, which makes every test suite fail before it ' +
+        'starts, with a misleading "more than one instance of bitcore-lib" error. ' +
+        'Keep this file dependency-light — see __tests__/integration/utils/time.util.ts.'
+    );
+  }
+}
+
 export default async function globalSetup(): Promise<void> {
+  assertGlobalSetupStayedLight();
+
   const startedAt = Date.now();
   const status = await ithService.waitUntilReady();
   const waitedMs = Date.now() - startedAt;

--- a/__tests__/integration/configuration/test.config.ts
+++ b/__tests__/integration/configuration/test.config.ts
@@ -47,4 +47,11 @@ module.exports = {
   ithTimeoutMs: positiveIntEnv('ITH_TIMEOUT_MS', 45000),
   ithMaxRetries: positiveIntEnv('ITH_MAX_RETRIES', 5, { min: 0 }),
   ithRetryBaseDelayMs: positiveIntEnv('ITH_RETRY_BASE_DELAY_MS', 500),
+
+  // Readiness gate (see configuration/global-setup.ts). The helper reports 503
+  // until it has synced the genesis wallet and split the funding pool, which on
+  // a cold private network waits out genesis reward-lock maturity — hence the
+  // generous default ceiling.
+  ithReadyTimeoutMs: positiveIntEnv('ITH_READY_TIMEOUT_MS', 300000),
+  ithReadyPollIntervalMs: positiveIntEnv('ITH_READY_POLL_INTERVAL_MS', 2000),
 };

--- a/__tests__/integration/helpers/ith-service.ts
+++ b/__tests__/integration/helpers/ith-service.ts
@@ -46,6 +46,18 @@ export interface FundResult {
   utxoSource: 'test' | 'leftover' | 'large';
 }
 
+/**
+ * The helper's readiness report. `ready` is false until it has synced the
+ * genesis wallet and split the funding pool; the remaining fields are pool
+ * statistics whose exact set varies by helper version.
+ */
+export interface ReadyStatus {
+  ready: boolean;
+  readyReason?: string;
+  testUtxos?: number;
+  [stat: string]: unknown;
+}
+
 /** A typed failure from the helper (or the transport), carrying the RFC error contract. */
 export class IthServiceError extends Error {
   readonly code: string;
@@ -68,6 +80,8 @@ interface IthConfig {
   timeoutMs: number;
   maxRetries: number;
   retryBaseDelayMs: number;
+  readyTimeoutMs: number;
+  readyPollIntervalMs: number;
 }
 
 function ithConfig(): IthConfig {
@@ -79,6 +93,8 @@ function ithConfig(): IthConfig {
     timeoutMs: testConfig.ithTimeoutMs,
     maxRetries: testConfig.ithMaxRetries,
     retryBaseDelayMs: testConfig.ithRetryBaseDelayMs,
+    readyTimeoutMs: testConfig.ithReadyTimeoutMs,
+    readyPollIntervalMs: testConfig.ithReadyPollIntervalMs,
   };
 }
 
@@ -232,5 +248,55 @@ export const ithService = {
       );
     }
     return result;
+  },
+
+  /**
+   * GET /ready — readiness probe.
+   *
+   * Deliberately does NOT go through {@link request}: a 503 here is the
+   * helper's documented "not ready yet" answer, not a failure, and it carries
+   * no `retryable` field — so the generic path would fail fast on the one
+   * response a caller most expects to see. Reports the state instead of
+   * throwing, and folds a transport error into the same "not ready" shape,
+   * since a helper that is not listening yet is indistinguishable from one
+   * that is still warming up to anybody who is polling.
+   */
+  async ready(): Promise<ReadyStatus> {
+    const { baseUrl, timeoutMs } = ithConfig();
+    try {
+      const res = await axios.get<ReadyStatus>(`${baseUrl}/ready`, {
+        timeout: timeoutMs,
+        validateStatus: () => true,
+      });
+      return { ...res.data, ready: res.status === 200 && res.data?.ready === true };
+    } catch (transportError) {
+      return { ready: false, readyReason: (transportError as Error).message };
+    }
+  },
+
+  /** Poll {@link ready} until the helper reports ready, or throw at the deadline. */
+  async waitUntilReady(
+    options: { timeoutMs?: number; pollIntervalMs?: number } = {}
+  ): Promise<ReadyStatus> {
+    const { readyTimeoutMs, readyPollIntervalMs } = ithConfig();
+    const timeoutMs = options.timeoutMs ?? readyTimeoutMs;
+    const pollIntervalMs = options.pollIntervalMs ?? readyPollIntervalMs;
+    const deadline = Date.now() + timeoutMs;
+
+    let status: ReadyStatus = { ready: false, readyReason: 'not yet polled' };
+    for (;;) {
+      status = await this.ready();
+      if (status.ready) {
+        return status;
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `The integration-test-helper did not become ready within ${timeoutMs}ms ` +
+            `(last reported: ${status.readyReason ?? 'no reason given'}). ` +
+            `Check that the wallet-provider container is running and healthy.`
+        );
+      }
+      await delay(pollIntervalMs);
+    }
   },
 };

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -11,6 +11,8 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['<rootDir>/src/**/*.js', '<rootDir>/src/**/*.ts'],
   testMatch: [mainTestMatch],
+  // Blocks the whole suite until the integration-test-helper reports ready.
+  globalSetup: '<rootDir>/__tests__/integration/configuration/global-setup.ts',
   coverageReporters: ['text-summary', 'lcov', 'clover'],
   testTimeout: 20 * 60 * 1000, // May be adjusted with optimizations
   setupFilesAfterEnv: ['<rootDir>/setupTests-integration.js'],


### PR DESCRIPTION
Part 3 of 9. Base: `ith/2-funding`.

Adds a jest `globalSetup` that polls the helper's `/ready` before any suite runs. Without it, a helper still seeding its UTXO pool produces funding failures scattered across unrelated tests, each looking like its own bug.

It also guards `globalSetup` against loading `bitcore-lib`. `globalSetup` runs before test environments are constructed, and bitcore's `versionGuard` uses a `global._bitcore` key that jest copies into every new context — so a stray import there breaks all 60 suites with `0 tests` and no usable error. This was not hypothetical: reusing `delay()` from `core.util.ts` (which imports `bitcore-mnemonic`) produced exactly that during development. The guard turns a silent whole-suite failure into a message naming the cause.

### Acceptance Criteria
- The suite waits for helper readiness instead of failing scattered tests during pool seeding.
- Adding a bitcore-reaching import to `globalSetup` fails with an explanatory error rather than an empty run.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
