### PR TITLE
test(itest): drop cross-worker state assumptions

### DIFF
--- a/__tests__/integration/nanocontracts/full_blueprint.test.ts
+++ b/__tests__/integration/nanocontracts/full_blueprint.test.ts
@@ -607,12 +607,14 @@ describe('Full blueprint basic tests', () => {
     expect(builtInBlueprintList.has_more).toBe(false);
     expect(builtInBlueprintList.blueprints.length).toBe(0);
 
-    const onChainBlueprintList = await ncApi.getOnChainBlueprintList();
+    // Identity check rather than a count: the on-chain list is node-global and
+    // grows with every jest worker (each publishes its own blueprint set in
+    // setupTests-integration.js), so any count-based assertion couples this
+    // test to worker count and to the API's default page size. Searching for
+    // our own blueprint exercises the same endpoint without that coupling.
+    const onChainBlueprintList = await ncApi.getOnChainBlueprintList(null, null, null, blueprintId);
     expect(onChainBlueprintList.success).toBe(true);
-    // Lower-bound check rather than exact count: the global on-chain blueprint
-    // list grows whenever a new fixture is registered in setupTests-integration.js,
-    // so an exact assertion couples this test to unrelated additions.
-    expect(onChainBlueprintList.blueprints.length).toBeGreaterThanOrEqual(8);
+    expect(onChainBlueprintList.blueprints).toEqual([expect.objectContaining({ id: blueprintId })]);
 
     const nanoList = await ncApi.getNanoContractCreationList();
     // The correct length depends on the execution order, so I

--- a/__tests__/integration/walletservice_nano_fee.test.ts
+++ b/__tests__/integration/walletservice_nano_fee.test.ts
@@ -25,7 +25,6 @@ describe('WalletService Nano Contract Fee Tests', () => {
   beforeAll(async () => {
     // 1. Start genesis wallet helper
     await GenesisWalletServiceHelper.start();
-    const gWallet = await GenesisWalletServiceHelper.getSingleton();
 
     // 2. Build and start wsWallet (uses precalculated wallet)
     const buildResult = await buildWalletInstance({});
@@ -33,10 +32,11 @@ describe('WalletService Nano Contract Fee Tests', () => {
     walletAddresses = buildResult.addresses;
     await wsWallet.start({ pinCode, password });
 
-    // 3. Fund wallet with HTR
+    // 3. Fund wallet with HTR through the helper's race-free pool — spending
+    // genesis UTXOs directly would compete with the integration-test-helper,
+    // which owns the genesis wallet.
     const address0 = walletAddresses[0];
-    const fundTx = await gWallet.sendTransaction(address0, 1000n, { pinCode });
-    await pollForTx(wsWallet, fundTx.hash!);
+    await GenesisWalletServiceHelper.injectFunds(address0, 1000n, wsWallet);
 
     // 4. Initialize FeeBlueprint contract
     const initTx = await wsWallet.createAndSendNanoContractTransaction(

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -12,7 +12,7 @@ import axios from 'axios';
 import fs from 'fs';
 import { loggers, LoggerUtil } from './__tests__/integration/utils/logger.util';
 import config from './src/config';
-import { TX_MINING_URL, WALLET_CONSTANTS } from './__tests__/integration/configuration/test-constants';
+import { TX_MINING_URL } from './__tests__/integration/configuration/test-constants';
 import {
   precalculationHelpers, WalletPrecalculationHelper
 } from './__tests__/integration/helpers/wallet-precalculation.helper';
@@ -49,8 +49,11 @@ axios.defaults.httpAgent = new http.Agent({ keepAlive: false });
 axios.defaults.httpsAgent = new https.Agent({ keepAlive: false });
 
 async function createOCBs(sharedState) {
-  const { seed } = WALLET_CONSTANTS.ocb;
-  const ocbWallet = await generateWalletHelper({ seed });
+  // The privnet does not restrict blueprint publishers
+  // (NC_ON_CHAIN_BLUEPRINT_RESTRICTED: false), so each jest worker publishes
+  // its own blueprint set from a fresh helper wallet. A shared fixed seed here
+  // would make concurrent workers race on the same UTXOs during this setup.
+  const ocbWallet = await generateWalletHelper();
   const address0 = await ocbWallet.getAddressAtIndex(0);
   await injectFunds(ocbWallet, address0, 1000n);
 


### PR DESCRIPTION
Prepares the integration suite for parallel jest workers by removing the three remaining spots that assumed a single test process:

- `walletservice_nano_fee` spent genesis UTXOs directly, racing the integration-test-helper that owns the genesis wallet — it now funds through the helper's race-free pool, dropping the suite's last direct genesis spend.
- `createOCBs()` published the on-chain blueprints from a shared hardcoded seed. Each jest worker runs this setup once, so two concurrent workers would double-spend each other. The privnet sets `NC_ON_CHAIN_BLUEPRINT_RESTRICTED: false`, so each worker now publishes from a fresh helper wallet instead.
- `full_blueprint` asserted a count on the node-global on-chain blueprint list, which grows by one set per worker; it now asserts its own blueprint's presence via the API's `search` parameter.

First of four stacked PRs concluding in CI integration tests running with 2 jest workers. Stacked PRs are a GitHub public preview — please review only this PR's incremental diff.

**Acceptance criteria**
- Integration tests behave identically under `--runInBand`; no test depends on genesis UTXOs, a fixed blueprint-publisher seed, or node-global blueprint-list counts.
