### PR TITLE
test(itest): retry parent-timestamp collisions

### DIFF
--- a/__tests__/integration/helpers/ith-service.ts
+++ b/__tests__/integration/helpers/ith-service.ts
@@ -145,6 +145,24 @@ function ithConfig(): IthConfig {
 /** Statuses worth retrying when the response carries no helper error contract. */
 const RETRYABLE_BARE_STATUSES = new Set([429, 502, 503, 504]);
 
+/**
+ * A fullnode rejection for a tx whose DAG parent shares its timestamp.
+ *
+ * With parallel jest workers, the helper's funding tx can be mined in the same
+ * second as another process's tx that the mining service picks as its parent —
+ * rejected because timestamps have 1-second granularity and must be strictly
+ * greater than each parent's (HathorNetwork/tx-mining-service#172).
+ *
+ * Retrying is safe even on the non-idempotent POST /fund, overriding the
+ * helper's own verdict: the broadcast was *rejected*, so no transaction exists
+ * on-chain and the helper has already released its reservation — a replay
+ * cannot double-fund. The retry re-mines with fresh parents and timestamp,
+ * which lands in a later second essentially always.
+ */
+function isParentTimestampCollision(message: string): boolean {
+  return /timestamp=(\d+), parent=[0-9a-f]+ timestamp=\1\b/.test(message);
+}
+
 /** Keep a non-conforming body in the message — truncated, since it may be an HTML page. */
 function describeBody(data: unknown): string {
   try {
@@ -203,15 +221,18 @@ async function request<T>(
       // Helper error body: { error, message, retryable }
       const errorBody = res.data as { error?: string; message?: string; retryable?: boolean };
       const conforms = typeof errorBody?.error === 'string' && 'retryable' in (errorBody ?? {});
+      const message = conforms
+        ? errorBody.message ?? `Request to ${path} failed with HTTP ${res.status}`
+        : `Request to ${path} failed with HTTP ${res.status}${describeBody(res.data)}`;
       err = new IthServiceError(
-        conforms
-          ? errorBody.message ?? `Request to ${path} failed with HTTP ${res.status}`
-          : `Request to ${path} failed with HTTP ${res.status}${describeBody(res.data)}`,
+        message,
         conforms ? errorBody.error! : 'UNKNOWN',
         // A body that doesn't match the contract carries no verdict, so fall back
         // to the status. This is where an operator most needs the raw body, hence
-        // describeBody above.
-        conforms ? Boolean(errorBody.retryable) : RETRYABLE_BARE_STATUSES.has(res.status),
+        // describeBody above. Parent-timestamp collisions are retryable no
+        // matter what the helper says — see isParentTimestampCollision.
+        (conforms ? Boolean(errorBody.retryable) : RETRYABLE_BARE_STATUSES.has(res.status)) ||
+          isParentTimestampCollision(message),
         res.status
       );
     } catch (transportError) {

--- a/setupTests-integration.js
+++ b/setupTests-integration.js
@@ -21,6 +21,8 @@ import { generateWalletHelper, waitTxConfirmed, waitUntilNextTimestamp } from '.
 import { waitForNextBlock } from './__tests__/integration/utils/fullnode.util';
 import { stopGLLBackgroundTask } from './src/sync/gll';
 import Transaction from './src/models/transaction';
+import SendTransaction from './src/new/sendTransaction';
+import SendTransactionWalletService from './src/wallet/sendTransactionWalletService';
 
 config.setTxMiningUrl(TX_MINING_URL);
 
@@ -31,6 +33,61 @@ jest.retryTimes(2, { logErrorsBeforeRetry: true });
 Transaction.prototype.calculateWeight = function () {
   return 1;
 };
+
+/**
+ * Re-mine and resubmit a broadcast rejected for sharing its DAG parent's
+ * timestamp.
+ *
+ * Parents and timestamp are assigned by the tx-mining-service at mining time,
+ * from the node's current tips. With parallel jest workers (or the
+ * integration-test-helper funding concurrently), a tx can be handed another
+ * process's same-second tx as parent, which the fullnode rejects — timestamps
+ * have 1-second granularity and must be strictly greater than each parent's.
+ * No worker-local wait can prevent this, so on that specific rejection the
+ * send is re-mined (fresh parents and timestamp over the same signed funds —
+ * signatures only cover the funds part) and resubmitted.
+ *
+ * Both facades funnel every send through `runFromMining`, so wrapping it
+ * covers all paths. The wallet-service facade hides the fullnode's reason
+ * behind a fixed proposal-error message, so that message is the best
+ * available signal on its path.
+ */
+const RE_MINE_ATTEMPTS = 3;
+
+function isParentTimestampCollision(error) {
+  return /timestamp=(\d+), parent=[0-9a-f]+ timestamp=\1\b/.test(error?.message ?? '');
+}
+
+function isTxProposalError(error) {
+  return (error?.message ?? '') === 'Error sending tx proposal.';
+}
+
+function retryParentTimestampCollisions(SendClass, shouldRetry) {
+  const originalRunFromMining = SendClass.prototype.runFromMining;
+  SendClass.prototype.runFromMining = async function runFromMiningWithRetry(...args) {
+    let lastError;
+    for (let attempt = 1; attempt <= RE_MINE_ATTEMPTS; attempt++) {
+      try {
+        return await originalRunFromMining.apply(this, args);
+      } catch (error) {
+        if (!shouldRetry(error) || attempt === RE_MINE_ATTEMPTS) {
+          throw error;
+        }
+        lastError = error;
+        loggers.test?.log(
+          `Re-mining after a rejected broadcast (attempt ${attempt}): ${error.message}`
+        );
+      }
+    }
+    throw lastError;
+  };
+}
+
+retryParentTimestampCollisions(SendTransaction, isParentTimestampCollision);
+retryParentTimestampCollisions(
+  SendTransactionWalletService,
+  error => isParentTimestampCollision(error) || isTxProposalError(error)
+);
 
 /**
  * Disable HTTP keep-alive for axios to prevent "socket hang up" errors in Jest.


### PR DESCRIPTION
Third of four stacked PRs toward parallel integration tests. Handles the one race parallel workers cannot avoid: the tx-mining-service assigns parents (current tips) and timestamp (now) independently, and the fullnode requires `tx.timestamp > parent.timestamp` at 1-second granularity — so any two same-second broadcasts from different processes can produce a deterministically rejected tx. No worker-local wait can prevent it. The root cause is filed as HathorNetwork/tx-mining-service#172; both mechanisms here are scaffolding that can be deleted once it lands.

- `runFromMining` (both facades) re-mines the same signed tx (signatures cover only the funds part) and resubmits on this specific rejection.
- The helper client marks the same rejection retryable on `POST /fund`: a rejected broadcast left nothing on-chain and the reservation was already released, so a replay cannot double-fund.

Measured at 4 workers on a local network: these turned 33 collision-driven test failures into zero, with collisions resolving invisibly at the tx layer.

Stacked PRs are a GitHub public preview — please review only this PR's incremental diff.

**Acceptance criteria**
- Only the parent-timestamp rejection (and the wallet-service's opaque proposal error) is retried; every other send failure surfaces unchanged.
