### PR TITLE
test(itest): log helper status on funding failure

### DIFF
--- a/__tests__/integration/helpers/ith-service.ts
+++ b/__tests__/integration/helpers/ith-service.ts
@@ -58,6 +58,20 @@ export interface ReadyStatus {
   [stat: string]: unknown;
 }
 
+/**
+ * The helper's operator diagnostic: readiness plus pool counts, the genesis
+ * address, and the bootstrap/funding lifecycle state. Field set varies by
+ * helper version, so everything past `ready` is optional.
+ */
+export interface HelperStatus {
+  ready: boolean;
+  readyReason?: string;
+  genesisAddress?: string | null;
+  startup?: unknown;
+  funding?: unknown;
+  [stat: string]: unknown;
+}
+
 /** A typed failure from the helper (or the transport), carrying the RFC error contract. */
 export class IthServiceError extends Error {
   readonly code: string;
@@ -199,6 +213,24 @@ async function request<T>(
   throw new Error(`ithService ${method} ${path}: retry loop exited without a result`);
 }
 
+/**
+ * Best-effort diagnostic dump of the helper's own view of itself, for when a
+ * funding call has already failed.
+ *
+ * Swallows its own errors on purpose: this runs on a path where an exception is
+ * already in flight, and a failure to *describe* that problem must never
+ * replace the problem itself. The worst case is one extra log line saying the
+ * diagnostic was unavailable.
+ */
+async function logHelperStatus(): Promise<void> {
+  try {
+    const status = await ithService.status();
+    loggers.test?.error(`ithService /status at failure: ${JSON.stringify(status)}`);
+  } catch (statusError) {
+    loggers.test?.error(`ithService could not read /status: ${(statusError as Error).message}`);
+  }
+}
+
 export const ithService = {
   /**
    * GET /simpleWallet — a fresh precalculated wallet.
@@ -235,19 +267,37 @@ export const ithService = {
     if (amount !== undefined) {
       payload.amount = amount.toString();
     }
-    const result = await request<FundResult>('post', '/fund', { idempotent: false }, payload);
-    // A 2xx is not proof of a usable body: a proxy error page or a renamed field
-    // would otherwise reach waitForTxReceived as `undefined` and hang for the
-    // full timeout with nothing pointing back at funding.
-    if (!result?.txId) {
-      throw new IthServiceError(
-        `POST /fund returned no txId${describeBody(result)}`,
-        'MALFORMED_RESPONSE',
-        false,
-        200
-      );
+    try {
+      const result = await request<FundResult>('post', '/fund', { idempotent: false }, payload);
+      // A 2xx is not proof of a usable body: a proxy error page or a renamed
+      // field would otherwise reach waitForTxReceived as `undefined` and hang
+      // for the full timeout with nothing pointing back at funding.
+      if (!result?.txId) {
+        throw new IthServiceError(
+          `POST /fund returned no txId${describeBody(result)}`,
+          'MALFORMED_RESPONSE',
+          false,
+          200
+        );
+      }
+      return result;
+    } catch (fundError) {
+      // Every throw reaching here is terminal — retries exhausted, a fail-fast
+      // non-retryable code, or a malformed body — so this is the right moment
+      // to capture the helper's state. Doing it here rather than at each call
+      // site means every funding path gets the diagnostic for free.
+      await logHelperStatus();
+      throw fundError;
     }
-    return result;
+  },
+
+  /**
+   * GET /status — operator diagnostic: readiness, pool counts, genesis address,
+   * bootstrap phase and funding lifecycle. Always 200, so the shared retry path
+   * applies normally. Idempotent: it is a pure read.
+   */
+  async status(): Promise<HelperStatus> {
+    return request<HelperStatus>('get', '/status', { idempotent: true });
   },
 
   /**

--- a/__tests__/utils/ithService.test.ts
+++ b/__tests__/utils/ithService.test.ts
@@ -148,9 +148,16 @@ describe('ithService idempotency', () => {
     mockedAxios.request.mockRejectedValue(new Error('timeout of 45000ms exceeded'));
 
     await expect(ithService.fund('addr', 10n)).rejects.toThrow('timeout');
+
+    // Count only the funding calls: a failed fund also fires a best-effort
+    // GET /status diagnostic, which is a separate request and must not be
+    // mistaken for a retry.
+    const fundCalls = mockedAxios.request.mock.calls.filter(([cfg]) =>
+      String(cfg?.url).endsWith('/fund')
+    );
     // A timed-out fund may already have reserved a UTXO and broadcast; replaying
     // it would double-fund the address.
-    expect(mockedAxios.request).toHaveBeenCalledTimes(1);
+    expect(fundCalls).toHaveLength(1);
   });
 
   it('still honours a helper-declared retryable failure on POST /fund', async () => {


### PR DESCRIPTION
Part 4 of 9. Base: `ith/3-ready`.

When a funding call fails, the suite now queries the helper's `/status` and logs it alongside the error.

Delegating funding to the helper created a failure mode that did not exist when the suite broadcast for itself: the helper funds successfully but our wallet never sees the transaction. In a CI log that is indistinguishable from the helper refusing to fund, and the two have opposite fixes. Recording the helper's own view of itself at the moment of failure — pool size, funding counters, readiness — is enough to tell them apart without reproducing locally.

The status call deliberately swallows its own errors: it runs on a path where an exception is already in flight, and a failure to *describe* a problem must never replace the problem itself. Worst case is one extra log line saying the diagnostic was unavailable.

### Acceptance Criteria
- A funding failure logs helper-side state next to the client-side error.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
