### PR TITLE
test(itest): stop starting the genesis wallet

### DIFF
--- a/__tests__/integration/adapters/fullnode.adapter.ts
+++ b/__tests__/integration/adapters/fullnode.adapter.ts
@@ -125,8 +125,8 @@ export class FullnodeWalletTestAdapter implements IWalletTestAdapter {
   }
 
   async suiteSetup(): Promise<void> {
-    // GenesisWalletHelper lazily initializes via getSingleton(), no explicit setup needed.
-    await GenesisWalletHelper.getSingleton();
+    // Nothing to warm up: funding goes through the integration-test-helper, and
+    // the suite gates on its readiness in globalSetup.
   }
 
   async suiteTeardown(): Promise<void> {

--- a/__tests__/integration/fullnode-specific/address-info.test.ts
+++ b/__tests__/integration/fullnode-specific/address-info.test.ts
@@ -232,21 +232,29 @@ describe('[Fullnode] getTxAddresses', () => {
 
   it('should identify transaction addresses correctly', async () => {
     const hWallet = await generateWalletHelper();
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
+
+    // The sender is an ordinary funded wallet rather than the genesis one. All
+    // this test needs is a wallet that built the transaction, so it can assert
+    // what the *sending* side sees in it. Funding index 0 and sending change
+    // back to index 0 keeps the sender's footprint to a single address, which
+    // is what the final assertion pins down.
+    const senderWallet = await generateWalletHelper();
+    const senderAddress = await senderWallet.getAddressAtIndex(0);
+    await GenesisWalletHelper.injectFunds(senderWallet, senderAddress, 20n);
 
     // Generating a transaction with outputs to multiple addresses
-    const tx = await gWallet.sendManyOutputsTransaction(
+    const tx = await senderWallet.sendManyOutputsTransaction(
       [
         { address: await hWallet.getAddressAtIndex(1), value: 1n, token: NATIVE_TOKEN_UID },
         { address: await hWallet.getAddressAtIndex(3), value: 3n, token: NATIVE_TOKEN_UID },
         { address: await hWallet.getAddressAtIndex(5), value: 5n, token: NATIVE_TOKEN_UID },
       ],
       {
-        changeAddress: WALLET_CONSTANTS.genesis.addresses[0],
+        changeAddress: senderAddress,
       }
     );
     await waitForTxReceived(hWallet, tx.hash);
-    await waitForTxReceived(gWallet, tx.hash);
+    await waitForTxReceived(senderWallet, tx.hash);
 
     // Validating the method results
     const decodedTx = await hWallet.getTx(tx.hash);
@@ -258,9 +266,10 @@ describe('[Fullnode] getTxAddresses', () => {
       ])
     );
 
-    // By convention, only the address 0 of the genesis wallet is used on the integration tests
-    await expect(gWallet.getTxAddresses(decodedTx)).resolves.toStrictEqual(
-      new Set([WALLET_CONSTANTS.genesis.addresses[0]])
+    // The sender funded and took change on a single address, so that is the
+    // whole of its footprint in this transaction.
+    await expect(senderWallet.getTxAddresses(decodedTx)).resolves.toStrictEqual(
+      new Set([senderAddress])
     );
   });
 });

--- a/__tests__/integration/helpers/genesis-wallet.helper.ts
+++ b/__tests__/integration/helpers/genesis-wallet.helper.ts
@@ -38,6 +38,64 @@ export type InjectedFundsTx = Pick<Transaction, 'hash'>;
 let singleton: GenesisWalletHelper | null = null;
 let singletonService: HathorWalletServiceWallet | null = null;
 
+/**
+ * Send HTR to a wallet's address through the integration-test-helper.
+ *
+ * Module-level because funding no longer involves a genesis wallet: keeping it
+ * as an instance method meant callers had to construct one first, paying a full
+ * genesis sync to reach code that never touched it.
+ *
+ * @param destinationWallet Wallet receiving the funds
+ * @param address Address to fund
+ * @param value Amount to send
+ * @param [options.waitTimeout] Websocket confirmation timeout; 0 skips the wait
+ */
+async function injectFundsViaHelper(
+  destinationWallet: HathorWallet,
+  address: string,
+  value: OutputValueType,
+  options: InjectFundsOptions = {}
+): Promise<InjectedFundsTx> {
+  // Captured outside the try so the catch can tell "the helper never funded"
+  // apart from "it funded and our wallet never saw the tx".
+  let fundedTxId: string | undefined;
+  try {
+    // Funding is delegated to the helper's race-free /fund endpoint rather
+    // than broadcast from a locally-synced genesis wallet. The helper returns
+    // once the tx is broadcast; we then wait until the destination wallet
+    // observes it, which is the guarantee callers actually rely on.
+    fundedTxId = (await ithService.fund(address, value)).txId;
+    const result: InjectedFundsTx = { hash: fundedTxId };
+
+    if (options.waitTimeout === 0) {
+      return result;
+    }
+
+    await waitForTxReceived(destinationWallet, fundedTxId, options.waitTimeout);
+    // Timestamps are per-second and a tx must be timestamped strictly after
+    // its parent. Without this wait, a test that spends the just-funded UTXO
+    // within the same second collides with the funding tx and flakes. Applied
+    // via the destination wallet, which is the one that now has the tx.
+    await waitUntilNextTimestamp(destinationWallet, fundedTxId);
+    return result;
+  } catch (e) {
+    // Delegating the broadcast created a failure mode that did not exist
+    // before: the helper funded successfully and our wallet never observed
+    // the tx. Without txId that is indistinguishable in the log from "the
+    // helper refused to fund", and there is nothing to cross-reference
+    // against the helper's own logs or the fullnode.
+    const cause =
+      e instanceof IthServiceError
+        ? `${e.code} (HTTP ${e.status}, retryable=${e.retryable}): ${e.message}`
+        : (e as Error).message;
+    loggers.test!.error(
+      `Failed to inject funds: address=${address} value=${value} ` +
+        `txId=${fundedTxId ?? 'not-broadcast'} — ${cause}`
+    );
+    throw e;
+  }
+}
+
 export class GenesisWalletHelper {
   /**
    * @type HathorWallet
@@ -95,51 +153,14 @@ export class GenesisWalletHelper {
    * @returns {Promise<InjectedFundsTx>}
    * @private
    */
-  // eslint-disable-next-line class-methods-use-this -- funding is delegated to ithService; kept as an instance method to preserve call sites
+  // eslint-disable-next-line class-methods-use-this -- delegates to the module-level function; kept for the existing call shape
   async _injectFunds(
     destinationWallet: HathorWallet,
     address: string,
     value: OutputValueType,
     options: InjectFundsOptions = {}
   ): Promise<InjectedFundsTx> {
-    // Captured outside the try so the catch can tell "the helper never funded"
-    // apart from "it funded and our wallet never saw the tx".
-    let fundedTxId: string | undefined;
-    try {
-      // Funding is delegated to the helper's race-free /fund endpoint rather
-      // than broadcast from a locally-synced genesis wallet. The helper returns
-      // once the tx is broadcast; we then wait until the destination wallet
-      // observes it, which is the guarantee callers actually rely on.
-      fundedTxId = (await ithService.fund(address, value)).txId;
-      const result: InjectedFundsTx = { hash: fundedTxId };
-
-      if (options.waitTimeout === 0) {
-        return result;
-      }
-
-      await waitForTxReceived(destinationWallet, fundedTxId, options.waitTimeout);
-      // Timestamps are per-second and a tx must be timestamped strictly after
-      // its parent. Without this wait, a test that spends the just-funded UTXO
-      // within the same second collides with the funding tx and flakes. Applied
-      // via the destination wallet, which is the one that now has the tx.
-      await waitUntilNextTimestamp(destinationWallet, fundedTxId);
-      return result;
-    } catch (e) {
-      // Delegating the broadcast created a failure mode that did not exist
-      // before: the helper funded successfully and our wallet never observed
-      // the tx. Without txId that is indistinguishable in the log from "the
-      // helper refused to fund", and there is nothing to cross-reference
-      // against the helper's own logs or the fullnode.
-      const cause =
-        e instanceof IthServiceError
-          ? `${e.code} (HTTP ${e.status}, retryable=${e.retryable}): ${e.message}`
-          : (e as Error).message;
-      loggers.test!.error(
-        `Failed to inject funds: address=${address} value=${value} ` +
-          `txId=${fundedTxId ?? 'not-broadcast'} — ${cause}`
-      );
-      throw e;
-    }
+    return injectFundsViaHelper(destinationWallet, address, value, options);
   }
 
   /**
@@ -174,18 +195,28 @@ export class GenesisWalletHelper {
     value: OutputValueType,
     options: InjectFundsOptions = {}
   ) {
-    const instance = await GenesisWalletHelper.getSingleton();
-    return instance._injectFunds(destinationWallet, address, value, options);
+    // No getSingleton() here. Funding goes through the integration-test-helper
+    // and has not touched the genesis wallet since that cutover, so starting one
+    // meant every test file paid a full genesis sync to call a function that
+    // never used it. The cost also grew across a run: each pool split the helper
+    // performs lands more history in that wallet for the next file to sync.
+    return injectFundsViaHelper(destinationWallet, address, value, options);
   }
 
   /**
-   * Clears all transaction listeners from the genesis wallet.
-   * Useful when a test run finishes, to ensure there are no leaks.
-   * @return {Promise<void>}
+   * Clears transaction listeners from the genesis wallet, if one was ever started.
+   *
+   * Deliberately does NOT start the wallet to clear it. Tests call this in
+   * teardown without knowing whether anything used the genesis wallet, and
+   * starting one here would reintroduce exactly the per-file sync that removing
+   * it from {@link injectFunds} was meant to eliminate. Nothing started means
+   * nothing to leak.
    */
   static async clearListeners(): Promise<void> {
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
-    gWallet.removeAllListeners('new-tx');
+    if (!singleton) {
+      return;
+    }
+    singleton.hWallet.removeAllListeners('new-tx');
   }
 }
 

--- a/__tests__/integration/utils/fullnode.util.ts
+++ b/__tests__/integration/utils/fullnode.util.ts
@@ -5,8 +5,42 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import axios from 'axios';
 import txApi from '../../../src/api/txApi';
 import { delay } from './time.util';
+import { FULLNODE_URL } from '../configuration/test-constants';
+
+/** Current best-block height, read straight from the fullnode. */
+async function getBestBlockHeight(): Promise<number> {
+  const { data } = await axios.get(`${FULLNODE_URL}status`, { timeout: 10000 });
+  return data?.dag?.best_block?.height ?? 0;
+}
+
+/**
+ * Wait until the fullnode's best block advances past the height at call time.
+ *
+ * The wallet-free counterpart of `waitNextBlock`, which reads
+ * `storage.getCurrentHeight()` and therefore needs a started, connected wallet.
+ * Height is a property of the chain rather than of any wallet, so asking the
+ * fullnode directly avoids that dependency. Prefer this one unless a caller
+ * already has a started wallet on hand.
+ */
+export async function waitForNextBlock({
+  timeoutMs = 600000,
+  pollIntervalMs = 1000,
+}: { timeoutMs?: number; pollIntervalMs?: number } = {}): Promise<void> {
+  const startingHeight = await getBestBlockHeight();
+  const deadline = Date.now() + timeoutMs;
+
+  while ((await getBestBlockHeight()) === startingHeight) {
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${timeoutMs}ms waiting for a block past height ${startingHeight}`
+      );
+    }
+    await delay(pollIntervalMs);
+  }
+}
 
 /**
  * Wait until the wall clock is strictly past `txId`'s timestamp second.

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -17,7 +17,8 @@ import {
   precalculationHelpers, WalletPrecalculationHelper
 } from './__tests__/integration/helpers/wallet-precalculation.helper';
 import { GenesisWalletHelper } from './__tests__/integration/helpers/genesis-wallet.helper';
-import { generateWalletHelper, waitNextBlock, waitTxConfirmed, waitUntilNextTimestamp } from './__tests__/integration/helpers/wallet.helper';
+import { generateWalletHelper, waitTxConfirmed, waitUntilNextTimestamp } from './__tests__/integration/helpers/wallet.helper';
+import { waitForNextBlock } from './__tests__/integration/utils/fullnode.util';
 import { stopGLLBackgroundTask } from './src/sync/gll';
 import Transaction from './src/models/transaction';
 
@@ -149,10 +150,12 @@ beforeAll(async () => {
   // One-time setup: Run only once across all test files (using shared state from CustomEnvironment)
   const sharedState = global.__SHARED_STATE__;
   if (!sharedState.setupDone) {
-    // Await first block to be mined to release genesis reward lock
-    const { hWallet: gWallet } = await GenesisWalletHelper.getSingleton();
+    // Await first block to be mined to release genesis reward lock.
+    // Asked of the fullnode rather than a wallet's storage: block height is a
+    // property of the chain, and the old form only used the genesis wallet
+    // because it happened to be running.
     try {
-      await waitNextBlock(gWallet.storage);
+      await waitForNextBlock();
     } catch (err) {
       // When running jest with jasmine there's a bug (or behavior)
       // that any error thrown inside beforeAll methods don't stop the tests


### PR DESCRIPTION
Part 6 of 9. Base: `ith/5-genesis-incidental`.

With PR 5 landed, nothing calls `GenesisWalletHelper.getSingleton()` any more, so the suite stops starting and syncing a genesis wallet at setup — a few seconds of setup per test file that no test was using, across ~60 files.

The one remaining consumer was `waitNextBlock`, which read `storage.getCurrentHeight()` and therefore needed a started, connected wallet — historically the genesis wallet, purely because it happened to be running. Height is a property of the chain rather than of any wallet, so `waitForNextBlock` asks the fullnode directly.

### Acceptance Criteria
- Suite setup no longer starts or syncs a genesis wallet.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
