### PR TITLE
test(itest): make the jest harness worker-safe

### DIFF
--- a/CustomEnvironment.js
+++ b/CustomEnvironment.js
@@ -17,18 +17,27 @@ const sharedState = {
 };
 
 /**
- * Extracts the test name from an absolute path received by the context
+ * Extracts the test name from an absolute path received by the context.
+ *
+ * The name is built from the path relative to `__tests__/integration`, not the
+ * basename alone: several test files share a basename across directories
+ * (shared/utxos, fullnode-specific/utxos, ...), and parallel workers starting
+ * two of those in the same second would otherwise open one log file from two
+ * processes.
  * @param {string} filePath Absolute path
- * @returns {string} Test filename without directories, test suffixes or extensions
+ * @returns {string} Test path without root directories, test suffixes or extensions
  * @example
- * const name = getTestName('/home/user/code/address-info.test.js')
- * assert(name == 'address-info')
+ * const name = getTestName('/home/user/code/__tests__/integration/shared/utxos.test.ts')
+ * assert(name == 'shared_utxos')
  */
 function getTestName(filePath) {
-  const baseName = path.basename(filePath);
-  const extName = path.extname(filePath);
+  const integrationRoot = `${path.sep}__tests__${path.sep}integration${path.sep}`;
+  const rootIndex = filePath.lastIndexOf(integrationRoot);
+  const relativePath =
+    rootIndex === -1 ? path.basename(filePath) : filePath.slice(rootIndex + integrationRoot.length);
+  const extName = path.extname(relativePath);
 
-  return baseName.replace(`.test${extName}`, '');
+  return relativePath.replace(`.test${extName}`, '').split(path.sep).join('_');
 }
 
 /**
@@ -58,12 +67,38 @@ export default class CustomEnvironment extends NodeEnvironment {
     this.global.__SHARED_STATE__ = sharedState;
   }
 
+  /**
+   * Sanitizes failure payloads so jest's worker IPC can carry them.
+   *
+   * jest-runner forwards circus events (test failures included) to the main
+   * process as the suite runs. With workerThreads that channel uses the
+   * structured clone algorithm, which throws on functions — and a raw
+   * AxiosError drags several along inside `config`/`request`. The throw kills
+   * the worker mid-suite: jest reports the whole file as "Test suite failed
+   * to run (DataCloneError)" and the actual failing test is never shown.
+   *
+   * Deleting only the own properties that structured clone rejects keeps the
+   * error's message, stack and any plain data — everything a reporter shows.
+   * Mutation is in place on purpose: circus stores this same object reference
+   * and serializes it later.
+   */
+  handleTestEvent(event) {
+    if (event.error && typeof event.error === 'object') {
+      for (const key of Object.keys(event.error)) {
+        try {
+          structuredClone(event.error[key]);
+        } catch {
+          delete event.error[key];
+        }
+      }
+    }
+  }
+
   /*
    * For debugging purposes, some helper methods can be added to this class, such as:
    * - getVmContext()
    * - teardown()
    * - runScript(script)
-   * - handleTestEvent(event)
    *
    * @see https://jestjs.io/docs/configuration#testenvironment-string
    */

--- a/jest-integration.config.js
+++ b/jest-integration.config.js
@@ -11,6 +11,12 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['<rootDir>/src/**/*.js', '<rootDir>/src/**/*.ts'],
   testMatch: [mainTestMatch],
+  // Worker-to-parent IPC uses the structured-clone algorithm instead of
+  // JSON.stringify, which cannot serialize the BigInts our amounts carry: a
+  // failing test whose error payload includes a tx object would otherwise
+  // crash its whole suite with "Do not know how to serialize a BigInt",
+  // masking the real failure. Only exercised when running with workers.
+  workerThreads: true,
   // Blocks the whole suite until the integration-test-helper reports ready.
   globalSetup: '<rootDir>/__tests__/integration/configuration/global-setup.ts',
   coverageReporters: ['text-summary', 'lcov', 'clover'],

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -170,7 +170,17 @@ beforeAll(async () => {
       process.exit(1);
     }
 
-    await createOCBs(sharedState);
+    try {
+      await createOCBs(sharedState);
+    } catch (error) {
+      // A raw failure here may carry axios internals (functions) or BigInts
+      // that crash jest's worker IPC while *reporting* it — surfacing as
+      // DataCloneError / "Do not know how to serialize a BigInt" with the
+      // whole suite down and the true cause hidden. Log the truth to the
+      // per-file transaction log and rethrow a clonable copy.
+      loggers.test?.error(`createOCBs failed: ${error?.stack ?? error}`);
+      throw new Error(`createOCBs failed: ${error?.message ?? error}`);
+    }
 
     sharedState.setupDone = true;
   }
@@ -210,3 +220,13 @@ expect.extend({
 
 // Stop gll interval to avoid background tasks during tests
 stopGLLBackgroundTask();
+
+// Record suite-level unhandled rejections in the per-file transaction log.
+// jest reports them by shipping the raw error object to the main process,
+// and payloads carrying axios internals crash that IPC (DataCloneError under
+// workerThreads, BigInt errors under JSON IPC), masking the original error.
+// This listener does not swallow anything — jest's own handler still runs —
+// it just guarantees the true failure is readable somewhere.
+process.on('unhandledRejection', reason => {
+  loggers.test?.error(`Unhandled rejection: ${reason?.stack ?? reason}`);
+});


### PR DESCRIPTION
Second of four stacked PRs toward parallel integration tests. Makes the jest harness itself worker-safe — everything here is inert under `--runInBand`:

- Transaction logs are named by the path relative to the integration root (`shared_utxos`): same-named files in different directories would otherwise open one log file from two workers starting in the same second — and the names finally distinguish e.g. `nanocontracts/fee` from `template/transaction/fee`.
- `workerThreads: true`: jest's worker IPC otherwise ships failure payloads through `JSON.stringify`, which throws on the BigInts our amounts carry — crashing the whole suite with "Do not know how to serialize a BigInt" and masking the real failure.
- `CustomEnvironment.handleTestEvent` strips non-clonable properties from failure events: structured clone throws on functions, and a raw `AxiosError` carries several inside `config`/`request` — one flaky test would otherwise take down its entire suite as a `DataCloneError`.
- Suite-level unhandled rejections and `createOCBs` failures are recorded in the per-file transaction log, the latter rethrown as a clonable error, so the true failure is always readable somewhere.

Stacked PRs are a GitHub public preview — please review only this PR's incremental diff.

**Acceptance criteria**
- Full suite still green under `--runInBand`.
- Under workers, a test failing with an error carrying BigInts or axios internals reports that test's failure normally instead of "Test suite failed to run".
