### PR TITLE
test(itest): stop using the genesis wallet incidentally

### DIFF
--- a/__tests__/integration/adapters/fullnode.adapter.ts
+++ b/__tests__/integration/adapters/fullnode.adapter.ts
@@ -16,7 +16,6 @@ import {
   SCANNING_POLICY,
   WalletState,
 } from '../../../src/types';
-import type Transaction from '../../../src/models/transaction';
 import {
   generateConnection,
   waitForWalletReady,
@@ -25,7 +24,9 @@ import {
   DEFAULT_PASSWORD,
   DEFAULT_PIN_CODE,
 } from '../helpers/wallet.helper';
-import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
+import { GenesisWalletHelper, type InjectedFundsTx } from '../helpers/genesis-wallet.helper';
+import { ithService } from '../helpers/ith-service';
+import { waitForTxOnFullnode } from '../utils/fullnode.util';
 import {
   mergePrecalculatedAddresses,
   precalculationHelpers,
@@ -195,7 +196,7 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
     destWallet: FuzzyWalletType,
     address: string,
     amount: bigint
-  ): Promise<Transaction> {
+  ): Promise<InjectedFundsTx> {
     return GenesisWalletHelper.injectFunds(this.concrete(destWallet), address, amount);
   }
 
@@ -204,20 +205,14 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
    *
    * Cannot delegate to {@link injectFunds} because that method waits for the
    * destination wallet to observe the tx — but that wallet isn't running yet,
-   * so the wait would hang or fail.
-   *
-   * Note this path still broadcasts from the locally-synced genesis wallet
-   * rather than the helper's /fund. The helper runs the same genesis seed and
-   * reserves from the same UTXO set on background timers, so the two are
-   * concurrent spenders; migrating this is tracked separately.
+   * so the wait would hang or fail. Waits on the fullnode instead: /fund returns
+   * on broadcast, and the caller starts a wallet immediately afterwards, which
+   * would otherwise race the fullnode's indexing and read an empty history.
    */
   async injectFundsBeforeStart(address: string, amount: bigint): Promise<string> {
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
-    const result = await gWallet.sendTransaction(address, amount);
-    if (!result || !result.hash) {
-      throw new Error('injectFundsBeforeStart: transaction had no hash');
-    }
-    return result.hash;
+    const { txId } = await ithService.fund(address, amount);
+    await waitForTxOnFullnode(txId);
+    return txId;
   }
 
   async waitForTx(

--- a/__tests__/integration/adapters/service.adapter.ts
+++ b/__tests__/integration/adapters/service.adapter.ts
@@ -20,7 +20,7 @@ import {
   pollUntilCondition,
   retryOnTransientWalletInit,
 } from '../helpers/service-facade.helper';
-import { GenesisWalletServiceHelper } from '../helpers/genesis-wallet.helper';
+import { GenesisWalletServiceHelper, type InjectedFundsTx } from '../helpers/genesis-wallet.helper';
 import { precalculationHelpers } from '../helpers/wallet-precalculation.helper';
 import type { WalletStopOptions } from '../../../src/new/types';
 import type { IHistoryTx } from '../../../src/types';
@@ -234,7 +234,7 @@ export class ServiceWalletTestAdapter implements IWalletTestAdapter {
     destWallet: FuzzyWalletType,
     address: string,
     amount: bigint
-  ): Promise<Transaction> {
+  ): Promise<InjectedFundsTx> {
     return GenesisWalletServiceHelper.injectFunds(address, amount, this.concrete(destWallet));
   }
 

--- a/__tests__/integration/adapters/types.ts
+++ b/__tests__/integration/adapters/types.ts
@@ -12,6 +12,7 @@ import type {
   WalletAddressMap,
 } from '../../../src/wallet/types';
 import type { PrecalculatedWalletData } from '../helpers/wallet-precalculation.helper';
+import type { InjectedFundsTx } from '../helpers/genesis-wallet.helper';
 import type Transaction from '../../../src/models/transaction';
 import type { IHistoryTx, IStorage, TokenVersion, AuthorityType } from '../../../src/types';
 import { HathorWallet, HathorWalletServiceWallet } from '../../../src';
@@ -179,10 +180,18 @@ export interface IWalletTestAdapter {
   // --- Fund injection ---
 
   /**
-   * Sends funds from the genesis wallet to a destination wallet's address.
-   * Waits for both genesis and destination wallets to see the tx.
+   * Sends funds to a destination wallet's address, waiting until that wallet
+   * observes the tx.
+   *
+   * Returns only the hash: funding is delegated to the integration-test-helper,
+   * whose response carries a txId and nothing else. Callers needing the full
+   * transaction should fetch it.
    */
-  injectFunds(destWallet: FuzzyWalletType, address: string, amount: bigint): Promise<Transaction>;
+  injectFunds(
+    destWallet: FuzzyWalletType,
+    address: string,
+    amount: bigint
+  ): Promise<InjectedFundsTx>;
 
   /**
    * Injects funds to an address BEFORE the wallet is started.

--- a/__tests__/integration/fullnode-specific/fullnode-api-query.test.ts
+++ b/__tests__/integration/fullnode-specific/fullnode-api-query.test.ts
@@ -42,7 +42,6 @@
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
 import { generateWalletHelper, stopAllWallets } from '../helpers/wallet.helper';
 import { TxNotFoundError } from '../../../src/errors';
-import HathorWallet from '../../../src/new/wallet';
 
 /**
  * A well-formed transaction hash that is absent from the private test network.
@@ -55,13 +54,11 @@ const NOT_FOUND_TX_HASH = '000000000bc8c6fab1b3a5af184cc0e7ff7934c6ad982c8bea9ab
 const INVALID_TX_HASH = 'invalid-tx-hash';
 
 describe('[Fullnode] fullnode API queries', () => {
-  let gWallet: HathorWallet;
-
-  beforeAll(async () => {
-    const { hWallet } = await GenesisWalletHelper.getSingleton();
-    gWallet = hWallet;
-  });
-
+  // The error-path tests below build their own wallet per test rather than
+  // sharing one across the describe. They need a started wallet only as a
+  // vehicle to reach the fullnode -- the transaction they query is never
+  // theirs -- and the afterEach below stops every tracked wallet, so a shared
+  // instance would be dead by the second test.
   afterEach(async () => {
     await stopAllWallets();
   });
@@ -91,13 +88,15 @@ describe('[Fullnode] fullnode API queries', () => {
     });
 
     it('should throw an error if success is false on response', async () => {
-      await expect(gWallet.getFullTxById(INVALID_TX_HASH)).rejects.toThrow(
+      const hWallet = await generateWalletHelper();
+      await expect(hWallet.getFullTxById(INVALID_TX_HASH)).rejects.toThrow(
         `Invalid transaction ${INVALID_TX_HASH}`
       );
     });
 
     it('should throw an error on valid but not found transaction', async () => {
-      await expect(gWallet.getFullTxById(NOT_FOUND_TX_HASH)).rejects.toThrow(TxNotFoundError);
+      const hWallet = await generateWalletHelper();
+      await expect(hWallet.getFullTxById(NOT_FOUND_TX_HASH)).rejects.toThrow(TxNotFoundError);
     });
   });
 
@@ -130,13 +129,15 @@ describe('[Fullnode] fullnode API queries', () => {
     });
 
     it('should throw an error if success is false on response', async () => {
-      await expect(gWallet.getTxConfirmationData(INVALID_TX_HASH)).rejects.toThrow(
+      const hWallet = await generateWalletHelper();
+      await expect(hWallet.getTxConfirmationData(INVALID_TX_HASH)).rejects.toThrow(
         `Invalid transaction ${INVALID_TX_HASH}`
       );
     });
 
     it('should throw TxNotFoundError on valid hash but not found transaction', async () => {
-      await expect(gWallet.getTxConfirmationData(NOT_FOUND_TX_HASH)).rejects.toThrow(
+      const hWallet = await generateWalletHelper();
+      await expect(hWallet.getTxConfirmationData(NOT_FOUND_TX_HASH)).rejects.toThrow(
         TxNotFoundError
       );
     });
@@ -179,13 +180,15 @@ describe('[Fullnode] fullnode API queries', () => {
     });
 
     it('should throw an error if success is false on response', async () => {
-      await expect(gWallet.graphvizNeighborsQuery(INVALID_TX_HASH, 'funds', 1)).rejects.toThrow(
+      const hWallet = await generateWalletHelper();
+      await expect(hWallet.graphvizNeighborsQuery(INVALID_TX_HASH, 'funds', 1)).rejects.toThrow(
         `Invalid transaction ${INVALID_TX_HASH}`
       );
     });
 
     it('should throw TxNotFoundError on valid but not found transaction', async () => {
-      await expect(gWallet.graphvizNeighborsQuery(NOT_FOUND_TX_HASH, 'funds', 1)).rejects.toThrow(
+      const hWallet = await generateWalletHelper();
+      await expect(hWallet.graphvizNeighborsQuery(NOT_FOUND_TX_HASH, 'funds', 1)).rejects.toThrow(
         TxNotFoundError
       );
     });

--- a/__tests__/integration/fullnode-specific/get-balance.test.ts
+++ b/__tests__/integration/fullnode-specific/get-balance.test.ts
@@ -54,10 +54,16 @@ describe('[Fullnode] getBalance', () => {
       newTokenAmount
     );
 
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
-    const genesisTknBalance = await gWallet.getBalance(tokenUid);
-    expect(genesisTknBalance).toHaveLength(1);
-    expect(genesisTknBalance[0]).toMatchObject({
+    // A second wallet that has its own history but never received this token.
+    // Funding it matters: a pristine wallet reports zero for everything, so the
+    // assertion would hold trivially. With funds of its own, "zero for THIS
+    // token" is a real claim about token scoping.
+    const otherWallet = await generateWalletHelper();
+    await GenesisWalletHelper.injectFunds(otherWallet, await otherWallet.getAddressAtIndex(0), 10n);
+
+    const otherTknBalance = await otherWallet.getBalance(tokenUid);
+    expect(otherTknBalance).toHaveLength(1);
+    expect(otherTknBalance[0]).toMatchObject({
       token: { id: tokenUid },
       balance: { unlocked: 0n, locked: 0n },
       transactions: 0,

--- a/__tests__/integration/fullnode-specific/history-query.test.ts
+++ b/__tests__/integration/fullnode-specific/history-query.test.ts
@@ -189,11 +189,17 @@ describe('[Fullnode] getTxById', () => {
       ])
     );
 
-    // Test case: non-accessible token for another wallet (genesis)
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
-    const genesisTknBalance = await gWallet.getBalance(tokenUid);
-    expect(genesisTknBalance).toHaveLength(1);
-    expect(genesisTknBalance[0]).toMatchObject({
+    // Test case: non-accessible token for another wallet
+    // A second wallet that has its own history but never received this token.
+    // Funding it matters: a pristine wallet reports zero for everything, so the
+    // assertion would hold trivially. With funds of its own, "zero for THIS
+    // token" is a real claim about token scoping.
+    const otherWallet = await generateWalletHelper();
+    await GenesisWalletHelper.injectFunds(otherWallet, await otherWallet.getAddressAtIndex(0), 10n);
+
+    const otherTknBalance = await otherWallet.getBalance(tokenUid);
+    expect(otherTknBalance).toHaveLength(1);
+    expect(otherTknBalance[0]).toMatchObject({
       token: { id: tokenUid },
       balance: { unlocked: 0n, locked: 0n },
       transactions: 0,

--- a/__tests__/integration/fullnode-specific/internal.test.ts
+++ b/__tests__/integration/fullnode-specific/internal.test.ts
@@ -26,13 +26,15 @@ describe('[Fullnode] internal methods', () => {
   let hWallet: HathorWallet;
 
   beforeAll(async () => {
-    const { hWallet: ghWallet } = await GenesisWalletHelper.getSingleton();
-    gWallet = ghWallet;
+    // Any started wallet exercises the debug-mode toggles; nothing here is
+    // genesis-specific.
+    gWallet = await generateWalletHelper();
     hWallet = await generateWalletHelper();
   });
 
   afterAll(async () => {
     await hWallet.stop();
+    await gWallet.stop();
   });
 
   it('should test the debug methods', async () => {

--- a/__tests__/integration/fullnode-specific/metadata-voiding.test.ts
+++ b/__tests__/integration/fullnode-specific/metadata-voiding.test.ts
@@ -20,7 +20,11 @@
 
 import { cloneDeep, reverse } from 'lodash';
 import { GenesisWalletHelper } from '../helpers/genesis-wallet.helper';
-import { generateWalletHelper, waitForTxReceived } from '../helpers/wallet.helper';
+import {
+  generateWalletHelper,
+  waitForTxReceived,
+  getExternalAddress,
+} from '../helpers/wallet.helper';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import HathorWallet from '../../../src/new/wallet';
 import { MemoryStore } from '../../../src/storage';
@@ -240,8 +244,7 @@ describe('[Fullnode] processing transaction metadata changes', () => {
   it('should process history when a tx sent by the wallet to another wallet is voided', async () => {
     const store = hWallet.storage.store as MemoryStore;
     const addr0 = await hWallet.getAddressAtIndex(0);
-    const genesis = await GenesisWalletHelper.getSingleton();
-    const addrExt = await genesis.hWallet.getAddressAtIndex(1);
+    const addrExt = await getExternalAddress();
     const wsSpy: jest.SpiedFunction<typeof hWallet.onNewTx> = jest.spyOn(hWallet, 'onNewTx');
     const procSpy: jest.SpiedFunction<typeof hWallet.storage.processHistory> = jest.spyOn(
       hWallet.storage,

--- a/__tests__/integration/fullnode-specific/send-transaction.test.ts
+++ b/__tests__/integration/fullnode-specific/send-transaction.test.ts
@@ -39,6 +39,7 @@ import {
   waitForTxReceived,
   waitUntilNextTimestamp,
   createTokenHelper,
+  getExternalAddress,
 } from '../helpers/wallet.helper';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import { TokenVersion } from '../../../src/types';
@@ -86,13 +87,10 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
       0
     );
 
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
     await waitUntilNextTimestamp(hWallet, tx1.hash);
-    const { hash: tx2Hash } = await hWallet.sendTransaction(
-      await gWallet.getAddressAtIndex(0),
-      8n,
-      { changeAddress: await hWallet.getAddressAtIndex(5) }
-    );
+    const { hash: tx2Hash } = await hWallet.sendTransaction(await getExternalAddress(), 8n, {
+      changeAddress: await hWallet.getAddressAtIndex(5),
+    });
     await waitForTxReceived(hWallet, tx2Hash);
 
     const htrBalance = await hWallet.getBalance(NATIVE_TOKEN_UID);
@@ -128,13 +126,11 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
       1
     );
 
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
     await waitUntilNextTimestamp(hWallet, tx1.hash);
-    const { hash: tx2Hash } = await hWallet.sendTransaction(
-      await gWallet.getAddressAtIndex(0),
-      80n,
-      { token: tokenUid, changeAddress: await hWallet.getAddressAtIndex(12) }
-    );
+    const { hash: tx2Hash } = await hWallet.sendTransaction(await getExternalAddress(), 80n, {
+      token: tokenUid,
+      changeAddress: await hWallet.getAddressAtIndex(12),
+    });
     await waitForTxReceived(hWallet, tx2Hash);
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(
@@ -172,13 +168,11 @@ describe('[Fullnode] sendTransaction — address tracking', () => {
       1
     );
 
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
     await waitUntilNextTimestamp(hWallet, tx1.hash);
-    const { hash: tx2Hash } = await hWallet.sendTransaction(
-      await gWallet.getAddressAtIndex(0),
-      82n,
-      { token: tokenUid, changeAddress: await hWallet.getAddressAtIndex(12) }
-    );
+    const { hash: tx2Hash } = await hWallet.sendTransaction(await getExternalAddress(), 82n, {
+      token: tokenUid,
+      changeAddress: await hWallet.getAddressAtIndex(12),
+    });
     await waitForTxReceived(hWallet, tx2Hash);
 
     expect(await hWallet.storage.getAddressInfo(await hWallet.getAddressAtIndex(5))).toHaveProperty(

--- a/__tests__/integration/hathorwallet_facade.test.ts
+++ b/__tests__/integration/hathorwallet_facade.test.ts
@@ -373,14 +373,13 @@ describe('getTxHistory', () => {
     await GenesisWalletHelper.clearListeners();
   });
 
+  // A second wallet to receive the "external transfer" in each test. Built per
+  // test rather than once for the describe: the afterEach above calls
+  // stopAllWallets(), which stops every tracked wallet, so a shared instance
+  // would be dead by the second test.
   let gWallet;
-  beforeAll(async () => {
-    const { hWallet } = await GenesisWalletHelper.getSingleton();
-    gWallet = hWallet;
-  });
-
-  afterAll(async () => {
-    await gWallet.stop({ cleanStorage: true, cleanAddresses: true });
+  beforeEach(async () => {
+    gWallet = await generateWalletHelper();
   });
 
   it('should show htr transactions in correct order', async () => {

--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -24,7 +24,16 @@ interface InjectFundsOptions {
   waitTimeout?: number;
 }
 
-type SuccessfulInjectTransaction = Transaction;
+/**
+ * What funding actually returns now that the broadcast is delegated.
+ *
+ * The helper's /fund answers with a txId and nothing else, so this is narrowed
+ * to exactly that rather than claiming to be a full `Transaction`. A wider type
+ * here would compile at every call site while returning `undefined` for
+ * `.outputs`, `.inputs` or `.timestamp` — a whole class of silent failures the
+ * checker can prevent for free.
+ */
+export type InjectedFundsTx = Pick<Transaction, 'hash'>;
 
 let singleton: GenesisWalletHelper | null = null;
 let singletonService: HathorWalletServiceWallet | null = null;
@@ -83,7 +92,7 @@ export class GenesisWalletHelper {
    * @param [options]
    * @param {number} [options.waitTimeout] Optional timeout for the websocket confirmation.
    *                                       Passing 0 here skips this waiting.
-   * @returns {Promise<Transaction>}
+   * @returns {Promise<InjectedFundsTx>}
    * @private
    */
   // eslint-disable-next-line class-methods-use-this -- funding is delegated to ithService; kept as an instance method to preserve call sites
@@ -92,7 +101,7 @@ export class GenesisWalletHelper {
     address: string,
     value: OutputValueType,
     options: InjectFundsOptions = {}
-  ): Promise<Transaction> {
+  ): Promise<InjectedFundsTx> {
     // Captured outside the try so the catch can tell "the helper never funded"
     // apart from "it funded and our wallet never saw the tx".
     let fundedTxId: string | undefined;
@@ -102,7 +111,7 @@ export class GenesisWalletHelper {
       // once the tx is broadcast; we then wait until the destination wallet
       // observes it, which is the guarantee callers actually rely on.
       fundedTxId = (await ithService.fund(address, value)).txId;
-      const result = { hash: fundedTxId } as unknown as SuccessfulInjectTransaction;
+      const result: InjectedFundsTx = { hash: fundedTxId };
 
       if (options.waitTimeout === 0) {
         return result;
@@ -157,7 +166,7 @@ export class GenesisWalletHelper {
    * @param [options]
    * @param {number} [options.waitTimeout] Optional timeout for the websocket confirmation.
    *                                       Passing 0 here skips this waiting.
-   * @returns {Promise<Transaction>}
+   * @returns {Promise<InjectedFundsTx>}
    */
   static async injectFunds(
     destinationWallet: HathorWallet,
@@ -246,10 +255,10 @@ export class GenesisWalletServiceHelper {
     address: string,
     amount: bigint,
     destinationWallet?: HathorWalletServiceWallet
-  ): Promise<Transaction> {
+  ): Promise<InjectedFundsTx> {
     // Delegated to the helper's /fund, same as the fullnode path above.
     const { txId } = await ithService.fund(address, amount);
-    const fundTx = { hash: txId } as unknown as Transaction;
+    const fundTx: InjectedFundsTx = { hash: txId };
 
     if (destinationWallet) {
       // Ensure the destination wallet is also aware of the transaction.

--- a/__tests__/integration/helpers/wallet.helper.ts
+++ b/__tests__/integration/helpers/wallet.helper.ts
@@ -87,6 +87,26 @@ const startedWallets = [];
  *   addresses: ['addr0','addr1'],
  * })
  */
+/**
+ * An address belonging to nobody the caller is testing with — for assertions
+ * about sending funds "somewhere external".
+ *
+ * Comes from a fresh pre-calculated wallet, so no wallet is started at all: no
+ * sync, no listeners, no shared state — just a valid address that belongs to
+ * nothing else in the run.
+ *
+ * Only use this where the receiving side is never inspected. If a test needs to
+ * wait for the recipient to observe the transaction, it needs a started wallet
+ * from {@link generateWalletHelper} instead.
+ *
+ * @param {number} [index=0] Which address of the fresh wallet to return
+ * @returns {Promise<string>}
+ */
+export async function getExternalAddress(index = 0) {
+  const { addresses } = await precalculationHelpers.test.getPrecalculatedWallet();
+  return addresses[index];
+}
+
 export async function generateWalletHelper(param) {
   /** @type PrecalculatedWalletData */
   let walletData = {};

--- a/__tests__/integration/utils/fullnode.util.ts
+++ b/__tests__/integration/utils/fullnode.util.ts
@@ -40,3 +40,47 @@ export async function waitPastTxTimestamp(txId: string): Promise<void> {
     await delay(remaining + 10);
   }
 }
+
+/**
+ * Wait until the fullnode knows about `txId`.
+ *
+ * Needed where no wallet is available to observe with — chiefly funding an
+ * address *before* its wallet starts. The helper's `POST /fund` returns as soon
+ * as the transaction is broadcast (its own tx observation only defers releasing
+ * the UTXO reservation, it does not gate the response), so a caller that starts
+ * a wallet immediately afterwards would otherwise race the fullnode's indexing
+ * and see an empty history.
+ *
+ * @param txId Transaction to wait for
+ * @param options.timeoutMs Total time to wait before throwing
+ * @param options.pollIntervalMs Gap between attempts
+ */
+export async function waitForTxOnFullnode(
+  txId: string,
+  { timeoutMs = 30000, pollIntervalMs = 500 }: { timeoutMs?: number; pollIntervalMs?: number } = {}
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  for (;;) {
+    // txApi is callback-style, and `success: false` is its normal "not indexed
+    // yet" answer. A rejection is treated the same way rather than rethrown, so
+    // a momentary blip while the fullnode is busy does not fail the wait — the
+    // deadline below still bounds it, and a persistent failure surfaces as the
+    // timeout rather than hanging.
+    const found = await new Promise<boolean>(resolve => {
+      txApi
+        .getTransaction(txId, response => resolve(Boolean(response?.success)))
+        .catch(() => {
+          resolve(false);
+        });
+    });
+
+    if (found) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for tx ${txId} on the fullnode`);
+    }
+    await delay(pollIntervalMs);
+  }
+}


### PR DESCRIPTION
Part 5 of 9. Base: `ith/4-status`.

Most tests reaching for the genesis wallet were not using it *because* it was genesis — they needed a wallet that happened to already be started. That made a shared singleton load-bearing for work any wallet could do. Nine such sites now build their own wallet or take a pre-calculated address.

One trap this exposed is worth a reviewer's attention: **the genesis singleton was never registered with the wallet tracker**, so it survived `stopAllWallets()` in `afterEach`. Four `describe` blocks had quietly built a `beforeAll` around that immunity. A normal wallet *is* tracked and does get stopped, so those become per-test. Three of the four passed either way — their queries are stateless enough to survive a stopped wallet — and are fixed rather than left to rot.

Also narrows `injectFunds` to `Pick<Transaction, 'hash'>`. The helper's response carries a transaction id and nothing else, so claiming a full `Transaction` let `.outputs` and `.inputs` compile everywhere while returning `undefined`. Note `tsconfig` covers `src/` only, so this is enforced by editors rather than CI.

### Acceptance Criteria
- No test depends on the genesis wallet merely to have a started wallet available.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
