### PR TITLE
test(itest): retire a hardcoded seed and a fixture assumption

### DIFF
--- a/__tests__/integration/fullnode-specific/send-transaction.test.ts
+++ b/__tests__/integration/fullnode-specific/send-transaction.test.ts
@@ -198,9 +198,20 @@ describe('[Fullnode] sendTransaction — multisig', () => {
     const mhWallet1 = await generateMultisigWalletHelper({ walletIndex: 0 });
     const mhWallet2 = await generateMultisigWalletHelper({ walletIndex: 1 });
     const mhWallet3 = await generateMultisigWalletHelper({ walletIndex: 2 });
-    await injectFunds(mhWallet1, await mhWallet1.getAddressAtIndex(0), 10n);
+    const fundTx = await injectFunds(mhWallet1, await mhWallet1.getAddressAtIndex(0), 10n);
 
-    const { tx_id: inputTxId, index: inputIndex } = (await mhWallet1.getUtxos()).utxos[0];
+    // Pick the UTXO this test just created, not whichever happens to sit at
+    // position 0. Position 0 is only the right input on a wallet holding
+    // nothing else; if the address carries any smaller output, spending 10n
+    // from it fails with "Sum of outputs is greater than sum of inputs", which
+    // reads like a wallet bug rather than a selection mistake. Selecting by
+    // funding tx is correct whatever else the address holds.
+    const { utxos } = await mhWallet1.getUtxos();
+    const fundedUtxo = utxos.find(utxo => utxo.tx_id === fundTx.hash);
+    if (!fundedUtxo) {
+      throw new Error(`Funding tx ${fundTx.hash} produced no utxo on the multisig wallet`);
+    }
+    const { tx_id: inputTxId, index: inputIndex } = fundedUtxo;
     const network = mhWallet1.getNetworkObject();
     const sendTransaction = new SendTransaction({
       storage: mhWallet1.storage,

--- a/__tests__/integration/helpers/service-facade.helper.ts
+++ b/__tests__/integration/helpers/service-facade.helper.ts
@@ -14,22 +14,18 @@ const pinCode = '123456';
 /** Default password to simplify the tests */
 const password = 'testpass';
 
-export const emptyWallet = {
-  words:
-    'buddy kingdom scorpion device uncover donate sense false few leaf oval illegal assume talent express glide above brain end believe abstract will marine crunch',
-  addresses: [
-    'WkHNZyrKNusTtu3EHfvozEqcBdK7RoEMR7',
-    'WivGyxDjWxijcns3hpGvEJKhjR9HMgFzZ5',
-    'WXQSeMcNt67hVpmgwYqmYLsddgXeGYP4mq',
-    'WTMH3NQs8YXyNguqwLyqoTKDFTfkJLxMzX',
-    'WTUiHeiajtt1MXd1Jb3TEeWUysfNJfig35',
-    'WgzZ4MNcuX3sBgLC5Fa6dTTQaoy4ccLdv5',
-    'WU6UQCnknGLh1WP392Gq6S69JmheS5kzZ2',
-    'WX7cKt38FfgKFWFxSa2YzCWeCPgMbRR98h',
-    'WZ1ABXsuwHHfLzeAWMX7RYs5919LPBaYpp',
-    'WUJjQGb4SGSLh44m2JdgAR4kui8mTPb8bK',
-  ],
-};
+/**
+ * A wallet guaranteed to have no transactions.
+ *
+ * The guarantee comes from how the wallet is obtained: a freshly generated one
+ * is empty by construction. Do not swap this for a fixed seed — on a network
+ * that lives across runs, "nobody ever funds this address" is a promise the
+ * test suite cannot keep.
+ */
+export async function getEmptyWallet(): Promise<{ words: string; addresses: string[] }> {
+  const { words, addresses } = await precalculationHelpers.test.getPrecalculatedWallet();
+  return { words, addresses };
+}
 
 export function initializeServiceGlobalConfigs() {
   // Set base URL for the wallet service API inside the privatenet test container

--- a/__tests__/integration/service-specific/get-balance.test.ts
+++ b/__tests__/integration/service-specific/get-balance.test.ts
@@ -16,7 +16,7 @@
 
 import type { HathorWalletServiceWallet } from '../../../src';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
-import { buildWalletInstance, emptyWallet } from '../helpers/service-facade.helper';
+import { buildWalletInstance, getEmptyWallet } from '../helpers/service-facade.helper';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
 import { loggers } from '../utils/logger.util';
 
@@ -69,7 +69,7 @@ describe('[Service] getBalance', () => {
   // entry with 0 balance for the native token, but currently returns an empty array.
   // Ref: https://github.com/HathorNetwork/hathor-wallet-lib/issues/397
   it.skip('should return balance array for empty wallet', async () => {
-    ({ wallet } = await buildWalletInstance({ words: emptyWallet.words }));
+    ({ wallet } = await buildWalletInstance({ words: (await getEmptyWallet()).words }));
     await wallet.start({ pinCode: adapter.defaultPinCode, password: adapter.defaultPassword });
 
     const balances = await wallet.getBalance();
@@ -83,7 +83,9 @@ describe('[Service] getBalance', () => {
   });
 
   it('should throw error when wallet is not ready', async () => {
-    const { wallet: notReadyWallet } = await buildWalletInstance({ words: emptyWallet.words });
+    const { wallet: notReadyWallet } = await buildWalletInstance({
+      words: (await getEmptyWallet()).words,
+    });
     await expect(notReadyWallet.getBalance()).rejects.toThrow('Wallet not ready');
   });
 });

--- a/__tests__/integration/service-specific/start.test.ts
+++ b/__tests__/integration/service-specific/start.test.ts
@@ -36,7 +36,7 @@ import { decryptData } from '../../../src/utils/crypto';
 import walletUtils from '../../../src/utils/wallet';
 import Network from '../../../src/models/network';
 import { NETWORK_NAME } from '../configuration/test-constants';
-import { buildWalletInstance, emptyWallet } from '../helpers/service-facade.helper';
+import { buildWalletInstance, getEmptyWallet } from '../helpers/service-facade.helper';
 import { ServiceWalletTestAdapter } from '../adapters/service.adapter';
 import { deriveXpubFromSeed } from '../utils/core.util';
 import { loggers } from '../utils/logger.util';
@@ -72,7 +72,7 @@ describe('[Service-specific] start', () => {
   });
 
   it('should have websocket disabled by default in tests', async () => {
-    ({ wallet } = await buildWalletInstance({ words: emptyWallet.words }));
+    ({ wallet } = await buildWalletInstance({ words: (await getEmptyWallet()).words }));
     await wallet.start({ pinCode, password });
     expect(wallet.isWsEnabled()).toBe(false);
   });
@@ -80,7 +80,7 @@ describe('[Service-specific] start', () => {
   // TODO: Move mock-based tests to unit tests
   it('should handle getAccessData unexpected errors', async () => {
     let storage: Storage;
-    ({ wallet, storage } = await buildWalletInstance({ words: emptyWallet.words }));
+    ({ wallet, storage } = await buildWalletInstance({ words: (await getEmptyWallet()).words }));
 
     // Exercise the event-emission path during a failed start
     const events: string[] = [];
@@ -97,10 +97,14 @@ describe('[Service-specific] start', () => {
 
   // TODO: Move mock-based tests to unit tests
   it('should create wallet with xpriv', async () => {
-    let storage: Storage;
-    ({ wallet, storage } = await buildWalletInstance({ words: emptyWallet.words }));
+    // One wallet for the whole test: the xpriv is derived from this seed and the
+    // final assertion compares against this address set, so they must match.
+    const emptyWalletData = await getEmptyWallet();
 
-    const seed = emptyWallet.words;
+    let storage: Storage;
+    ({ wallet, storage } = await buildWalletInstance({ words: emptyWalletData.words }));
+
+    const seed = emptyWalletData.words;
     const accessData = walletUtils.generateAccessDataFromSeed(seed, {
       networkName: 'testnet',
       password: '1234',
@@ -132,7 +136,7 @@ describe('[Service-specific] start', () => {
 
     const currentAddress = wallet.getCurrentAddress();
     expect(currentAddress.index).toBeDefined();
-    expect(currentAddress.address).toEqual(emptyWallet.addresses[currentAddress.index]);
+    expect(currentAddress.address).toEqual(emptyWalletData.addresses[currentAddress.index]);
   });
 
   it('should complete start() on a brand-new wallet that goes through creating→ready', async () => {


### PR DESCRIPTION
Part 8 of 9. Base: `ith/7-funding-helper`.

Two fixture assumptions that only hold on a pristine chain. Both were found by keeping a test network alive across many runs instead of restarting it between them — which is the point of the helper, and the mode CI never exercises.

- **`emptyWallet`** was a seed asserted to have no transactions, true only as long as nothing ever funded it. `getEmptyWallet()` draws a fresh wallet instead, so the guarantee comes from how the wallet was obtained rather than from convention.
- **The multisig `sendTransaction` test** spent `getUtxos().utxos[0]` — an arbitrary UTXO. Its fixture address had accumulated 29 transactions, and when position 0 landed on a `1n` output, spending `10n` failed with *"Sum of outputs is greater than sum of inputs"* — which reads like a wallet bug rather than a stale fixture. It now selects the UTXO from its own funding transaction, which is correct regardless of what else the address holds.

The other seed originally in scope here, `singleAddressWallet2`, was fixed upstream by HathorNetwork/hathor-wallet-lib#1150 while this branch was in flight; that resolution is kept over this one, since it routes through `buildWalletInstance()` rather than constructing wallets inline.

Left alone deliberately: `WALLET_CONSTANTS.miner` is the miner reward address wired into docker-compose, not a test wallet; and `WALLET_CONSTANTS.ocb` is shared on purpose — `setupTests` funds it and creates the blueprints that the nano-contract suite reuses. It accumulates history but nothing asserts otherwise, so it does not break on re-runs.

### Acceptance Criteria
- Re-running the suite against a network that already has history no longer fails on fixture state.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
