### PR TITLE
test(itest): provision multisig wallets from the helper

### DIFF
--- a/__tests__/integration/fullnode-specific/addresses.test.ts
+++ b/__tests__/integration/fullnode-specific/addresses.test.ts
@@ -20,9 +20,9 @@ import {
   DEFAULT_PIN_CODE,
   generateMultisigWalletHelper,
   generateWalletHelper,
+  getMultisigAddresses,
   stopAllWallets,
 } from '../helpers/wallet.helper';
-import { WALLET_CONSTANTS } from '../configuration/test-constants';
 import { verifyMessage } from '../../../src/utils/crypto';
 import { GAP_LIMIT } from '../../../src/constants';
 
@@ -75,7 +75,7 @@ describe('[Fullnode] addresses methods', () => {
     // The fullnode facade derives every index locally (no gap-limit window), so
     // we verify the whole precalculated multisig set. The bound is the length of
     // that precalculated list, not a magic number.
-    const expected = WALLET_CONSTANTS.multisig.addresses;
+    const expected = await getMultisigAddresses();
     for (let i = 0; i < expected.length; i++) {
       expect(await mshWallet.getAddressAtIndex(i)).toStrictEqual(expected[i]);
     }

--- a/__tests__/integration/fullnode-specific/stream-sync.test.ts
+++ b/__tests__/integration/fullnode-specific/stream-sync.test.ts
@@ -19,10 +19,13 @@
  */
 
 import { injectFunds } from '../helpers/funding.helper';
-import { generateMultisigWalletHelper, stopAllWallets } from '../helpers/wallet.helper';
+import {
+  generateMultisigWalletHelper,
+  getMultisigAddresses,
+  stopAllWallets,
+} from '../helpers/wallet.helper';
 import { NATIVE_TOKEN_UID } from '../../../src/constants';
 import { HistorySyncMode } from '../../../src/types';
-import { WALLET_CONSTANTS } from '../configuration/test-constants';
 
 describe('[Fullnode] history-streaming sync', () => {
   afterEach(async () => {
@@ -37,9 +40,10 @@ describe('[Fullnode] history-streaming sync', () => {
     // 1. Fund the first multisig address using a regular (polling) multisig wallet. Doing it
     //    BEFORE the streaming wallet starts guarantees the funds can only be discovered through
     //    the history-streaming sync, not through a live `new-tx` websocket event.
+    const multisigAddresses = await getMultisigAddresses();
     const funder = await generateMultisigWalletHelper({ walletIndex: 0 });
     const fundedAddress = await funder.getAddressAtIndex(0);
-    expect(fundedAddress).toEqual(WALLET_CONSTANTS.multisig.addresses[0]);
+    expect(fundedAddress).toEqual(multisigAddresses[0]);
 
     const [htrBefore] = await funder.getBalance(NATIVE_TOKEN_UID);
     // injectFunds waits for the funder wallet to receive and confirm the tx.
@@ -69,7 +73,7 @@ describe('[Fullnode] history-streaming sync', () => {
     for (let i = 0; i < 5; i++) {
       // eslint-disable-next-line no-await-in-loop -- sequential reads keep the assertion readable
       const address = await streamWallet.getAddressAtIndex(i);
-      expect(address).toEqual(WALLET_CONSTANTS.multisig.addresses[i]);
+      expect(address).toEqual(multisigAddresses[i]);
     }
   }, 60000);
 });

--- a/__tests__/integration/helpers/ith-service.ts
+++ b/__tests__/integration/helpers/ith-service.ts
@@ -33,6 +33,36 @@ export interface SimpleWalletData {
 }
 
 /**
+ * One participant of a multisig group, from `GET /multisigWallet`.
+ *
+ * Every participant shares the same `addresses` and the same `pubkeys`: a P2SH
+ * multisig address derives from the pubkey set, not from any single seed. Only
+ * `words` differs, which is what lets each participant sign independently.
+ */
+export interface MultisigParticipantData {
+  words: string;
+  addresses: string[];
+  /**
+   * Precalculated shielded address pairs. Absent from every helper version
+   * released so far — `/multisigWallet` does not precalculate them yet
+   * (HathorNetwork/hathor-integration-test-helper#31), and the wallet derives
+   * each pair live meanwhile. Reading it optionally means the day the helper
+   * starts sending them, callers pick them up with no code change.
+   */
+  shieldedAddresses?: IPrecalculatedShieldedAddress[];
+  multisigDebugData: {
+    total: number;
+    minSignatures: number;
+    pubkeys: string[];
+  };
+}
+
+/** Mirrors the helper's `GET /multisigWallet` response. */
+export interface MultisigWalletSet {
+  wallets: MultisigParticipantData[];
+}
+
+/**
  * Mirrors the helper's `POST /fund` response.
  *
  * `amount` is a `bigint` on the wire, serialised by the helper via
@@ -242,6 +272,40 @@ export const ithService = {
     if (!data?.words || !Array.isArray(data?.addresses)) {
       throw new IthServiceError(
         `GET /simpleWallet returned an unexpected shape${describeBody(data)}`,
+        'MALFORMED_RESPONSE',
+        false,
+        200
+      );
+    }
+    return data;
+  },
+
+  /**
+   * GET /multisigWallet — a fresh multisig group: `participants` seeds sharing
+   * one pubkey set, `numSignatures` of which must sign to spend.
+   *
+   * Idempotent: the helper derives the group on demand and keeps no per-caller
+   * state, so a retry repeats the derivation and nothing else.
+   */
+  async getMultisigWallet({
+    participants,
+    numSignatures,
+  }: {
+    participants: number;
+    numSignatures: number;
+  }): Promise<MultisigWalletSet> {
+    const data = await request<MultisigWalletSet>(
+      'get',
+      `/multisigWallet?participants=${participants}&numSignatures=${numSignatures}`,
+      { idempotent: true }
+    );
+
+    // Check the arity too, not just the shape: asking for 5 participants and
+    // silently receiving 3 would surface much later as an out-of-range
+    // walletIndex reading `undefined.words`.
+    if (!Array.isArray(data?.wallets) || data.wallets.length !== participants) {
+      throw new IthServiceError(
+        `GET /multisigWallet returned an unexpected shape${describeBody(data)}`,
         'MALFORMED_RESPONSE',
         false,
         200

--- a/__tests__/integration/helpers/wallet.helper.ts
+++ b/__tests__/integration/helpers/wallet.helper.ts
@@ -12,15 +12,11 @@ import {
   FULLNODE_URL,
   NETWORK_NAME,
   TX_TIMEOUT_DEFAULT,
-  WALLET_CONSTANTS,
 } from '../configuration/test-constants';
 import HathorWallet from '../../../src/new/wallet';
 import walletUtils from '../../../src/utils/wallet';
-import {
-  mergePrecalculatedAddresses,
-  multisigWalletsData,
-  precalculationHelpers,
-} from './wallet-precalculation.helper';
+import { mergePrecalculatedAddresses, precalculationHelpers } from './wallet-precalculation.helper';
+import { ithService, type MultisigWalletSet } from './ith-service';
 import { getPrecalculatedShieldedForSeed } from '../configuration/precalculated-shielded-addresses';
 import { delay, getGapLimitConfig } from '../utils/core.util';
 import { loggers } from '../utils/logger.util';
@@ -207,25 +203,113 @@ export async function generateWalletHelperRO(options) {
   return hWallet;
 }
 
+/** Group shape used when a caller does not ask for a specific one. */
+export const DEFAULT_MULTISIG_PARTICIPANTS = 5;
+export const DEFAULT_MULTISIG_NUM_SIGNATURES = 3;
+
+/**
+ * @typedef {Object} MultisigGroupShape
+ * @property {number} [participants=5] How many seeds share the pubkey set
+ * @property {number} [numSignatures=3] How many of them must sign to spend
+ */
+
+/** One memoised group per requested shape, keyed `<numSignatures>-of-<participants>`. */
+const multisigWalletSets = new Map<string, Promise<MultisigWalletSet>>();
+
+/**
+ * A multisig group provisioned by the helper.
+ *
+ * Fetched once per shape and shared by every participant of it, because they
+ * must genuinely be one group: a P2SH address derives from the pubkey set, so
+ * participants that did not come from the same `/multisigWallet` call would
+ * compute different addresses and could not co-sign.
+ *
+ * The memo is per test file — jest gives each file a fresh module registry —
+ * which is the useful scope: every file gets a group nobody has spent from, so
+ * no test inherits another file's on-chain history. Distinct shapes are cached
+ * separately, so asking for 2-of-3 does not disturb the file's 3-of-5 group.
+ *
+ * The promise, rather than the resolved value, is what gets cached, so two
+ * participants awaiting concurrently share one request instead of racing to
+ * provision two different groups.
+ *
+ * @param {MultisigGroupShape} [shape]
+ */
+export async function getMultisigWalletSet({
+  participants = DEFAULT_MULTISIG_PARTICIPANTS,
+  numSignatures = DEFAULT_MULTISIG_NUM_SIGNATURES,
+} = {}): Promise<MultisigWalletSet> {
+  const key = `${numSignatures}-of-${participants}`;
+  let pending = multisigWalletSets.get(key);
+  if (!pending) {
+    pending = ithService.getMultisigWallet({ participants, numSignatures });
+    multisigWalletSets.set(key, pending);
+  }
+  return pending;
+}
+
+/**
+ * The P2SH addresses of a multisig group.
+ *
+ * Shared by every participant, so which one they are read from is arbitrary.
+ * Tests asserting on multisig addresses take them from here rather than from a
+ * committed constant, so the expectation follows whatever group the helper
+ * provisioned for this run. Pass the same shape the wallets were built with.
+ *
+ * @param {MultisigGroupShape} [shape]
+ */
+export async function getMultisigAddresses(shape = {}): Promise<string[]> {
+  const { wallets } = await getMultisigWalletSet(shape);
+  return wallets[0].addresses;
+}
+
 /**
  *
+ * Called with no arguments, builds participant 0 of the default
+ * {@link DEFAULT_MULTISIG_NUM_SIGNATURES}-of-{@link DEFAULT_MULTISIG_PARTICIPANTS}
+ * group. `participants`/`numSignatures` request a different shape; every
+ * participant of one group must be built with the same pair, or they will not
+ * share a pubkey set and cannot co-sign.
+ *
  * @param [parameters]
- * @param {number} [parameters.walletIndex] Index of the harcoded wallet that will be used
+ * @param {number} [parameters.walletIndex=0] Index of the participant to build, within the
+ *                                            helper-provisioned group
+ * @param {number} [parameters.participants=5] Size of the group to request
+ * @param {number} [parameters.numSignatures=3] Signatures required to spend
  * @param {string} [parameters.walletWords] Custom wallet words to be used. If informed, all the
  *                                          other parameters (except walletIndex) become mandatory
  * @param {string[]} [parameters.preCalculatedAddresses] Custom pre-calculated addresses, if
  *                                                       walletWords is used
  * @param {string[]} [parameters.pubkeys] Custom pubkeys if walletWords is used
- * @param {number} [parameters.numSignatures] Custom numSignatures if walletWords is used
  * @param {HistorySyncMode} [parameters.historySyncMode] History sync mode to set before start
  *
  * @example
- * const multisigWallet = await generateMultisigWalletHelper({ walletIndex: 0 });
+ * const multisigWallet = await generateMultisigWalletHelper();
+ * @example
+ * const twoOfThree = await generateMultisigWalletHelper({
+ *   walletIndex: 1,
+ *   participants: 3,
+ *   numSignatures: 2,
+ * });
  *
  * @return {Promise<HathorWallet>}
  */
-export async function generateMultisigWalletHelper(parameters) {
-  const seed = parameters.walletWords || multisigWalletsData.words[parameters.walletIndex];
+export async function generateMultisigWalletHelper(parameters = {}) {
+  // Passing the pair through explicitly keeps `undefined` meaning "default":
+  // destructuring in getMultisigWalletSet applies them, so an absent shape and
+  // an explicit default resolve to the same memoised group.
+  const { wallets } = await getMultisigWalletSet({
+    participants: parameters.participants,
+    numSignatures: parameters.numSignatures,
+  });
+  const participant = wallets[parameters.walletIndex ?? 0];
+  if (!participant) {
+    throw new Error(
+      `No multisig participant at index ${parameters.walletIndex}: the helper provisioned a group of ${wallets.length}`
+    );
+  }
+
+  const seed = parameters.walletWords || participant.words;
   // Start the wallet
   const walletConfig = {
     seed,
@@ -233,15 +317,22 @@ export async function generateMultisigWalletHelper(parameters) {
     password: DEFAULT_PASSWORD,
     pinCode: DEFAULT_PIN_CODE,
     // Both chains for each index travel together in the unified array. The
-    // multisig seeds are fixed in-repo, so their shielded pairs are committed
-    // fixtures.
+    // helper does not precalculate shielded pairs for multisig groups yet
+    // (HathorNetwork/hathor-integration-test-helper#31), so `shieldedAddresses`
+    // is absent today and the wallet derives each pair live -- the cost of
+    // provisioning these fresh. Reading it from the participant regardless
+    // means the day the helper starts sending them, this speeds up on its own.
     preCalculatedAddresses: mergePrecalculatedAddresses(
-      parameters.preCalculatedAddresses || WALLET_CONSTANTS.multisig.addresses,
-      parameters.preCalculatedShieldedAddresses || getPrecalculatedShieldedForSeed(seed)
+      parameters.preCalculatedAddresses || participant.addresses,
+      parameters.preCalculatedShieldedAddresses ||
+        participant.shieldedAddresses ||
+        getPrecalculatedShieldedForSeed(seed)
     ),
+    // Read back from the group the helper actually built rather than from the
+    // request, so these stay the single source of truth for the pubkey set.
     multisig: {
-      pubkeys: parameters.pubkeys || multisigWalletsData.pubkeys,
-      numSignatures: parameters.numSignatures || 3,
+      pubkeys: parameters.pubkeys || participant.multisigDebugData.pubkeys,
+      numSignatures: participant.multisigDebugData.minSignatures,
     },
     scanPolicy: getGapLimitConfig(),
   };


### PR DESCRIPTION
Part 9 of 9. Base: `ith/8-drop-hardcoded-seeds`.

`generateMultisigWalletHelper` drew its five participants from seeds fixed in-repo, so every run reused the same P2SH address. On a network kept alive across runs that address accumulates history — 29 transactions by the time this was written — and tests written against a pristine chain start failing in ways that read like wallet bugs. The multisig send fixed in PR 8 was one of them.

The group now comes from the helper's `GET /multisigWallet`, fetched once per test file and shared by every participant. They must genuinely be one group: a P2SH address derives from the pubkey set rather than from any single seed, so participants provisioned separately would compute different addresses and could not co-sign. Jest gives each test file a fresh module registry, so that memo is per-file — every file gets a group nobody has spent from.

The group shape is the caller's to choose. `generateMultisigWalletHelper()` with no arguments builds participant 0 of a 3-of-5 group, which is what every current test wants:

```js
const wallet    = await generateMultisigWalletHelper();
const twoOfThree = await generateMultisigWalletHelper({
  walletIndex: 1, participants: 3, numSignatures: 2,
});
```

Groups are memoised per shape, so requesting a second shape does not disturb the file's default one. `numSignatures` on the built wallet is read back from the helper's response rather than from the request, keeping the provisioned group the single source of truth for the pubkey set.

The helper does not precalculate shielded pairs for multisig groups yet (HathorNetwork/hathor-integration-test-helper#31), so the wallet derives them live meanwhile. `participant.shieldedAddresses` is read regardless, so the day the helper starts sending them, this speeds up with no change here.

Cheaper than expected rather than dearer: `fullnode-specific/send-transaction` went 132s → 70s in isolation, because a wallet nobody has spent from has no history to sync — more than paying for the live derivation.

The fixed multisig seeds stay where they are the subject rather than a convenience: `fullnode-specific/start.test.ts` withholds the legacy addresses deliberately to prove P2SH derivation, `shared/send-transaction` uses one only as a destination address, and `multisigFixtureDerivation` / `precalculated-shielded-addresses` guard the committed fixtures.

### Acceptance Criteria
- Multisig tests run against a group provisioned per run, with no in-repo multisig seed on the path.
- A caller can request a non-default group shape; calling with no arguments keeps the 3-of-5 default.
- When the helper begins serving shielded pairs for multisig, no change is needed here.

### Security Checklist
- [x] Make sure you do not include new dependencies in the project unless strictly necessary and do not include dev-dependencies as production ones. More dependencies increase the possibility of one of them being hijacked and affecting us.
